### PR TITLE
standardize code format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stumpless
 
-[![Build Status](https://travis-ci.org/goatshriek/stumpless.svg?branch=master)](https://travis-ci.org/goatshriek/stumpless.svg?branch=master)
+[![Build Status](https://travis-ci.org/goatshriek/stumpless.svg?branch=master)](https://travis-ci.org/goatshriek/stumpless)
 
 A very simple logging library.
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,9 +1,9 @@
 ## Build Environment
 In order to compile the library, a standard suite of build tools must be
-available. These tools are standard for building a C project and are listed
+available. These tools are standard for building C projects and are listed
 below:
- * `make` for build targets and orchestration
- * `gcc` for compilation of C source code
+ * `cmake` for build targets and orchestration
+ * a toolchain that can be used by cmake (gcc, for example)
 
 ## Testing
 The test suite for the project is written using the Google Test suite. The
@@ -27,12 +27,13 @@ More information on the Google Benchmark framework may be found on the project
 ## Documentation
 The specification for the Syslogv2 protocol is in an XML file that can be used
 to generate an RFC-styled document outlining the details. In order to generate
-text, HTML, or other RFC output you will need to use the `xml2rfc` tool,
+text, HTML, or other RFC output you will need to use the `xml2rfc` tool.
 
 ## Development
 If you wish to develop within the stumpless project itself, you will need a few
 additional tools:
  * `perl` for some of the development scripts
+ * `indent` to format sources according to the project standard
 
 ## Simplified Wrapper Interface Generator (SWIG)
 The SWIG project is used to expose the functionality of Stumpless to languages

--- a/include/private/config/have_unistd.h
+++ b/include/private/config/have_unistd.h
@@ -1,3 +1,4 @@
+
 /*
 * Copyright 2018 Joel E. Anderson
 *
@@ -15,11 +16,11 @@
 */
 
 #ifndef __STUMPLESS_PRIVATE_CONFIG_HAVE_UNISTD_H
-#define __STUMPLESS_PRIVATE_CONFIG_HAVE_UNISTD_H
+#  define __STUMPLESS_PRIVATE_CONFIG_HAVE_UNISTD_H
 
-#include <stddef.h>
+#  include <stddef.h>
 
-int unistd_gethostname(char *buffer, size_t namelen);
-int unistd_getpid();
+int unistd_gethostname( char *buffer, size_t namelen );
+int unistd_getpid( void );
 
 #endif /* __STUMPLESS_PRIVATE_CONFIG_HAVE_UNISTD_H */

--- a/include/private/config/have_windows.h
+++ b/include/private/config/have_windows.h
@@ -1,3 +1,4 @@
+
 /*
 * Copyright 2018 Joel E. Anderson
 *
@@ -15,8 +16,8 @@
 */
 
 #ifndef __STUMPLESS_PRIVATE_CONFIG_HAVE_WINDOWS_H
-#define __STUMPLESS_PRIVATE_CONFIG_HAVE_WINDOWS_H
+#  define __STUMPLESS_PRIVATE_CONFIG_HAVE_WINDOWS_H
 
-int windows_getpid();
+int windows_getpid( void );
 
 #endif /* __STUMPLESS_PRIVATE_CONFIG_HAVE_WINDOWS_H */

--- a/include/private/config/have_winsock2.h
+++ b/include/private/config/have_winsock2.h
@@ -1,3 +1,4 @@
+
 /*
 * Copyright 2018 Joel E. Anderson
 *
@@ -15,8 +16,8 @@
 */
 
 #ifndef __STUMPLESS_PRIVATE_CONFIG_HAVE_WINSOCK2_H
-#define __STUMPLESS_PRIVATE_CONFIG_HAVE_WINSOCK2_H
+#  define __STUMPLESS_PRIVATE_CONFIG_HAVE_WINSOCK2_H
 
-int winsock2_gethostname(char *buffer, size_t namelen);
+int winsock2_gethostname( char *buffer, size_t namelen );
 
 #endif /* __STUMPLESS_PRIVATE_CONFIG_HAVE_WINSOCK2_H */

--- a/include/private/config/wrapper.h
+++ b/include/private/config/wrapper.h
@@ -1,3 +1,4 @@
+
 /*
 * Copyright 2018 Joel E. Anderson
 *
@@ -15,43 +16,43 @@
 */
 
 #ifndef __STUMPLESS_PRIVATE_CONFIG_WRAPPER_H
-#define __STUMPLESS_PRIVATE_CONFIG_WRAPPER_H
+#  define __STUMPLESS_PRIVATE_CONFIG_WRAPPER_H
 
-#include <stumpless/config.h>
-#include "private/config.h"
+#  include <stumpless/config.h>
+#  include "private/config.h"
 
-#ifdef HAVE_UNISTD_H
-  #include "private/config/have_unistd.h"
-#endif
+#  ifdef HAVE_UNISTD_H
+#    include "private/config/have_unistd.h"
+#  endif
 
-#ifdef HAVE_WINDOWS_H
-  #include "private/config/have_windows.h"
-#endif
+#  ifdef HAVE_WINDOWS_H
+#    include "private/config/have_windows.h"
+#  endif
 
-#ifdef HAVE_WINSOCK2_H
-  #include "private/config/have_winsock2.h"
-#endif
+#  ifdef HAVE_WINSOCK2_H
+#    include "private/config/have_winsock2.h"
+#  endif
 
 /* definition of config_socket */
-#ifdef STUMPLESS_SOCKET_TARGETS_SUPPORTED
-  #include "private/target/socket.h"
-  #define config_sendto_socket_target sendto_socket_target
-#else
-  #define config_sendto_socket_target target_unsupported
-#endif
+#  ifdef STUMPLESS_SOCKET_TARGETS_SUPPORTED
+#    include "private/target/socket.h"
+#    define config_sendto_socket_target sendto_socket_target
+#  else
+#    define config_sendto_socket_target target_unsupported
+#  endif
 
 /* definition of config_gethostname */
-#ifdef HAVE_UNISTD_H
-  #define config_gethostname(buffer, namelen) unistd_gethostname((buffer), (namelen))
-#elif HAVE_WINSOCK2_H
-  #define config_gethostname(buffer, namelen) winsock2_gethostname((buffer), (namelen))
-#endif
+#  ifdef HAVE_UNISTD_H
+#    define config_gethostname(buffer, namelen) unistd_gethostname((buffer), (namelen))
+#  elif HAVE_WINSOCK2_H
+#    define config_gethostname(buffer, namelen) winsock2_gethostname((buffer), (namelen))
+#  endif
 
 /* definition of config_getpid */
-#ifdef HAVE_UNISTD_H
-  #define config_getpid unistd_getpid
-#elif HAVE_WINDOWS_H
-  #define config_getpid windows_getpid
-#endif
+#  ifdef HAVE_UNISTD_H
+#    define config_getpid unistd_getpid
+#  elif HAVE_WINDOWS_H
+#    define config_getpid windows_getpid
+#  endif
 
 #endif /* __STUMPLESS_PRIVATE_CONFIG_WRAPPER_H */

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -13,18 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include <sys/types.h>
 #include <stumpless/entry.h>
 
 #ifndef __STUMPLESS_PRIVATE_ENTRY_H
-#define __STUMPLESS_PRIVATE_ENTRY_H
+#  define __STUMPLESS_PRIVATE_ENTRY_H
 
-struct strbuilder *strbuilder_append_app_name(struct strbuilder *builder, const struct stumpless_entry *entry);
-struct strbuilder *strbuilder_append_hostname(struct strbuilder *builder);
-struct strbuilder *strbuilder_append_msgid(struct strbuilder *builder, const struct stumpless_entry *entry);
-struct strbuilder *strbuilder_append_message(struct strbuilder *builder, const struct stumpless_entry *entry);
-struct strbuilder *strbuilder_append_procid(struct strbuilder *builder);
-struct strbuilder *strbuilder_append_structured_data(struct strbuilder *builder, const struct stumpless_entry *entry);
+struct strbuilder *strbuilder_append_app_name( struct strbuilder *builder, const struct stumpless_entry
+                                               *entry );
+struct strbuilder *strbuilder_append_hostname( struct strbuilder *builder );
+struct strbuilder *strbuilder_append_msgid( struct strbuilder *builder, const struct stumpless_entry
+                                            *entry );
+struct strbuilder *strbuilder_append_message( struct strbuilder *builder, const struct stumpless_entry
+                                              *entry );
+struct strbuilder *strbuilder_append_procid( struct strbuilder *builder );
+struct strbuilder *strbuilder_append_structured_data( struct strbuilder
+                                                      *builder, const struct
+                                                      stumpless_entry *entry );
 
 #endif /* __STUMPLESS_PRIVATE_ENTRY_H */

--- a/include/private/error.h
+++ b/include/private/error.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,15 +16,15 @@
  */
 
 #ifndef __STUMPLESS_PRIVATE_ERROR_H
-#define __STUMPLESS_PRIVATE_ERROR_H
+#  define __STUMPLESS_PRIVATE_ERROR_H
 
-#include <stumpless/error.h>
+#  include <stumpless/error.h>
 
-void clear_error();
-void raise_argument_empty();
-void raise_argument_too_big();
-void raise_error(enum stumpless_error_id id);
-void raise_memory_allocation_failure();
-void raise_target_unsupported();
+void clear_error( void );
+void raise_argument_empty( void );
+void raise_argument_too_big( void );
+void raise_error( enum stumpless_error_id id );
+void raise_memory_allocation_failure( void );
+void raise_target_unsupported( void );
 
 #endif /* __STUMPLESS_PRIVATE_ERROR_H */

--- a/include/private/formatter.h
+++ b/include/private/formatter.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,25 +16,27 @@
  */
 
 #ifndef __STUMPLESS_PRIVATE_FORMATTER_H
-#define __STUMPLESS_PRIVATE_FORMATTER_H
+#  define __STUMPLESS_PRIVATE_FORMATTER_H
 
-#include <stddef.h>
-#include <sys/types.h>
-#include <stumpless/entry.h>
-#include <stumpless/target.h>
+#  include <stddef.h>
+#  include <sys/types.h>
+#  include <stumpless/entry.h>
+#  include <stumpless/target.h>
 
-#define RFC_5424_MAX_PRI_LENGTH 5
-#define RFC_5424_MAX_TIMESTAMP_LENGTH 32
-#define RFC_5424_MAX_HOSTNAME_LENGTH 255
-#define RFC_5424_MAX_PROCID_LENGTH 128
+#  define RFC_5424_MAX_PRI_LENGTH 5
+#  define RFC_5424_MAX_TIMESTAMP_LENGTH 32
+#  define RFC_5424_MAX_HOSTNAME_LENGTH 255
+#  define RFC_5424_MAX_PROCID_LENGTH 128
 
-char *format_entry(const struct stumpless_target *target, struct stumpless_entry *entry);
+char *format_entry( const struct stumpless_target *target,
+                    struct stumpless_entry *entry );
 
 /*
  * Gets the current timestamp and writes it to the string builder. The time
  * reflected by the timestamp will be as close to the time of the function
  * invocation as feasible.
  */
-struct strbuilder *strbuilder_append_rfc5424_timestamp(struct strbuilder *builder);
+struct strbuilder *strbuilder_append_rfc5424_timestamp( struct strbuilder
+                                                        *builder );
 
 #endif /* __STUMPLESS_PRIVATE_FORMATTER_H */

--- a/include/private/id.h
+++ b/include/private/id.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,9 +16,9 @@
  */
 
 #ifndef __STUMPLESS_PRIVATE_ID_H
-#define __STUMPLESS_PRIVATE_ID_H
- 
-#include <stumpless/id.h>
+#  define __STUMPLESS_PRIVATE_ID_H
+
+#  include <stumpless/id.h>
 
 struct id_map_node {
   struct id_map_node *next;
@@ -30,9 +31,9 @@ struct id_map {
 };
 
 /* returns 0 on error, id otherwise */
-stumpless_id_t add_to_id_map(struct id_map *map, void *value);
-void destroy_id_map(struct id_map *map);
-void *get_by_id(struct id_map *map, stumpless_id_t id);
-struct id_map *new_id_map();
+stumpless_id_t add_to_id_map( struct id_map *map, void *value );
+void destroy_id_map( struct id_map *map );
+void *get_by_id( struct id_map *map, stumpless_id_t id );
+struct id_map *new_id_map( void );
 
 #endif /* __STUMPLESS_PRIVATE_ID_H */

--- a/include/private/memory.h
+++ b/include/private/memory.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,11 +16,11 @@
  */
 
 #ifndef __STUMPLESS_PRIVATE_MEMORY_H
-#define __STUMPLESS_PRIVATE_MEMORY_H
+#  define __STUMPLESS_PRIVATE_MEMORY_H
 
-#include <stddef.h>
+#  include <stddef.h>
 
-void *alloc_mem(size_t amount);
-void free_mem(void *mem);
+void *alloc_mem( size_t amount );
+void free_mem( void *mem );
 
 #endif /* __STUMPLESS_PRIVATE_MEMORY_H */

--- a/include/private/strbuilder.h
+++ b/include/private/strbuilder.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,11 +16,11 @@
  */
 
 #ifndef __STUMPLESS_PRIVATE_STRBUILDER_H
-#define __STUMPLESS_PRIVATE_STRBUILDER_H
+#  define __STUMPLESS_PRIVATE_STRBUILDER_H
 
-#include <stddef.h>
+#  include <stddef.h>
 
-#define STRBUILDER_DEFAULT_BUFFER_SIZE 1024
+#  define STRBUILDER_DEFAULT_BUFFER_SIZE 1024
 
 struct strbuilder {
   char *buffer;
@@ -27,13 +28,15 @@ struct strbuilder {
   char *buffer_end;
 };
 
-struct strbuilder *strbuilder_append_buffer(struct strbuilder *builder, const char *buffer, size_t size);
-struct strbuilder *strbuilder_append_char(struct strbuilder *builder, char c);
-struct strbuilder *strbuilder_append_int(struct strbuilder *builder, int i);
-struct strbuilder *strbuilder_append_string(struct strbuilder *builder, const char *str);
-void strbuilder_destroy(struct strbuilder *builder);
-char *strbuilder_to_string(struct strbuilder *builder);
-struct strbuilder *strbuilder_new();
-struct strbuilder *strbuilder_new_sized(size_t size);
+struct strbuilder *strbuilder_append_buffer( struct strbuilder *builder,
+                                             const char *buffer, size_t size );
+struct strbuilder *strbuilder_append_char( struct strbuilder *builder, char c );
+struct strbuilder *strbuilder_append_int( struct strbuilder *builder, int i );
+struct strbuilder *strbuilder_append_string( struct strbuilder *builder,
+                                             const char *str );
+void strbuilder_destroy( struct strbuilder *builder );
+char *strbuilder_to_string( struct strbuilder *builder );
+struct strbuilder *strbuilder_new( void );
+struct strbuilder *strbuilder_new_sized( size_t size );
 
 #endif /* __STUMPLESS_PRIVATE_STRBUILDER_H */

--- a/include/private/target.h
+++ b/include/private/target.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,8 +16,9 @@
  */
 
 #ifndef __STUMPLESS_PRIVATE_TARGET_H
-#define __STUMPLESS_PRIVATE_TARGET_H
- 
-int target_unsupported(const struct stumpless_target *target, const char *msg);
+#  define __STUMPLESS_PRIVATE_TARGET_H
+
+int target_unsupported( const struct stumpless_target *target,
+                        const char *msg );
 
 #endif /* __STUMPLESS_PRIVATE_TARGET_H */

--- a/include/private/target/buffer.h
+++ b/include/private/target/buffer.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,19 +16,20 @@
  */
 
 #ifndef __STUMPLESS_PRIVATE_TARGET_BUFFER_H
-#define __STUMPLESS_PRIVATE_TARGET_BUFFER_H
+#  define __STUMPLESS_PRIVATE_TARGET_BUFFER_H
 
-#include <stddef.h> 
-#include <stumpless/target.h>
- 
+#  include <stddef.h>
+#  include <stumpless/target.h>
+
 struct buffer_target {
   char *buffer;
   size_t size;
   size_t position;
 };
 
-void destroy_buffer_target(struct buffer_target *target);
-struct buffer_target *new_buffer_target(char *buffer, size_t size);
-int sendto_buffer_target(const struct stumpless_target *target, const char *msg);
+void destroy_buffer_target( struct buffer_target *target );
+struct buffer_target *new_buffer_target( char *buffer, size_t size );
+int sendto_buffer_target( const struct stumpless_target *target,
+                          const char *msg );
 
 #endif /* __STUMPLESS_PRIVATE_TARGET_BUFFER_H */

--- a/include/private/target/socket.h
+++ b/include/private/target/socket.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,14 +16,14 @@
  */
 
 #ifndef __STUMPLESS_PRIVATE_TARGET_SOCKET_H
-#define __STUMPLESS_PRIVATE_TARGET_SOCKET_H
- 
-#include <string.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/un.h>
-#include <stumpless/target.h>
- 
+#  define __STUMPLESS_PRIVATE_TARGET_SOCKET_H
+
+#  include <string.h>
+#  include <sys/socket.h>
+#  include <sys/types.h>
+#  include <sys/un.h>
+#  include <stumpless/target.h>
+
 struct socket_target {
   struct sockaddr_un target_addr;
   socklen_t target_addr_len;
@@ -30,8 +31,9 @@ struct socket_target {
   int local_socket;
 };
 
-void destroy_socket_target(struct socket_target *trgt);
-struct socket_target *new_socket_target(const char *dest, size_t dest_len);
-int sendto_socket_target(const struct stumpless_target *trgt, const char *msg);
+void destroy_socket_target( struct socket_target *trgt );
+struct socket_target *new_socket_target( const char *dest, size_t dest_len );
+int sendto_socket_target( const struct stumpless_target *trgt,
+                          const char *msg );
 
 #endif /* __STUMPLESS_PRIVATE_TARGET_SOCKET_H */

--- a/include/stumpless.h
+++ b/include/stumpless.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 

--- a/include/stumpless/entry.h
+++ b/include/stumpless/entry.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,52 +16,60 @@
  */
 
 #ifndef __STUMPLESS_ENTRY_H
-#define __STUMPLESS_ENTRY_H
+#  define __STUMPLESS_ENTRY_H
 
-#include <stddef.h>
-#include <stumpless/id.h>
+#  include <stddef.h>
+#  include <stumpless/id.h>
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 extern "C" {
-#endif
+#  endif
 
-struct stumpless_param {
-  char *name;
-  size_t name_length;
-  char *value;
-  size_t value_length;
-};
+  struct stumpless_param {
+    char *name;
+    size_t name_length;
+    char *value;
+    size_t value_length;
+  };
 
-struct stumpless_element {
-  char *name;
-  size_t name_length;
-  struct stumpless_param **params;
-  size_t param_count;
-};
+  struct stumpless_element {
+    char *name;
+    size_t name_length;
+    struct stumpless_param **params;
+    size_t param_count;
+  };
 
-struct stumpless_entry {
-  stumpless_id_t id;
-  char *app_name;
-  size_t app_name_length;
-  char *message;
-  size_t message_length;
-  char *msgid;
-  size_t msgid_length;
-  struct stumpless_element **elements;
-  size_t element_count;
-};
+  struct stumpless_entry {
+    stumpless_id_t id;
+    char *app_name;
+    size_t app_name_length;
+    char *message;
+    size_t message_length;
+    char *msgid;
+    size_t msgid_length;
+    struct stumpless_element **elements;
+    size_t element_count;
+  };
 
-struct stumpless_entry *stumpless_add_element(struct stumpless_entry *entry, struct stumpless_element *element);
-struct stumpless_element *stumpless_add_param(struct stumpless_element *element, struct stumpless_param *param);
-struct stumpless_element *stumpless_new_element(const char *name);
-struct stumpless_entry *stumpless_new_entry(const char *app_name, const char *msgid, const char *message);
-struct stumpless_param *stumpless_new_param(const char *name, const char *value);
-void stumpless_destroy_element(struct stumpless_element *element);
-void stumpless_destroy_entry(struct stumpless_entry *entry);
-void stumpless_destroy_param(struct stumpless_param *param);
+  struct stumpless_entry *stumpless_add_element( struct stumpless_entry *entry,
+                                                 struct stumpless_element
+                                                 *element );
+  struct stumpless_element *stumpless_add_param( struct stumpless_element
+                                                 *element,
+                                                 struct stumpless_param
+                                                 *param );
+  struct stumpless_element *stumpless_new_element( const char *name );
+  struct stumpless_entry *stumpless_new_entry( const char *app_name,
+                                               const char *msgid,
+                                               const char *message );
+  struct stumpless_param *stumpless_new_param( const char *name,
+                                               const char *value );
+  void stumpless_destroy_element( struct stumpless_element *element );
+  void stumpless_destroy_entry( struct stumpless_entry *entry );
+  void stumpless_destroy_param( struct stumpless_param *param );
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+#  ifdef __cplusplus
+}                               /* extern "C" */
+#  endif
 
-#endif /* __STUMPLESS_ENTRY_H */
+#endif                          /* __STUMPLESS_ENTRY_H */

--- a/include/stumpless/error.h
+++ b/include/stumpless/error.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,27 +16,27 @@
  */
 
 #ifndef __STUMPLESS_ERROR_H
-#define __STUMPLESS_ERROR_H
+#  define __STUMPLESS_ERROR_H
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 extern "C" {
-#endif
+#  endif
 
-enum stumpless_error_id{
-  STUMPLESS_ARGUMENT_EMPTY,
-  STUMPLESS_ARGUMENT_TOO_BIG,
-  STUMPLESS_MEMORY_ALLOCATION_FAILURE,
-  STUMPLESS_TARGET_UNSUPPORTED
-};
+  enum stumpless_error_id {
+    STUMPLESS_ARGUMENT_EMPTY,
+    STUMPLESS_ARGUMENT_TOO_BIG,
+    STUMPLESS_MEMORY_ALLOCATION_FAILURE,
+    STUMPLESS_TARGET_UNSUPPORTED
+  };
 
-struct stumpless_error {
-  enum stumpless_error_id id;
-};
+  struct stumpless_error {
+    enum stumpless_error_id id;
+  };
 
-struct stumpless_error *stumpless_get_error();
+  struct stumpless_error *stumpless_get_error( void );
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+#  ifdef __cplusplus
+}                               /* extern "C" */
+#  endif
 
-#endif /* __STUMPLESS_ERROR_H */
+#endif                          /* __STUMPLESS_ERROR_H */

--- a/include/stumpless/id.h
+++ b/include/stumpless/id.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,16 +16,16 @@
  */
 
 #ifndef __STUMPLESS_ID_H
-#define __STUMPLESS_ID_H
+#  define __STUMPLESS_ID_H
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 extern "C" {
-#endif
+#  endif
 
-typedef int stumpless_id_t;
+  typedef int stumpless_id_t;
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+#  ifdef __cplusplus
+}                               /* extern "C" */
+#  endif
 
-#endif /* __STUMPLESS_ID_H */
+#endif                          /* __STUMPLESS_ID_H */

--- a/include/stumpless/target.h
+++ b/include/stumpless/target.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,38 +16,39 @@
  */
 
 #ifndef __STUMPLESS_TARGET_H
-#define __STUMPLESS_TARGET_H
+#  define __STUMPLESS_TARGET_H
 
-#include <stumpless/entry.h>
-#include <stumpless/id.h>
+#  include <stumpless/entry.h>
+#  include <stumpless/id.h>
 
-#define STUMPLESS_MAX_TARGET_COUNT 10
+#  define STUMPLESS_MAX_TARGET_COUNT 10
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 extern "C" {
-#endif
+#  endif
 
-enum stumpless_target_type {
-  STUMPLESS_BUFFER_TARGET,
-  STUMPLESS_SOCKET_TARGET
-};
+  enum stumpless_target_type {
+    STUMPLESS_BUFFER_TARGET,
+    STUMPLESS_SOCKET_TARGET
+  };
 
-struct stumpless_target {
-  stumpless_id_t id;
-  enum stumpless_target_type type;
-  char *name;
-  int options;
-  int facility;
-  int severity;
-};
+  struct stumpless_target {
+    stumpless_id_t id;
+    enum stumpless_target_type type;
+    char *name;
+    int options;
+    int facility;
+    int severity;
+  };
 
-int stumpless(const char *message);
-int stumpless_add_entry(struct stumpless_target *target, struct stumpless_entry *entry);
-struct stumpless_target *stumpless_get_current_target();
-void stumpless_set_current_target(struct stumpless_target *target);
+  int stumpless( const char *message );
+  int stumpless_add_entry( struct stumpless_target *target,
+                           struct stumpless_entry *entry );
+  struct stumpless_target *stumpless_get_current_target(  );
+  void stumpless_set_current_target( struct stumpless_target *target );
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+#  ifdef __cplusplus
+}                               /* extern "C" */
+#  endif
 
-#endif /* __STUMPLESS_TARGET_H */
+#endif                          /* __STUMPLESS_TARGET_H */

--- a/include/stumpless/target/buffer.h
+++ b/include/stumpless/target/buffer.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,20 +16,24 @@
  */
 
 #ifndef __STUMPLESS_TARGET_BUFFER_H
-#define __STUMPLESS_TARGET_BUFFER_H
+#  define __STUMPLESS_TARGET_BUFFER_H
 
-#include <stddef.h>
-#include <stumpless/target.h>
+#  include <stddef.h>
+#  include <stumpless/target.h>
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 extern "C" {
-#endif
+#  endif
 
-void stumpless_close_buffer_target(struct stumpless_target *target);
-struct stumpless_target *stumpless_open_buffer_target(const char *name, char *buffer, size_t size, int options, int facility);
+  void stumpless_close_buffer_target( struct stumpless_target *target );
+  struct stumpless_target *stumpless_open_buffer_target( const char *name,
+                                                         char *buffer,
+                                                         size_t size,
+                                                         int options,
+                                                         int facility );
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+#  ifdef __cplusplus
+}                               /* extern "C" */
+#  endif
 
-#endif /* __STUMPLESS_TARGET_BUFFER_H */
+#endif                          /* __STUMPLESS_TARGET_BUFFER_H */

--- a/include/stumpless/target/socket.h
+++ b/include/stumpless/target/socket.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,22 +16,24 @@
  */
 
 #ifndef __STUMPLESS_TARGET_SOCKET_H
-#define __STUMPLESS_TARGET_SOCKET_H
+#  define __STUMPLESS_TARGET_SOCKET_H
 
-#include <stumpless/target.h>
+#  include <stumpless/target.h>
 
-#define STUMPLESS_SOCKET_NAME "/tmp/stumplesstestpipe"
-#define STUMPLESS_SOCKET_NAME_LENGTH 22
+#  define STUMPLESS_SOCKET_NAME "/tmp/stumplesstestpipe"
+#  define STUMPLESS_SOCKET_NAME_LENGTH 22
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 extern "C" {
-#endif
+#  endif
 
-void stumpless_close_socket_target(struct stumpless_target *target);
-struct stumpless_target *stumpless_open_socket_target(const char *name, int options, int facility);
+  void stumpless_close_socket_target( struct stumpless_target *target );
+  struct stumpless_target *stumpless_open_socket_target( const char *name,
+                                                         int options,
+                                                         int facility );
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+#  ifdef __cplusplus
+}                               /* extern "C" */
+#  endif
 
-#endif /* __STUMPLESS_TARGET_SOCKET_H */
+#endif                          /* __STUMPLESS_TARGET_SOCKET_H */

--- a/include/stumpless/version.h
+++ b/include/stumpless/version.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,26 +16,26 @@
  */
 
 #ifndef __STUMPLESS_VERSION_H
-#define __STUMPLESS_VERSION_H
+#  define __STUMPLESS_VERSION_H
 
-#define STUMPLESS_MAJOR_VERSION 0
-#define STUMPLESS_MINOR_VERSION 0
-#define STUMPLESS_PATCH_VERSION 1
+#  define STUMPLESS_MAJOR_VERSION 0
+#  define STUMPLESS_MINOR_VERSION 0
+#  define STUMPLESS_PATCH_VERSION 1
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 extern "C" {
-#endif
+#  endif
 
-struct stumpless_version {
-  int major;
-  int minor;
-  int patch;
-};
+  struct stumpless_version {
+    int major;
+    int minor;
+    int patch;
+  };
 
-struct stumpless_version *get_stumpless_version();
+  struct stumpless_version *get_stumpless_version( void );
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+#  ifdef __cplusplus
+}                               /* extern "C" */
+#  endif
 
-#endif /* __STUMPLESS_VERSION_H */
+#endif                          /* __STUMPLESS_VERSION_H */

--- a/include/test/function/rfc5424.hpp
+++ b/include/test/function/rfc5424.hpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,7 +16,7 @@
  */
 
 #ifndef __STUMPLESS_TEST_FUNCTION_RFC5424_HPP
-#define __STUMPLESS_TEST_FUNCTION_RFC5424_HPP
+#  define __STUMPLESS_TEST_FUNCTION_RFC5424_HPP
 
 /*
  * This format is specified in https://tools.ietf.org/html/rfc5424
@@ -71,59 +72,59 @@
  * 24 - everything from the first PARAM-NAME to the last "PARAM-VALUE"
  * 25 - MSG (the log message itself)
  */
-#define RFC_5424_REGEX_STRING "^<(\\d{1,3})>"                        /* PRI */ \
-                              "([1-9]\\d{0,2})"                  /* VERSION */ \
-                              " "                                     /* SP */ \
-                              "(-|("                           /* TIMESTAMP */ \
-                              "(\\d{4})-(\\d{2})-(\\d{2})"     /* FULL-DATE */ \
-			      "T"                                    /* "T" */ \
-                              "\\d{2}:\\d{2}:\\d{2}"        /* PARTIAL-TIME */ \
-			      "(\\.\\d{1,6})?"              /* TIME-SECFRAC */ \
-                              "(Z|("                         /* TIME-OFFSET */ \
-			      "(\\+|-)\\d{2}:\\d{2}"      /* TIME-NUMOFFSET */ \
-                              "))"                           /* TIME-OFFSET */ \
-                              "))"                             /* TIMESTAMP */ \
-                              " "                                     /* SP */ \
-                              "(-|([!-~]{1,255}))"              /* HOSTNAME */ \
-                              " "                                     /* SP */ \
-                              "(-|([!-~]{1,48}))"               /* APP-NAME */ \
-                              " "                                     /* SP */ \
-                              "(-|([!-~]{1,128}))"                /* PROCID */ \
-                              " "                                     /* SP */ \
-                              "(-|([!-~]{1,32}))"                  /* MSGID */ \
-                              " "                                     /* SP */ \
-                              "(-|(("                    /* STRUCTURED-DATA */ \
-                              "\\["                           /* SD-ELEMENT */ \
-                              "([!#-<>-\\\\\\^-~]{1,32})"          /* SD-ID */ \
-			      "( [!#-<>-\\\\\\^-~]{1,32}"     /* PARAM-NAME */ \
-                              "=\".*\")*"                    /* PARAM-VALUE */ \
-			      "\\]"                           /* SD-ELEMENT */ \
-                              ")+))"                     /* STRUCTURED-DATA */ \
-                              " "                                     /* SP */ \
-                              "(.*)$"                                /* MSG */
+#  define RFC_5424_REGEX_STRING "^<(\\d{1,3})>"                      /* PRI */ \
+                                "([1-9]\\d{0,2})"                /* VERSION */ \
+                                " "                                   /* SP */ \
+                                "(-|("                         /* TIMESTAMP */ \
+                                "(\\d{4})-(\\d{2})-(\\d{2})"   /* FULL-DATE */ \
+          		      "T"                                    /* "T" */ \
+                                "\\d{2}:\\d{2}:\\d{2}"      /* PARTIAL-TIME */ \
+          		      "(\\.\\d{1,6})?"              /* TIME-SECFRAC */ \
+                                "(Z|("                       /* TIME-OFFSET */ \
+          		      "(\\+|-)\\d{2}:\\d{2}"      /* TIME-NUMOFFSET */ \
+                                "))"                         /* TIME-OFFSET */ \
+                                "))"                           /* TIMESTAMP */ \
+                                " "                                   /* SP */ \
+                                "(-|([!-~]{1,255}))"            /* HOSTNAME */ \
+                                " "                                   /* SP */ \
+                                "(-|([!-~]{1,48}))"             /* APP-NAME */ \
+                                " "                                   /* SP */ \
+                                "(-|([!-~]{1,128}))"              /* PROCID */ \
+                                " "                                   /* SP */ \
+                                "(-|([!-~]{1,32}))"                /* MSGID */ \
+                                " "                                   /* SP */ \
+                                "(-|(("                  /* STRUCTURED-DATA */ \
+                                "\\["                         /* SD-ELEMENT */ \
+                                "([!#-<>-\\\\\\^-~]{1,32})"        /* SD-ID */ \
+          		      "( [!#-<>-\\\\\\^-~]{1,32}"     /* PARAM-NAME */ \
+                                "=\".*\")*"                  /* PARAM-VALUE */ \
+          		      "\\]"                           /* SD-ELEMENT */ \
+                                ")+))"                   /* STRUCTURED-DATA */ \
+                                " "                                   /* SP */ \
+                                "(.*)$" /* MSG */
 
-#define RFC_5424_SYSLOG_MSG_MATCH_INDEX 0
-#define RFC_5424_PRIVAL_MATCH_INDEX 1
-#define RFC_5424_VERSION_MATCH_INDEX 2
-#define RFC_5424_TIMESTAMP_MATCH_INDEX 3
-#define RFC_5424_DATE_FULLYEAR_MATCH_INDEX 5
-#define RFC_5424_DATE_MONTH_MATCH_INDEX 6
-#define RFC_5424_DATE_MDAY_MATCH_INDEX 7
-#define RFC_5424_TIME_SECFRAC_MATCH_INDEX 8
-#define RFC_5424_TIME_OFFSET_MATCH_INDEX 9
-#define RFC_5424_TIME_NUMOFFSET_MATCH_INDEX 10
-#define RFC_5424_HOSTNAME_MATCH_INDEX 12
-#define RFC_5424_APP_NAME_MATCH_INDEX 14
-#define RFC_5424_PROCID_MATCH_INDEX 16
-#define RFC_5424_MSGID_MATCH_INDEX 18
-#define RFC_5424_STRUCTURED_DATA_MATCH_INDEX 20
-#define RFC_5424_SD_ELEMENTS_MATCH_INDEX 21
-#define RFC_5424_MSG_MATCH_INDEX 25
+#  define RFC_5424_SYSLOG_MSG_MATCH_INDEX 0
+#  define RFC_5424_PRIVAL_MATCH_INDEX 1
+#  define RFC_5424_VERSION_MATCH_INDEX 2
+#  define RFC_5424_TIMESTAMP_MATCH_INDEX 3
+#  define RFC_5424_DATE_FULLYEAR_MATCH_INDEX 5
+#  define RFC_5424_DATE_MONTH_MATCH_INDEX 6
+#  define RFC_5424_DATE_MDAY_MATCH_INDEX 7
+#  define RFC_5424_TIME_SECFRAC_MATCH_INDEX 8
+#  define RFC_5424_TIME_OFFSET_MATCH_INDEX 9
+#  define RFC_5424_TIME_NUMOFFSET_MATCH_INDEX 10
+#  define RFC_5424_HOSTNAME_MATCH_INDEX 12
+#  define RFC_5424_APP_NAME_MATCH_INDEX 14
+#  define RFC_5424_PROCID_MATCH_INDEX 16
+#  define RFC_5424_MSGID_MATCH_INDEX 18
+#  define RFC_5424_STRUCTURED_DATA_MATCH_INDEX 20
+#  define RFC_5424_SD_ELEMENTS_MATCH_INDEX 21
+#  define RFC_5424_MSG_MATCH_INDEX 25
 
-#define RFC_5424_PRIVAL_MIN 0
-#define RFC_5424_PRIVAL_MAX 191
+#  define RFC_5424_PRIVAL_MIN 0
+#  define RFC_5424_PRIVAL_MAX 191
 
-void TestRFC5424Compliance(const char *syslog_msg);
-void TestRFC5424StructuredData(const char *sd_elements);
+void TestRFC5424Compliance( const char *syslog_msg );
+void TestRFC5424StructuredData( const char *sd_elements );
 
 #endif /* __STUMPLESS_TEST_FUNCTION_RFC5424_HPP */

--- a/include/test/function/utf8.hpp
+++ b/include/test/function/utf8.hpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -15,8 +16,8 @@
  */
 
 #ifndef __STUMPLESS_TEST_FUNCTION_UTF8_HPP
-#define __STUMPLESS_TEST_FUNCTION_UTF8_HPP
+#  define __STUMPLESS_TEST_FUNCTION_UTF8_HPP
 
-void TestUTF8Compliance(const char *str);
+void TestUTF8Compliance( const char *str );
 
 #endif /* __STUMPLESS_TEST_FUNCTION_UTF8_HPP */

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,8 @@
 These scripts are useful for various development and build tasks. Each script
-can be run with --help as a parameter to see specific usage.
+can be run with `--help` as a parameter to see specific usage.
 
 ## headers_check.pl
 Checks a source file for extraneous or missing `#include` statements.
+
+## indent.sh
+Runs `indent` on a source file to apply standard formatting.

--- a/scripts/indent.sh
+++ b/scripts/indent.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+indent \
+  --blank-lines-before-block-comments \
+  --braces-on-func-def-line \
+  --braces-on-if-line \
+  --braces-on-struct-decl-line \
+  --case-indentation2 \
+  --comment-line-length80 \
+  --cuddle-else \
+  --format-all-comments \
+  --ignore-profile \
+  --indent-level2 \
+  --line-length80 \
+  --no-space-after-for \
+  --no-space-after-if \
+  --no-space-after-function-call-names \
+  --no-tabs \
+  --preprocessor-indentation2 \
+  --space-after-parentheses \
+  --tab-size2 \
+  $1

--- a/src/config/have_unistd.c
+++ b/src/config/have_unistd.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -18,15 +19,17 @@
 #include <unistd.h>
 #include "private/config/have_unistd.h"
 
-int unistd_gethostname(char *buffer, size_t namelen) {
+int
+unistd_gethostname( char *buffer, size_t namelen ) {
   int result;
 
-  result = gethostname(buffer, namelen);
+  result = gethostname( buffer, namelen );
   buffer[namelen - 1] = '\0';
 
   return result;
 }
 
-int unistd_getpid() {
-  return (int)(getpid());
+int
+unistd_getpid( void ) {
+  return ( int ) ( getpid(  ) );
 }

--- a/src/config/have_windows.c
+++ b/src/config/have_windows.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -16,6 +17,7 @@
 
 #include <windows.h>
 
-int windows_getpid() {
-  return (int)(GetCurrentProcessId());
+int
+windows_getpid( void ) {
+  return ( int ) ( GetCurrentProcessId(  ) );
 }

--- a/src/config/have_winsock2.c
+++ b/src/config/have_winsock2.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -17,17 +18,18 @@
 #include <winsock2.h>
 #include "private/config/have_winsock2.h"
 
-int winsock2_gethostname(char *buffer, size_t namelen) {
+int
+winsock2_gethostname( char *buffer, size_t namelen ) {
   int result;
   WSADATA wsa_data;
 
-  result = gethostname(buffer, namelen);
-  
-  if (result == SOCKET_ERROR) {
-	  if (WSAGetLastError() == WSANOTINITIALISED) {
-		  WSAStartup(MAKEWORD(2, 2), &wsa_data);
-		  result = gethostname(buffer, namelen);
-	  }
+  result = gethostname( buffer, namelen );
+
+  if( result == SOCKET_ERROR ) {
+    if( WSAGetLastError(  ) == WSANOTINITIALISED ) {
+      WSAStartup( MAKEWORD( 2, 2 ), &wsa_data );
+      result = gethostname( buffer, namelen );
+    }
   }
 
   return result;

--- a/src/entry.c
+++ b/src/entry.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -25,26 +26,32 @@
 #include "private/memory.h"
 
 struct stumpless_entry *
-stumpless_add_element(struct stumpless_entry *entry, struct stumpless_element *element){
+stumpless_add_element( struct stumpless_entry *entry,
+                       struct stumpless_element *element ) {
+
   struct stumpless_element **new_elements;
+  size_t old_elements_size, new_elements_size;
 
-  clear_error();
+  clear_error(  );
 
-  if(!entry || !element){
-    raise_argument_empty();
+  if( !entry || !element ) {
+    raise_argument_empty(  );
     return NULL;
   }
 
   // todo need to check for duplicates first
 
-  new_elements = alloc_mem(sizeof(struct stumpless_element *) * (entry->element_count+1));
-  if(!new_elements){
+  old_elements_size = sizeof( element ) * entry->element_count;
+  new_elements_size = old_elements_size + sizeof( element );
+
+  new_elements = alloc_mem( new_elements_size );
+  if( !new_elements ) {
     return NULL;
   }
 
-  if(entry->elements != NULL){
-    memcpy(new_elements, entry->elements, sizeof(struct stumpless_element *) * entry->element_count);
-    free_mem(entry->elements);
+  if( entry->elements != NULL ) {
+    memcpy( new_elements, entry->elements, old_elements_size );
+    free_mem( entry->elements );
   }
 
   new_elements[entry->element_count] = element;
@@ -55,24 +62,31 @@ stumpless_add_element(struct stumpless_entry *entry, struct stumpless_element *e
 }
 
 
-struct stumpless_element *stumpless_add_param(struct stumpless_element *element, struct stumpless_param *param){
+struct stumpless_element *
+stumpless_add_param( struct stumpless_element *element,
+                     struct stumpless_param *param ) {
+
   struct stumpless_param **new_params;
+  size_t old_params_size, new_params_size;
 
-  clear_error();
+  clear_error(  );
 
-  if(!element || !param){
-    raise_argument_empty();
+  if( !element || !param ) {
+    raise_argument_empty(  );
     return NULL;
   }
 
-  new_params = alloc_mem(sizeof(struct stumpless_param *) * (element->param_count+1));
-  if(!new_params){
+  old_params_size = sizeof( param ) * element->param_count;
+  new_params_size = old_params_size + sizeof( param );
+
+  new_params = alloc_mem( new_params_size );
+  if( !new_params ) {
     return NULL;
   }
 
-  if(element->params != NULL){
-    memcpy(new_params, element->params, sizeof(struct stumpless_param *) * element->param_count);
-    free_mem(element->params);
+  if( element->params != NULL ) {
+    memcpy( new_params, element->params, old_params_size );
+    free_mem( element->params );
   }
 
   new_params[element->param_count] = param;
@@ -82,69 +96,72 @@ struct stumpless_element *stumpless_add_param(struct stumpless_element *element,
   return element;
 }
 
-struct stumpless_element *stumpless_new_element(const char *name){
+struct stumpless_element *
+stumpless_new_element( const char *name ) {
   struct stumpless_element *element;
 
-  clear_error();
+  clear_error(  );
 
-  if(!name){
+  if( !name ) {
     goto fail;
   }
 
-  element = alloc_mem(sizeof(struct stumpless_element));
-  if(!element){
+  element = alloc_mem( sizeof( *element ) );
+  if( !element ) {
     goto fail;
   }
 
-  element->name_length = strlen(name);
-  element->name = alloc_mem(element->name_length);
-  if(!element->name){
+  element->name_length = strlen( name );
+  element->name = alloc_mem( element->name_length );
+  if( !element->name ) {
     goto fail_name;
   }
 
-  memcpy(element->name, name, element->name_length);
+  memcpy( element->name, name, element->name_length );
   element->params = NULL;
   element->param_count = 0;
 
   return element;
 
 fail_name:
-  free_mem(element);
+  free_mem( element );
 
 fail:
   return NULL;
 }
 
-struct stumpless_entry *stumpless_new_entry(const char *app_name, const char *msgid, const char *message){
+struct stumpless_entry *
+stumpless_new_entry( const char *app_name, const char *msgid,
+                     const char *message ) {
   struct stumpless_entry *entry;
 
-  clear_error();
+  clear_error(  );
 
-  entry = alloc_mem(sizeof(struct stumpless_entry));
-  if(!entry){
+  entry = alloc_mem( sizeof( *entry ) );
+  if( !entry ) {
     goto fail;
   }
 
-  entry->app_name_length = strlen(app_name);
-  entry->app_name = alloc_mem(entry->app_name_length);
-  if(!entry->app_name){
+  entry->app_name_length = strlen( app_name );
+  entry->app_name = alloc_mem( entry->app_name_length );
+  if( !entry->app_name ) {
     goto fail_app_name;
   }
-  memcpy(entry->app_name, app_name, entry->app_name_length);
+  memcpy( entry->app_name, app_name, entry->app_name_length );
 
-  entry->msgid_length = strlen(msgid);
-  entry->msgid = alloc_mem(entry->msgid_length);
-  if(!entry->msgid){
+  entry->msgid_length = strlen( msgid );
+  entry->msgid = alloc_mem( entry->msgid_length );
+  if( !entry->msgid ) {
     goto fail_msgid;
   }
-  memcpy(entry->msgid, msgid, entry->msgid_length);
+  memcpy( entry->msgid, msgid, entry->msgid_length );
 
-  entry->message_length = strlen(message);
-  entry->message = alloc_mem(entry->message_length);
-  if(!entry->message){
+  entry->message_length = strlen( message );
+  entry->message = alloc_mem( entry->message_length );
+  if( !entry->message ) {
     goto fail_message;
   }
-  memcpy(entry->message, message, entry->message_length);
+  memcpy( entry->message, message, entry->message_length );
 
   entry->elements = NULL;
   entry->element_count = 0;
@@ -152,184 +169,194 @@ struct stumpless_entry *stumpless_new_entry(const char *app_name, const char *ms
   return entry;
 
 fail_message:
-  free_mem(entry->msgid);
+  free_mem( entry->msgid );
 fail_msgid:
-  free_mem(entry->app_name);
+  free_mem( entry->app_name );
 fail_app_name:
-  free_mem(entry);
+  free_mem( entry );
 fail:
   return NULL;
 }
 
-struct stumpless_param *stumpless_new_param(const char *name, const char *value){
+struct stumpless_param *
+stumpless_new_param( const char *name, const char *value ) {
   struct stumpless_param *param;
 
-  clear_error();
+  clear_error(  );
 
-  if(!name || !value){
-    raise_argument_empty();
+  if( !name || !value ) {
+    raise_argument_empty(  );
     goto fail;
   }
 
-  param = alloc_mem(sizeof(struct stumpless_param));
-  if(!param){
+  param = alloc_mem( sizeof( *param ) );
+  if( !param ) {
     goto fail;
   }
 
-  param->name_length = strlen(name);
-  param->name = alloc_mem(param->name_length);
-  if(!param->name){
+  param->name_length = strlen( name );
+  param->name = alloc_mem( param->name_length );
+  if( !param->name ) {
     goto fail_name;
   }
-  memcpy(param->name, name, param->name_length);
+  memcpy( param->name, name, param->name_length );
 
-  param->value_length = strlen(value);
-  param->value = alloc_mem(param->value_length);
-  if(!param->value){
+  param->value_length = strlen( value );
+  param->value = alloc_mem( param->value_length );
+  if( !param->value ) {
     goto fail_value;
   }
-  memcpy(param->value, value, param->value_length);
+  memcpy( param->value, value, param->value_length );
 
   return param;
 
 fail_value:
-  free_mem(param->name);
+  free_mem( param->name );
 
 fail_name:
-  free_mem(param);
+  free_mem( param );
 
 fail:
   return NULL;
 }
 
-void stumpless_destroy_element(struct stumpless_element *element){
+void
+stumpless_destroy_element( struct stumpless_element *element ) {
   size_t i;
 
-  if(!element){
+  if( !element ) {
     return;
   }
 
-  for(i=0; i<element->param_count; i++){
-    stumpless_destroy_param(element->params[i]);
+  for( i = 0; i < element->param_count; i++ ) {
+    stumpless_destroy_param( element->params[i] );
   }
 }
 
-void stumpless_destroy_entry(struct stumpless_entry *entry){
+void
+stumpless_destroy_entry( struct stumpless_entry *entry ) {
   size_t i;
 
-  if(!entry){
+  if( !entry ) {
     return;
   }
 
-  for(i=0; i<entry->element_count; i++){
-    stumpless_destroy_element(entry->elements[i]);
+  for( i = 0; i < entry->element_count; i++ ) {
+    stumpless_destroy_element( entry->elements[i] );
   }
 
-  free_mem(entry->elements);
-  free_mem(entry->msgid);
-  free_mem(entry->app_name);
-  free_mem(entry->message);
-  free_mem(entry);
+  free_mem( entry->elements );
+  free_mem( entry->msgid );
+  free_mem( entry->app_name );
+  free_mem( entry->message );
+  free_mem( entry );
 }
 
-void stumpless_destroy_param(struct stumpless_param *param){
-  if(!param){
+void
+stumpless_destroy_param( struct stumpless_param *param ) {
+  if( !param ) {
     return;
   }
 
-  free_mem(param->name);
-  free_mem(param->value);
-  free_mem(param);
+  free_mem( param->name );
+  free_mem( param->value );
+  free_mem( param );
 }
 
 /* private functions */
 struct strbuilder *
-strbuilder_append_app_name(struct strbuilder *builder,
-                           const struct stumpless_entry *entry){
-  if(!entry){
+strbuilder_append_app_name( struct strbuilder *builder,
+                            const struct stumpless_entry *entry ) {
+  if( !entry ) {
     return NULL;
   }
 
-  return strbuilder_append_buffer(builder,
-                                  entry->app_name,
-                                  entry->app_name_length);
-}
-
-struct strbuilder *strbuilder_append_hostname(struct strbuilder *builder){
-  char buffer[RFC_5424_MAX_HOSTNAME_LENGTH+1];
-
-  config_gethostname(buffer, RFC_5424_MAX_HOSTNAME_LENGTH+1);
-
-  return strbuilder_append_string(builder, buffer);
-}
-
-struct strbuilder *strbuilder_append_msgid(struct strbuilder *builder,
-                                           const struct stumpless_entry *entry){
-  if(!entry){
-    return NULL;
-  }
-
-  return strbuilder_append_buffer(builder, entry->msgid, entry->msgid_length);
+  return strbuilder_append_buffer( builder,
+                                   entry->app_name, entry->app_name_length );
 }
 
 struct strbuilder *
-strbuilder_append_message(struct strbuilder *builder,
-                          const struct stumpless_entry *entry){
-  if(!entry){
-    return NULL;
-  }
+strbuilder_append_hostname( struct strbuilder *builder ) {
+  char buffer[RFC_5424_MAX_HOSTNAME_LENGTH + 1];
 
-  return strbuilder_append_buffer(builder,
-                                  entry->message,
-                                  entry->message_length);
-}
+  config_gethostname( buffer, RFC_5424_MAX_HOSTNAME_LENGTH + 1 );
 
-struct strbuilder *strbuilder_append_procid(struct strbuilder *builder){
-  return strbuilder_append_int(builder, config_getpid());
+  return strbuilder_append_string( builder, buffer );
 }
 
 struct strbuilder *
-strbuilder_append_structured_data(struct strbuilder *builder,
-                                  const struct stumpless_entry *entry){
+strbuilder_append_msgid( struct strbuilder *builder,
+                         const struct stumpless_entry *entry ) {
+
+  if( !entry ) {
+    return NULL;
+  }
+
+  return strbuilder_append_buffer( builder, entry->msgid, entry->msgid_length );
+}
+
+struct strbuilder *
+strbuilder_append_message( struct strbuilder *builder,
+                           const struct stumpless_entry *entry ) {
+
+  if( !entry ) {
+    return NULL;
+  }
+
+  return strbuilder_append_buffer( builder,
+                                   entry->message, entry->message_length );
+}
+
+struct strbuilder *
+strbuilder_append_procid( struct strbuilder *builder ) {
+  return strbuilder_append_int( builder, config_getpid(  ) );
+}
+
+struct strbuilder *
+strbuilder_append_structured_data( struct strbuilder *builder,
+                                   const struct stumpless_entry *entry ) {
   size_t i, j;
-  
-  if(!entry){
+  struct stumpless_element *element;
+  struct stumpless_param *param;
+
+  if( !entry ) {
     return NULL;
   }
 
-  if(entry->element_count == 0){
-    return strbuilder_append_char(builder, '-');
+  if( entry->element_count == 0 ) {
+    return strbuilder_append_char( builder, '-' );
   }
 
-  if(!entry->elements){
+  if( !entry->elements ) {
     return builder;
   }
 
-  for(i=0; i < entry->element_count; i++){
-    builder = strbuilder_append_char(builder, '[');
-    builder = strbuilder_append_buffer(builder,
-                                       entry->elements[i]->name,
-                                       entry->elements[i]->name_length);
+  for( i = 0; i < entry->element_count; i++ ) {
+    element = entry->elements[i];
 
-    for(j=0; j < entry->elements[i]->param_count; j++){
-      builder = strbuilder_append_char(builder, ' ');
+    builder = strbuilder_append_char( builder, '[' );
+    builder = strbuilder_append_buffer( builder,
+                                        element->name, element->name_length );
 
-      builder = strbuilder_append_buffer(builder,
-                                         entry->elements[i]->params[j]->name,
-                                         entry->elements[i]->params[j]->name_length);
+    for( j = 0; j < entry->elements[i]->param_count; j++ ) {
+      param = element->params[j];
 
-      builder = strbuilder_append_char(builder, '=');
-      builder = strbuilder_append_char(builder, '"');
+      builder = strbuilder_append_char( builder, ' ' );
 
-      builder = strbuilder_append_buffer(builder,
-                                         entry->elements[i]->params[j]->value,
-                                         entry->elements[i]->params[j]->value_length);
+      builder = strbuilder_append_buffer( builder,
+                                          param->name, param->name_length );
 
-      builder = strbuilder_append_char(builder, '"');
+      builder = strbuilder_append_char( builder, '=' );
+      builder = strbuilder_append_char( builder, '"' );
+
+      builder = strbuilder_append_buffer( builder,
+                                          param->value, param->value_length );
+
+      builder = strbuilder_append_char( builder, '"' );
     }
 
-    builder = strbuilder_append_char(builder, ']');
+    builder = strbuilder_append_char( builder, ']' );
   }
 
-  return builder; 
+  return builder;
 }

--- a/src/error.c
+++ b/src/error.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -19,11 +20,12 @@
 #include <stumpless/error.h>
 #include "private/error.h"
 
-static struct stumpless_error *last_error=NULL;
-static short error_valid=0;
+static struct stumpless_error *last_error = NULL;
+static short error_valid = 0;
 
-struct stumpless_error *stumpless_get_error(){
-  if(error_valid)
+struct stumpless_error *
+stumpless_get_error( void ) {
+  if( error_valid )
     return last_error;
   else
     return NULL;
@@ -31,35 +33,41 @@ struct stumpless_error *stumpless_get_error(){
 
 /* private functions */
 
-void clear_error(){
+void
+clear_error( void ) {
   error_valid = 0;
 }
 
-void raise_argument_empty(){
-  raise_error(STUMPLESS_ARGUMENT_EMPTY);
+void
+raise_argument_empty( void ) {
+  raise_error( STUMPLESS_ARGUMENT_EMPTY );
 }
 
-void raise_argument_too_big(){
-  raise_error(STUMPLESS_ARGUMENT_TOO_BIG);
+void
+raise_argument_too_big( void ) {
+  raise_error( STUMPLESS_ARGUMENT_TOO_BIG );
 }
 
-void raise_error(enum stumpless_error_id id){
-  if( !last_error ){
-    last_error = malloc(sizeof(struct stumpless_error));
-    if( !last_error ){
+void
+raise_error( enum stumpless_error_id id ) {
+  if( !last_error ) {
+    last_error = malloc( sizeof( struct stumpless_error ) );
+    if( !last_error ) {
       error_valid = 0;
       return;
     }
   }
-  
+
   last_error->id = id;
   error_valid = 1;
 }
 
-void raise_memory_allocation_failure(){
-  raise_error(STUMPLESS_MEMORY_ALLOCATION_FAILURE);
+void
+raise_memory_allocation_failure( void ) {
+  raise_error( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
 }
 
-void raise_target_unsupported() {
-  raise_error(STUMPLESS_TARGET_UNSUPPORTED);
+void
+raise_target_unsupported( void ) {
+  raise_error( STUMPLESS_TARGET_UNSUPPORTED );
 }

--- a/src/formatter.c
+++ b/src/formatter.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -22,48 +23,51 @@
 #include "private/strbuilder.h"
 #include "private/formatter.h"
 
-char *format_entry(const struct stumpless_target *target, struct stumpless_entry *entry){
+char *
+format_entry( const struct stumpless_target *target,
+              struct stumpless_entry *entry ) {
   char *str;
   struct strbuilder *builder, *first_builder;
   int prival;
 
-  first_builder = strbuilder_new();
+  first_builder = strbuilder_new(  );
 
-  builder = strbuilder_append_char(first_builder, '<');
+  builder = strbuilder_append_char( first_builder, '<' );
 
-  prival = target->facility*8 + target->severity;
-  builder = strbuilder_append_int(builder, prival);
+  prival = target->facility * 8 + target->severity;
+  builder = strbuilder_append_int( builder, prival );
 
-  builder = strbuilder_append_string(builder, ">1 ");
-  builder = strbuilder_append_rfc5424_timestamp(builder);
-  builder = strbuilder_append_char(builder, ' ');
-  builder = strbuilder_append_hostname(builder);
-  builder = strbuilder_append_char(builder, ' ');
-  builder = strbuilder_append_app_name(builder, entry);
-  builder = strbuilder_append_char(builder, ' ');
-  builder = strbuilder_append_procid(builder);
-  builder = strbuilder_append_char(builder, ' ');
-  builder = strbuilder_append_msgid(builder, entry);
-  builder = strbuilder_append_char(builder, ' ');
-  builder = strbuilder_append_structured_data(builder, entry);
-  builder = strbuilder_append_char(builder, ' ');
-  builder = strbuilder_append_message(builder, entry);
+  builder = strbuilder_append_string( builder, ">1 " );
+  builder = strbuilder_append_rfc5424_timestamp( builder );
+  builder = strbuilder_append_char( builder, ' ' );
+  builder = strbuilder_append_hostname( builder );
+  builder = strbuilder_append_char( builder, ' ' );
+  builder = strbuilder_append_app_name( builder, entry );
+  builder = strbuilder_append_char( builder, ' ' );
+  builder = strbuilder_append_procid( builder );
+  builder = strbuilder_append_char( builder, ' ' );
+  builder = strbuilder_append_msgid( builder, entry );
+  builder = strbuilder_append_char( builder, ' ' );
+  builder = strbuilder_append_structured_data( builder, entry );
+  builder = strbuilder_append_char( builder, ' ' );
+  builder = strbuilder_append_message( builder, entry );
 
-  str = strbuilder_to_string(builder);
-  strbuilder_destroy(first_builder);
+  str = strbuilder_to_string( builder );
+  strbuilder_destroy( first_builder );
 
   return str;
 }
 
-struct strbuilder *strbuilder_append_rfc5424_timestamp(struct strbuilder *builder){
+struct strbuilder *
+strbuilder_append_rfc5424_timestamp( struct strbuilder *builder ) {
   char buffer[RFC_5424_MAX_TIMESTAMP_LENGTH];
   struct tm *now;
   time_t now_timer;
   size_t written;
 
-  now_timer = time(NULL);
-  now = gmtime(&now_timer);
+  now_timer = time( NULL );
+  now = gmtime( &now_timer );
   // todo add support for fractional times
-  written = strftime(buffer, RFC_5424_MAX_TIMESTAMP_LENGTH, "%FT%TZ", now);
-  return strbuilder_append_buffer(builder, buffer, written);
+  written = strftime( buffer, RFC_5424_MAX_TIMESTAMP_LENGTH, "%FT%TZ", now );
+  return strbuilder_append_buffer( builder, buffer, written );
 }

--- a/src/id.c
+++ b/src/id.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -19,17 +20,18 @@
 #include "private/id.h"
 #include "private/memory.h"
 
-static stumpless_id_t next_id=1;
+static stumpless_id_t next_id = 1;
 
-stumpless_id_t add_to_id_map(struct id_map *map, void *value){
+stumpless_id_t
+add_to_id_map( struct id_map *map, void *value ) {
   struct id_map_node *new, *curr;
 
-  if(!map || !value){
+  if( !map || !value ) {
     return 0;
   }
 
-  new = alloc_mem(sizeof(struct id_map_node));
-  if(!new){
+  new = alloc_mem( sizeof( *new ) );
+  if( !new ) {
     return 0;
   }
   new->id = next_id++;
@@ -37,10 +39,11 @@ stumpless_id_t add_to_id_map(struct id_map *map, void *value){
   new->value = value;
 
   curr = map->root;
-  if(!curr){
+  if( !curr ) {
     map->root = new;
-  } else {
-    while(curr->next){
+  }
+  else {
+    while ( curr->next ) {
       curr = curr->next;
     }
     curr->next = new;
@@ -49,32 +52,34 @@ stumpless_id_t add_to_id_map(struct id_map *map, void *value){
   return new->id;
 }
 
-void destroy_id_map(struct id_map *map){
-  struct id_map_node *next, *remove=NULL;
+void
+destroy_id_map( struct id_map *map ) {
+  struct id_map_node *next, *remove = NULL;
 
-  if(!map){
+  if( !map ) {
     return;
   }
 
   next = map->root;
-  while(next != NULL){
+  while ( next != NULL ) {
     remove = next;
     next = next->next;
-    free_mem(remove);
+    free_mem( remove );
   }
 
-  free_mem(map);
+  free_mem( map );
 }
 
-void *get_by_id(struct id_map *map, stumpless_id_t id){
+void *
+get_by_id( struct id_map *map, stumpless_id_t id ) {
   struct id_map_node *curr;
 
-  if(!map){
+  if( !map ) {
     return NULL;
   }
 
-  for(curr=map->root; curr != NULL; curr=curr->next){
-    if(curr->id == id){
+  for( curr = map->root; curr != NULL; curr = curr->next ) {
+    if( curr->id == id ) {
       return curr->value;
     }
   }
@@ -82,11 +87,12 @@ void *get_by_id(struct id_map *map, stumpless_id_t id){
   return NULL;
 }
 
-struct id_map *new_id_map(){
+struct id_map *
+new_id_map(  ) {
   struct id_map *map;
 
-  map = alloc_mem(sizeof(struct id_map));
-  if(!map){
+  map = alloc_mem( sizeof( *map ) );
+  if( !map ) {
     return NULL;
   }
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -19,18 +20,20 @@
 #include "private/error.h"
 #include "private/memory.h"
 
-void *alloc_mem(size_t amount){
-  void *mem = malloc(amount);
-  if( !mem ){
-    raise_memory_allocation_failure();
+void *
+alloc_mem( size_t amount ) {
+  void *mem = malloc( amount );
+  if( !mem ) {
+    raise_memory_allocation_failure(  );
     return NULL;
   }
-  
+
   return mem;
 }
 
-void free_mem(void *mem){
-  if(mem){
-    free(mem);
+void
+free_mem( void *mem ) {
+  if( mem ) {
+    free( mem );
   }
 }

--- a/src/strbuilder.c
+++ b/src/strbuilder.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -20,92 +21,98 @@
 #include <string.h>
 #include "private/strbuilder.h"
 
-static size_t increase_size(struct strbuilder *builder){
+static size_t
+increase_size( struct strbuilder *builder ) {
   char *old_buffer, *new_buffer;
   size_t old_size, new_size;
 
   old_buffer = builder->buffer;
   old_size = builder->buffer_end - old_buffer;
-  new_size = old_size*2;
-  new_buffer = realloc(old_buffer, new_size);
-  if(!new_buffer){
+  new_size = old_size * 2;
+  new_buffer = realloc( old_buffer, new_size );
+  if( !new_buffer ) {
     return 0;
   }
 
-  builder->position = new_buffer + (builder->position-old_buffer);
+  builder->position = new_buffer + ( builder->position - old_buffer );
   builder->buffer = new_buffer;
   builder->buffer_end = new_buffer + new_size;
 
   return old_size;
 }
 
-struct strbuilder *strbuilder_append_buffer(struct strbuilder *builder, const char *buffer, size_t size){
+struct strbuilder *
+strbuilder_append_buffer( struct strbuilder *builder, const char *buffer,
+                          size_t size ) {
   size_t size_added, size_left;
 
-  if(!builder || !buffer){
+  if( !builder || !buffer ) {
     return NULL;
   }
 
   size_left = builder->buffer_end - builder->position;
-  while(size_left < size){
-    size_added = increase_size(builder);
-    if(size_added == 0){
+  while ( size_left < size ) {
+    size_added = increase_size( builder );
+    if( size_added == 0 ) {
       return NULL;
     } else {
       size_left += size_added;
     }
   }
 
-  memcpy(builder->position, buffer, size);
+  memcpy( builder->position, buffer, size );
   builder->position += size;
 
   return builder;
 }
 
-struct strbuilder *strbuilder_append_char(struct strbuilder *builder, char c){
-  if(!builder){
+struct strbuilder *
+strbuilder_append_char( struct strbuilder *builder, char c ) {
+  if( !builder ) {
     return NULL;
   }
 
-  if(builder->position == builder->buffer_end){
-    if(increase_size(builder) == 0){
+  if( builder->position == builder->buffer_end ) {
+    if( increase_size( builder ) == 0 ) {
       return NULL;
     }
   }
 
-  *(builder->position) = c;
-  (builder->position)++;
+  *( builder->position ) = c;
+  ( builder->position )++;
 
   return builder;
 }
 
-struct strbuilder *strbuilder_append_int(struct strbuilder *builder, int i){
-  char buffer[100]; //todo need to make more precise
+struct strbuilder *
+strbuilder_append_int( struct strbuilder *builder, int i ) {
+  char buffer[100];             // todo need to make more precise
 
-  if(!builder){
+  if( !builder ) {
     return NULL;
   }
 
-  snprintf(buffer, 100, "%d", i);
-  return strbuilder_append_string(builder, buffer);
+  snprintf( buffer, 100, "%d", i );
+  return strbuilder_append_string( builder, buffer );
 }
 
-struct strbuilder *strbuilder_append_string(struct strbuilder *builder, const char *str){
+struct strbuilder *
+strbuilder_append_string( struct strbuilder *builder, const char *str ) {
   const char *curr;
 
-  if(!builder){
+  if( !builder ) {
     return NULL;
   }
 
   curr = str;
-  while(*curr != '\0'){
-    if(builder->position == builder->buffer_end){
-      if(increase_size(builder) == 0){
+  while ( *curr != '\0' ) {
+    if( builder->position == builder->buffer_end ) {
+      if( increase_size( builder ) == 0 ) {
         return NULL;
       }
     }
-      
-    *(builder->position) = *curr;
+
+    *( builder->position ) = *curr;
     builder->position++;
 
     curr++;
@@ -114,40 +121,44 @@ struct strbuilder *strbuilder_append_string(struct strbuilder *builder, const ch
   return builder;
 }
 
-void strbuilder_destroy(struct strbuilder *builder){
-  free(builder);
+void
+strbuilder_destroy( struct strbuilder *builder ) {
+  free( builder );
 }
 
-char *strbuilder_to_string(struct strbuilder *builder){
-  if(strbuilder_append_char(builder, '\0') == NULL){
+char *
+strbuilder_to_string( struct strbuilder *builder ) {
+  if( strbuilder_append_char( builder, '\0' ) == NULL ) {
     return NULL;
   } else {
     return builder->buffer;
   }
 }
 
-struct strbuilder *strbuilder_new(){
-  return strbuilder_new_sized(STRBUILDER_DEFAULT_BUFFER_SIZE);
+struct strbuilder *
+strbuilder_new(  ) {
+  return strbuilder_new_sized( STRBUILDER_DEFAULT_BUFFER_SIZE );
 }
 
-struct strbuilder *strbuilder_new_sized(size_t size){
+struct strbuilder *
+strbuilder_new_sized( size_t size ) {
   struct strbuilder *builder;
   char *buffer;
- 
-  builder = malloc(sizeof(struct strbuilder));
-  if(!builder){
+
+  builder = malloc( sizeof( struct strbuilder ) );
+  if( !builder ) {
     return NULL;
   }
 
-  buffer = malloc(size);
-  if(!buffer){
-    free(builder);
+  buffer = malloc( size );
+  if( !buffer ) {
+    free( builder );
     return NULL;
   }
 
   builder->buffer = buffer;
   builder->position = buffer;
-  builder->buffer_end = buffer+size;
+  builder->buffer_end = buffer + size;
 
   return builder;
 }

--- a/src/target.c
+++ b/src/target.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -26,70 +27,77 @@
 #include "private/target.h"
 #include "private/target/buffer.h"
 
-static struct stumpless_target *current_target=NULL;
+static struct stumpless_target *current_target = NULL;
 
-int stumpless(const char *message){
+int
+stumpless( const char *message ) {
   struct stumpless_entry *entry;
   struct stumpless_target *current_target;
   int result;
 
-  clear_error();
+  clear_error(  );
 
-  current_target = stumpless_get_current_target();
-  if(!current_target){
-    //current_target = stumpless_open_socket_target(STUMPLESS_SOCKET_NAME, 0, 0);
-	return -1;
-  }
-
-  entry = stumpless_new_entry("APP-NAME", "MSGID", message);
-  if(!entry){
+  current_target = stumpless_get_current_target(  );
+  if( !current_target ) {
+    // current_target = stumpless_open_socket_target(STUMPLESS_SOCKET_NAME, 0,
+    // 0);
     return -1;
   }
 
-  result = stumpless_add_entry(current_target, entry);
-  stumpless_destroy_entry(entry);
+  entry = stumpless_new_entry( "APP-NAME", "MSGID", message );
+  if( !entry ) {
+    return -1;
+  }
+
+  result = stumpless_add_entry( current_target, entry );
+  stumpless_destroy_entry( entry );
   return result;
 }
 
-int stumpless_add_entry(struct stumpless_target *target, struct stumpless_entry *entry){
+int
+stumpless_add_entry( struct stumpless_target *target,
+                     struct stumpless_entry *entry ) {
   char *message;
 
-  clear_error();
- 
-  if( !target ){
+  clear_error(  );
+
+  if( !target ) {
     return -1;
   }
 
-  message = format_entry(target, entry);
+  message = format_entry( target, entry );
 
-  switch(target->type){
+  switch ( target->type ) {
     case STUMPLESS_SOCKET_TARGET:
-      return config_sendto_socket_target(target, message);
+      return config_sendto_socket_target( target, message );
     case STUMPLESS_BUFFER_TARGET:
-      if( sendto_buffer_target(target, message) <= 0 ){
+      if( sendto_buffer_target( target, message ) <= 0 ) {
         return -1;
       }
       break;
     default:
-	  return target_unsupported(target, message);
+      return target_unsupported( target, message );
   }
 
   return 0;
 }
 
-struct stumpless_target *stumpless_get_current_target(){
-  clear_error();
+struct stumpless_target *
+stumpless_get_current_target( void ) {
+  clear_error(  );
 
   return current_target;
 }
 
-void stumpless_set_current_target(struct stumpless_target *target){
+void
+stumpless_set_current_target( struct stumpless_target *target ) {
   current_target = target;
 }
 
 /* private definitions */
 
-int target_unsupported(const struct stumpless_target *target, const char *msg) {
-  raise_target_unsupported();
+int
+target_unsupported( const struct stumpless_target *target, const char *msg ) {
+  raise_target_unsupported(  );
   return -1;
 }

--- a/src/target/socket.c
+++ b/src/target/socket.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -26,65 +27,64 @@
 #include "private/memory.h"
 #include "private/target/socket.h"
 
-static struct id_map *targets=NULL;
+static struct id_map *targets = NULL;
 
 void
-stumpless_close_socket_target(struct stumpless_target *target){
-  clear_error();
-  
-  if(target && targets){
-    destroy_socket_target(get_by_id(targets, target->id));
+stumpless_close_socket_target( struct stumpless_target *target ) {
+  clear_error(  );
+
+  if( target && targets ) {
+    destroy_socket_target( get_by_id( targets, target->id ) );
   }
-  
   // todo need to clean up the id list
 }
 
 struct stumpless_target *
-stumpless_open_socket_target(const char *name, int options, int facility){
+stumpless_open_socket_target( const char *name, int options, int facility ) {
   struct stumpless_target *pub_target;
   struct socket_target *priv_target;
   size_t name_len;
 
-  clear_error();
-  
-  if(!targets){
-    targets = new_id_map();
-    if(!targets){
+  clear_error(  );
+
+  if( !targets ) {
+    targets = new_id_map(  );
+    if( !targets ) {
       goto fail;
     }
   }
 
-  pub_target = alloc_mem(sizeof(struct stumpless_target));
-  if( !pub_target ){
+  pub_target = alloc_mem( sizeof( *pub_target ) );
+  if( !pub_target ) {
     goto fail;
   }
-  
-  name_len = strlen(name) ;
-  priv_target = new_socket_target(name, name_len);
-  if( !priv_target ){
+
+  name_len = strlen( name );
+  priv_target = new_socket_target( name, name_len );
+  if( !priv_target ) {
     goto fail_priv_target;
   }
 
-  pub_target->name = alloc_mem(name_len);
-  if( !pub_target->name ){
+  pub_target->name = alloc_mem( name_len );
+  if( !pub_target->name ) {
     goto fail_pub_name;
   }
 
-  memcpy(pub_target->name, name, name_len);
+  memcpy( pub_target->name, name, name_len );
   pub_target->name[name_len] = '\0';
   pub_target->type = STUMPLESS_SOCKET_TARGET;
   pub_target->options = options;
   pub_target->facility = facility;
-  pub_target->severity = 6; // todo change this from a hardcoded value
-  pub_target->id = add_to_id_map(targets, priv_target);
+  pub_target->severity = 6;     // todo change this from a hardcoded value
+  pub_target->id = add_to_id_map( targets, priv_target );
 
-  stumpless_set_current_target(pub_target);
+  stumpless_set_current_target( pub_target );
   return pub_target;
 
 fail_pub_name:
-  free_mem(priv_target);
+  free_mem( priv_target );
 fail_priv_target:
-  free_mem(pub_target);
+  free_mem( pub_target );
 fail:
   return NULL;
 }
@@ -92,55 +92,62 @@ fail:
 
 /* private definitions */
 
-void destroy_socket_target(struct socket_target *trgt){
-  if( !trgt ){
+void
+destroy_socket_target( struct socket_target *trgt ) {
+  if( !trgt ) {
     return;
   }
-  
-  close(trgt->local_socket);
-  free_mem(trgt);
+
+  close( trgt->local_socket );
+  free_mem( trgt );
 }
 
-struct socket_target *new_socket_target(const char *dest, size_t dest_len){
+struct socket_target *
+new_socket_target( const char *dest, size_t dest_len ) {
   struct socket_target *trgt;
-  
-  trgt = alloc_mem(sizeof(struct socket_target));
-  if( !trgt ){
+
+  trgt = alloc_mem( sizeof( *trgt ) );
+  if( !trgt ) {
     return NULL;
   }
-  
+
   trgt->target_addr.sun_family = AF_UNIX;
   // todo need to check dest_len before this memcpy happens
-  memcpy(&trgt->target_addr.sun_path, dest, dest_len);
+  memcpy( &trgt->target_addr.sun_path, dest, dest_len );
   trgt->target_addr.sun_path[dest_len] = '\0';
-  
+
   trgt->local_addr.sun_family = AF_UNIX;
-  memcpy(&trgt->local_addr.sun_path, "\0/stmplss-tst", 14);
-  
-  trgt->local_socket = socket(trgt->local_addr.sun_family, SOCK_DGRAM, 0);
-  if(trgt->local_socket < 0){
-    free_mem(trgt);
+  memcpy( &trgt->local_addr.sun_path, "\0/stmplss-tst", 14 );
+
+  trgt->local_socket = socket( trgt->local_addr.sun_family, SOCK_DGRAM, 0 );
+  if( trgt->local_socket < 0 ) {
+    free_mem( trgt );
     return NULL;
   }
-  
-  if( bind(trgt->local_socket, (struct sockaddr *) &trgt->local_addr, sizeof(trgt->local_addr)) < 0 ){
-    free_mem(trgt);
+
+  if( bind
+      ( trgt->local_socket, ( struct sockaddr * ) &trgt->local_addr,
+        sizeof( trgt->local_addr ) ) < 0 ) {
+    free_mem( trgt );
     return NULL;
   }
-  
-  trgt->target_addr_len = sizeof(trgt->target_addr);
-  
+
+  trgt->target_addr_len = sizeof( trgt->target_addr );
+
   return trgt;
 }
 
-int sendto_socket_target(const struct stumpless_target *target, const char *msg){
+int
+sendto_socket_target( const struct stumpless_target *target, const char *msg ) {
   struct socket_target *priv_trgt;
 
-  if(!target || !targets || !msg){
+  if( !target || !targets || !msg ) {
     return 0;
   }
-  
-  priv_trgt = get_by_id(targets, target->id);
 
-  return sendto(priv_trgt->local_socket, msg, strlen(msg)+1, 0, (struct sockaddr *) &priv_trgt->target_addr, priv_trgt->target_addr_len);
+  priv_trgt = get_by_id( targets, target->id );
+
+  return sendto( priv_trgt->local_socket, msg, strlen( msg ) + 1, 0,
+                 ( struct sockaddr * ) &priv_trgt->target_addr,
+                 priv_trgt->target_addr_len );
 }

--- a/src/version.c
+++ b/src/version.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2018 Joel E. Anderson
  * 
@@ -20,13 +21,13 @@
 #include "private/memory.h"
 
 struct stumpless_version *
-get_stumpless_version(){
+get_stumpless_version( void ) {
   struct stumpless_version *version;
 
-  clear_error();
+  clear_error(  );
 
-  version = alloc_mem(sizeof(struct stumpless_version));
-  if(!version){
+  version = alloc_mem( sizeof( struct stumpless_version ) );
+  if( !version ) {
     return NULL;
   }
 


### PR DESCRIPTION
Header and source files should be formatted according to an established
standard. This is enforced by a wrapper script to the GNU indent tool which
provides all of the necessary options to format a given file.
