### PR TITLE
add details to errors

### DIFF
--- a/include/private/error.h
+++ b/include/private/error.h
@@ -28,7 +28,7 @@ void
 raise_argument_empty( const char *message );
 
 void
-raise_argument_too_big( void );
+raise_argument_too_big( const char *message, int code, const char *code_type );
 
 void
 raise_error( enum stumpless_error_id id,

--- a/include/private/error.h
+++ b/include/private/error.h
@@ -25,13 +25,16 @@ void
 clear_error( void );
 
 void
-raise_argument_empty( void );
+raise_argument_empty( const char *message );
 
 void
 raise_argument_too_big( void );
 
 void
-raise_error( enum stumpless_error_id id );
+raise_error( enum stumpless_error_id id,
+             const char *message,
+             int code,
+             const char *code_type );
 
 void
 raise_file_open_failure( void );

--- a/include/stumpless/error.h
+++ b/include/stumpless/error.h
@@ -23,25 +23,46 @@
 extern "C" {
 #  endif
 
-  enum stumpless_error_id {
-    STUMPLESS_ARGUMENT_EMPTY,
-    STUMPLESS_ARGUMENT_TOO_BIG,
-    STUMPLESS_FILE_OPEN_FAILURE,
-    STUMPLESS_FILE_WRITE_FAILURE,
-    STUMPLESS_INVALID_ID,
-    STUMPLESS_MEMORY_ALLOCATION_FAILURE,
-    STUMPLESS_SOCKET_BIND_FAILURE,
-    STUMPLESS_STREAM_WRITE_FAILURE,
-    STUMPLESS_TARGET_UNSUPPORTED,
-    STUMPLESS_WINDOWS_EVENT_LOG_CLOSE_FAILURE,
-    STUMPLESS_WINDOWS_EVENT_LOG_OPEN_FAILURE
-  };
+/**
+ * An identifier of the types of errors that might be encountered. Note that
+ * the same error may be encountered in different contexts.
+ */
+enum stumpless_error_id {
+  STUMPLESS_ARGUMENT_EMPTY,
+  STUMPLESS_ARGUMENT_TOO_BIG,
+  STUMPLESS_FILE_OPEN_FAILURE,
+  STUMPLESS_FILE_WRITE_FAILURE,
+  STUMPLESS_INVALID_ID,
+  STUMPLESS_MEMORY_ALLOCATION_FAILURE,
+  STUMPLESS_SOCKET_BIND_FAILURE,
+  STUMPLESS_STREAM_WRITE_FAILURE,
+  STUMPLESS_TARGET_UNSUPPORTED,
+  STUMPLESS_WINDOWS_EVENT_LOG_CLOSE_FAILURE,
+  STUMPLESS_WINDOWS_EVENT_LOG_OPEN_FAILURE
+};
 
-  struct stumpless_error {
-    enum stumpless_error_id id;
-  };
+/**
+ * Information describing an error encountered by the library.
+ */
+struct stumpless_error {
+  enum stumpless_error_id id; /**< error family */
+  const char *message; /**< specific details of the failure */
+  int code; /**< an error code possibly providing more information */
+  const char *code_type; /**< a description of the error code */
+};
 
-  struct stumpless_error *stumpless_get_error( void );
+/**
+ * Retrieves the error encountered by the last library call.
+ *
+ * Note that the id is the only field of the error that is guaranteed to be set.
+ * Other members may or may not be set, depending on the context of the error.
+ *
+ * If the code_type is NULL, then the code is not valid and should be ignored.
+ *
+ * @return A stumpless_error struct describing the error encountered by the last
+ * function call. If no error was encountered, this will be NULL.
+ */
+struct stumpless_error *stumpless_get_error( void );
 
 #  ifdef __cplusplus
 }                               /* extern "C" */

--- a/src/config/wel_supported.c
+++ b/src/config/wel_supported.c
@@ -30,7 +30,7 @@ stumpless_set_wel_category( struct stumpless_entry *entry, WORD category ) {
   clear_error(  );
 
   if( !entry ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "entry is NULL" );
     return NULL;
   }
 
@@ -44,7 +44,7 @@ stumpless_set_wel_event_id( struct stumpless_entry *entry, DWORD event_id ) {
   clear_error(  );
 
   if( !entry ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "entry is NULL" );
     return NULL;
   }
 
@@ -59,8 +59,13 @@ stumpless_set_wel_insertion_param( struct stumpless_entry *entry,
                                    struct stumpless_param *param ) {
   clear_error(  );
 
-  if( !entry || !param ) {
-    raise_argument_empty(  );
+  if( !entry ) {
+    raise_argument_empty( "entry is NULL" );
+    return NULL;
+  }
+
+  if( !param ) {
+    raise_argument_empty( "param is NULL" );
     return NULL;
   }
 
@@ -85,8 +90,13 @@ stumpless_set_wel_insertion_string( struct stumpless_entry *entry,
 
   clear_error(  );
 
-  if( !entry || !str ) {
-    raise_argument_empty(  );
+  if( !entry ) {
+    raise_argument_empty( "entry is NULL" );
+    goto fail;
+  }
+
+  if( !str ) {
+    raise_argument_empty( "str is NULL" );
     goto fail;
   }
 
@@ -131,7 +141,7 @@ stumpless_set_wel_type( struct stumpless_entry *entry, WORD type ) {
   clear_error(  );
 
   if( !entry ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "entry is NULL" );
     return NULL;
   }
 

--- a/src/entry.c
+++ b/src/entry.c
@@ -40,8 +40,13 @@ stumpless_add_element( struct stumpless_entry *entry,
 
   clear_error(  );
 
-  if( !entry || !element ) {
-    raise_argument_empty(  );
+  if( !entry ) {
+    raise_argument_empty( "entry is NULL" );
+    return NULL;
+  }
+
+  if( !element ) {
+    raise_argument_empty( "element is NULL" );
     return NULL;
   }
   // todo need to check for duplicates first
@@ -72,8 +77,13 @@ stumpless_add_param( struct stumpless_element *element,
 
   clear_error(  );
 
-  if( !element || !param ) {
-    raise_argument_empty(  );
+  if( !element ) {
+    raise_argument_empty( "element is NULL" );
+    return NULL;
+  }
+
+  if( !param ) {
+    raise_argument_empty( "param is NULL" );
     return NULL;
   }
 
@@ -99,7 +109,7 @@ stumpless_new_element( const char *name ) {
   clear_error(  );
 
   if( !name ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "name is NULL" );
     goto fail;
   }
 
@@ -193,8 +203,13 @@ stumpless_new_param( const char *name, const char *value ) {
 
   clear_error(  );
 
-  if( !name || !value ) {
-    raise_argument_empty(  );
+  if( !name ) {
+    raise_argument_empty( "name is NULL" );
+    goto fail;
+  }
+
+  if( !value ) {
+    raise_argument_empty( "value is NULL" );
     goto fail;
   }
 
@@ -287,7 +302,7 @@ stumpless_set_entry_app_name( struct stumpless_entry *entry,
   clear_error(  );
 
   if( !entry ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "entry is NULL" );
     return NULL;
   }
 
@@ -309,7 +324,7 @@ stumpless_set_entry_message( struct stumpless_entry *entry,
   clear_error(  );
 
   if( !entry ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "entry is NULL" );
     return NULL;
   }
 

--- a/src/error.c
+++ b/src/error.c
@@ -40,17 +40,20 @@ clear_error( void ) {
 }
 
 void
-raise_argument_empty( void ) {
-  raise_error( STUMPLESS_ARGUMENT_EMPTY );
+raise_argument_empty( const char *message ) {
+  raise_error( STUMPLESS_ARGUMENT_EMPTY, message, 0, NULL );
 }
 
 void
 raise_argument_too_big( void ) {
-  raise_error( STUMPLESS_ARGUMENT_TOO_BIG );
+  raise_error( STUMPLESS_ARGUMENT_TOO_BIG, NULL, 0, NULL );
 }
 
 void
-raise_error( enum stumpless_error_id id ) {
+raise_error( enum stumpless_error_id id,
+             const char *message,
+             int code,
+             const char *code_type ) {
   if( !last_error ) {
     last_error = malloc( sizeof( struct stumpless_error ) );
     if( !last_error ) {
@@ -60,50 +63,53 @@ raise_error( enum stumpless_error_id id ) {
   }
 
   last_error->id = id;
+  last_error->message = message;
+  last_error->code = code;
+  last_error->code_type = code_type;
   error_valid = 1;
 }
 
 void
 raise_file_open_failure( void ) {
-  raise_error( STUMPLESS_FILE_OPEN_FAILURE );
+  raise_error( STUMPLESS_FILE_OPEN_FAILURE, NULL, 0, NULL );
 }
 
 void
 raise_file_write_failure( void ) {
-  raise_error( STUMPLESS_FILE_WRITE_FAILURE );
+  raise_error( STUMPLESS_FILE_WRITE_FAILURE, NULL, 0, NULL );
 }
 
 void
 raise_invalid_id( void ) {
-  raise_error( STUMPLESS_INVALID_ID );
+  raise_error( STUMPLESS_INVALID_ID, NULL, 0, NULL );
 }
 
 void
 raise_memory_allocation_failure( void ) {
-  raise_error( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
+  raise_error( STUMPLESS_MEMORY_ALLOCATION_FAILURE, NULL, 0, NULL );
 }
 
 void
 raise_socket_bind_failure( void ) {
-  raise_error( STUMPLESS_SOCKET_BIND_FAILURE );
+  raise_error( STUMPLESS_SOCKET_BIND_FAILURE, NULL, 0, NULL );
 }
 
 void
 raise_stream_write_failure( void ) {
-  raise_error( STUMPLESS_STREAM_WRITE_FAILURE );
+  raise_error( STUMPLESS_STREAM_WRITE_FAILURE, NULL, 0, NULL );
 }
 
 void
 raise_target_unsupported( void ) {
-  raise_error( STUMPLESS_TARGET_UNSUPPORTED );
+  raise_error( STUMPLESS_TARGET_UNSUPPORTED, NULL, 0, NULL );
 }
 
 void
 raise_wel_close_failure( void ) {
-  raise_error( STUMPLESS_WINDOWS_EVENT_LOG_CLOSE_FAILURE );
+  raise_error( STUMPLESS_WINDOWS_EVENT_LOG_CLOSE_FAILURE, NULL, 0, NULL );
 }
 
 void
 raise_wel_open_failure( void ) {
-  raise_error( STUMPLESS_WINDOWS_EVENT_LOG_OPEN_FAILURE );
+  raise_error( STUMPLESS_WINDOWS_EVENT_LOG_OPEN_FAILURE, NULL, 0, NULL );
 }

--- a/src/error.c
+++ b/src/error.c
@@ -45,8 +45,8 @@ raise_argument_empty( const char *message ) {
 }
 
 void
-raise_argument_too_big( void ) {
-  raise_error( STUMPLESS_ARGUMENT_TOO_BIG, NULL, 0, NULL );
+raise_argument_too_big( const char *message, int code, const char *code_type ) {
+  raise_error( STUMPLESS_ARGUMENT_TOO_BIG, message, code, code_type );
 }
 
 void

--- a/src/memory.c
+++ b/src/memory.c
@@ -36,7 +36,7 @@ stumpless_set_malloc( malloc_func_t malloc_func ) {
   clear_error(  );
 
   if( !malloc_func ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "malloc_func is NULL" );
     return NULL;
   } else {
     stumpless_malloc = malloc_func;
@@ -49,7 +49,7 @@ stumpless_set_free( free_func_t free_func ) {
   clear_error(  );
 
   if( !free_func ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "free_func is NULL" );
     return NULL;
   } else {
     stumpless_free = free_func;
@@ -62,7 +62,7 @@ stumpless_set_realloc( realloc_func_t realloc_func ) {
   clear_error(  );
 
   if( !realloc_func ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "realloc_func is NULL" );
     return NULL;
   } else {
     stumpless_realloc = realloc_func;

--- a/src/target.c
+++ b/src/target.c
@@ -97,8 +97,13 @@ stumpless_add_entry( struct stumpless_target *target,
 
   clear_error(  );
 
-  if( !target || !entry ) {
-    raise_argument_empty(  );
+  if( !target ) {
+    raise_argument_empty( "target is NULL" );
+    return -1;
+  }
+
+  if( !entry ) {
+    raise_argument_empty( "entry is NULL" );
     return -1;
   }
 

--- a/src/target/buffer.c
+++ b/src/target/buffer.c
@@ -116,7 +116,9 @@ sendto_buffer_target( struct buffer_target *target,
   size_t buffer_remaining;
 
   if( msg_length >= target->size ) {
-    raise_argument_too_big(  );
+    raise_argument_too_big( "buffer is too small for the given message",
+                            cap_size_t_to_int( msg_length ),
+                            "size of the message that is too large" );
     return -1;
   }
 

--- a/src/target/buffer.c
+++ b/src/target/buffer.c
@@ -31,7 +31,7 @@ stumpless_close_buffer_target( struct stumpless_target *target ) {
   clear_error(  );
 
   if( !target ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "target is NULL" );
     return;
   }
 
@@ -49,8 +49,13 @@ stumpless_open_buffer_target( const char *name,
 
   clear_error(  );
 
-  if( !name || !buffer ) {
-    raise_argument_empty(  );
+  if( !name ) {
+    raise_argument_empty( "name is NULL" );
+    return NULL;
+  }
+
+  if( !buffer ) {
+    raise_argument_empty( "buffer is NULL" );
     return NULL;
   }
 

--- a/src/target/file.c
+++ b/src/target/file.c
@@ -33,7 +33,7 @@ stumpless_close_file_target( struct stumpless_target *target ) {
   clear_error(  );
 
   if( !target ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "target is NULL" );
     return;
   }
 
@@ -49,7 +49,7 @@ stumpless_open_file_target( const char *name,
   clear_error(  );
 
   if( !name ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "name is NULL" );
     return NULL;
   }
 

--- a/src/target/socket.c
+++ b/src/target/socket.c
@@ -34,7 +34,7 @@ stumpless_close_socket_target( struct stumpless_target *target ) {
   clear_error(  );
 
   if( !target ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "target is NULL" );
     return;
   }
 
@@ -54,7 +54,7 @@ stumpless_open_socket_target( const char *name,
   clear_error(  );
 
   if( !name ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "name is NULL" );
     goto fail;
   }
 

--- a/src/target/stream.c
+++ b/src/target/stream.c
@@ -32,7 +32,7 @@ stumpless_close_stream_target( struct stumpless_target *target ) {
   clear_error(  );
 
   if( !target ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "target is NULL" );
     return;
   }
 
@@ -70,8 +70,13 @@ stumpless_open_stream_target( const char *name,
 
   clear_error(  );
 
-  if( !name || !stream ) {
-    raise_argument_empty(  );
+  if( !name ) {
+    raise_argument_empty( "name is NULL" );
+    return NULL;
+  }
+
+  if( !stream ) {
+    raise_argument_empty( "stream is NULL" );
     return NULL;
   }
 

--- a/src/target/wel.c
+++ b/src/target/wel.c
@@ -32,7 +32,7 @@ stumpless_close_wel_target( struct stumpless_target *target ) {
   clear_error(  );
 
   if( !target ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "target is NULL" );
     return;
   }
 
@@ -48,7 +48,7 @@ stumpless_open_local_wel_target( const char *name,
   clear_error(  );
 
   if( !name ) {
-    raise_argument_empty(  );
+    raise_argument_empty( "name is NULL" );
     goto fail;
   }
 
@@ -87,7 +87,7 @@ stumpless_open_remote_wel_target( const char *server,
    clear_error(  );
 
    if( !name ) {
-     raise_argument_empty(  );
+     raise_argument_empty( "name is NULL" );
      goto fail;
    }
 

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -16,11 +16,14 @@
  * limitations under the License.
  */
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stumpless.h>
+
+using::testing::HasSubstr;
 
 namespace {
 
@@ -252,6 +255,28 @@ namespace {
     EXPECT_EQ( error->id, STUMPLESS_ARGUMENT_EMPTY );
 
     stumpless_destroy_element( element );
+  }
+
+  TEST( AddParamTest, NullElement ) {
+    struct stumpless_param *param;
+    struct stumpless_element *element;
+    struct stumpless_error *error;
+
+    param = stumpless_new_param( "test-name", "test-value" );
+    ASSERT_TRUE( param != NULL );
+
+    element = stumpless_add_param( NULL, param );
+    EXPECT_TRUE( element == NULL );
+
+    error = stumpless_get_error(  );
+    EXPECT_TRUE( error != NULL );
+    if( error ) {
+      EXPECT_EQ( error->id, STUMPLESS_ARGUMENT_EMPTY );
+      EXPECT_THAT( error->message, HasSubstr( "element" ) );
+      EXPECT_THAT( error->message, HasSubstr( "NULL" ) );
+    }
+
+    stumpless_destroy_param( param );
   }
 
   TEST( DestroyElementTest, NullElement ) {


### PR DESCRIPTION
Augment the stumpless_error struct with the capability to reveal more details of the problem encountered.