### PR TITLE
move rfc tests into object library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,10 +124,13 @@ target_include_directories(stumpless
 # standard functionality tests
 enable_testing()
 
+add_library(rfc5424_checker
+  OBJECT ${PROJECT_SOURCE_DIR}/test/function/rfc5424.cpp ${PROJECT_SOURCE_DIR}/test/function/utf8.cpp
+)
+
 add_function_test(buffer
   test/function/target/buffer.cpp
-  test/function/rfc5424.cpp
-  test/function/utf8.cpp
+  $<TARGET_OBJECTS:objlib>
 )
 
 add_function_test(entry
@@ -140,8 +143,7 @@ add_function_test(entry_memory_failure
 
 add_function_test(file
   test/function/target/file.cpp
-  test/function/rfc5424.cpp
-  test/function/utf8.cpp
+  $<TARGET_OBJECTS:objlib>
 )
 
 add_function_test(memory
@@ -167,8 +169,7 @@ add_performance_test(target
 if(STUMPLESS_SOCKET_TARGETS_SUPPORTED)
   add_function_test(socket
     test/function/target/socket.cpp
-    test/function/rfc5424.cpp
-    test/function/utf8.cpp
+    $<TARGET_OBJECTS:objlib>
   )
 
   add_function_test(socket_add_malloc_failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,9 +128,17 @@ add_library(rfc5424_checker
   OBJECT ${PROJECT_SOURCE_DIR}/test/function/rfc5424.cpp ${PROJECT_SOURCE_DIR}/test/function/utf8.cpp
 )
 
+add_dependencies(rfc5424_checker libgtest)
+
+target_include_directories(rfc5424_checker
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${CMAKE_BINARY_DIR}/include
+)
+
 add_function_test(buffer
   test/function/target/buffer.cpp
-  $<TARGET_OBJECTS:objlib>
+  $<TARGET_OBJECTS:rfc5424_checker>
 )
 
 add_function_test(entry
@@ -143,7 +151,7 @@ add_function_test(entry_memory_failure
 
 add_function_test(file
   test/function/target/file.cpp
-  $<TARGET_OBJECTS:objlib>
+  $<TARGET_OBJECTS:rfc5424_checker>
 )
 
 add_function_test(memory
@@ -169,7 +177,7 @@ add_performance_test(target
 if(STUMPLESS_SOCKET_TARGETS_SUPPORTED)
   add_function_test(socket
     test/function/target/socket.cpp
-    $<TARGET_OBJECTS:objlib>
+    $<TARGET_OBJECTS:rfc5424_checker>
   )
 
   add_function_test(socket_add_malloc_failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,18 +124,6 @@ target_include_directories(stumpless
 # standard functionality tests
 enable_testing()
 
-add_library(rfc5424_checker
-  OBJECT ${PROJECT_SOURCE_DIR}/test/function/rfc5424.cpp ${PROJECT_SOURCE_DIR}/test/function/utf8.cpp
-)
-
-add_dependencies(rfc5424_checker libgtest)
-
-target_include_directories(rfc5424_checker
-    PRIVATE
-    ${PROJECT_SOURCE_DIR}/include
-    ${CMAKE_BINARY_DIR}/include
-)
-
 add_function_test(buffer
   test/function/target/buffer.cpp
   $<TARGET_OBJECTS:rfc5424_checker>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Thread-safe operation.
  - Examples for file and socket targets.
 
-## [1.2.0] - 2018-11-3
+## [1.2.0] - 2018-11-8
 ### Added
  - Increased coverage on object cache.
  - Support for fractional timestamps.
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Use of unsafe fopen when fopen_s is available.
  - Use of unsafe gmtime function when gmtime_r is available.
  - Safely convert from size_t to int types.
+ - Inclusion of RFC 5424 test sources in multiple executables, using an object
+   library instead.
 
 ## [1.1.2] - 2018-10-04
 ### Fixed

--- a/tools/cmake/test.cmake
+++ b/tools/cmake/test.cmake
@@ -1,3 +1,9 @@
+if(MSVC)
+  set(function_test_compile_flags "")
+else()
+  set(function_test_compile_flags "-std=c++11")
+endif(MSVC)
+
 macro(add_function_test name)
   list(APPEND STUMPLESS_FUNCTION_TESTS function-test-${name})
 
@@ -5,12 +11,6 @@ macro(add_function_test name)
     EXCLUDE_FROM_ALL
     ${ARGN}
   )
-
-  if(MSVC)
-    set(function_test_compile_flags "")
-  else()
-    set(function_test_compile_flags "-std=c++11")
-  endif(MSVC)
 
   set_target_properties(function-test-${name}
     PROPERTIES
@@ -75,6 +75,11 @@ endmacro(add_performance_test)
 # RFC 5424 checking tools
 add_library(rfc5424_checker
   OBJECT ${PROJECT_SOURCE_DIR}/test/function/rfc5424.cpp ${PROJECT_SOURCE_DIR}/test/function/utf8.cpp
+)
+
+set_target_properties(rfc5424_checker
+  PROPERTIES
+  COMPILE_FLAGS "${function_test_compile_flags}"
 )
 
 add_dependencies(rfc5424_checker libgtest)

--- a/tools/cmake/test.cmake
+++ b/tools/cmake/test.cmake
@@ -71,3 +71,16 @@ macro(add_performance_test name)
     DEPENDS performance-test-${name}
   )
 endmacro(add_performance_test)
+
+# RFC 5424 checking tools
+add_library(rfc5424_checker
+  OBJECT ${PROJECT_SOURCE_DIR}/test/function/rfc5424.cpp ${PROJECT_SOURCE_DIR}/test/function/utf8.cpp
+)
+
+add_dependencies(rfc5424_checker libgtest)
+
+target_include_directories(rfc5424_checker
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${CMAKE_BINARY_DIR}/include
+)


### PR DESCRIPTION
Factor the RFC 5424 test suite into a separate object library instead of including the sources in each test requiring them.