### PR TITLE
remove duplicate code from network target

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Thread-safe operation.
  - Examples for file and socket targets.
 
+## [1.3.1] - 2019-02-15
+### Fixed
+ - Code duplication in network target code.
+
 ## [1.3.0] - 2019-02-14
 ### Added
  - Install target and documentation.

--- a/include/private/config/have_sys_socket.h
+++ b/include/private/config/have_sys_socket.h
@@ -25,9 +25,6 @@ void
 sys_socket_close_network_target( struct network_target *target );
 
 void
-sys_socket_free_all( void );
-
-void
 sys_socket_init_network_target( struct network_target *target );
 
 struct network_target *
@@ -55,14 +52,9 @@ struct network_target *
 sys_socket_reopen_udp6_target( struct network_target *target );
 
 int
-sys_socket_sendto_tcp_target( struct network_target *target,
-                              const char *msg,
-                              size_t msg_length );
-
-int
-sys_socket_sendto_udp_target( struct network_target *target,
-                              const char *msg,
-                              size_t msg_length );
+sys_socket_sendto_target( struct network_target *target,
+                          const char *msg,
+                          size_t msg_length );
 
 int
 sys_socket_network_target_is_open( const struct network_target *target );

--- a/include/private/config/have_winsock2.h
+++ b/include/private/config/have_winsock2.h
@@ -26,7 +26,7 @@ void
 winsock2_close_network_target( struct network_target *target );
 
 void
-winsock2_free_all( void );
+winsock2_cleanup( void );
 
 int
 winsock2_gethostname( char *buffer, size_t namelen );
@@ -59,14 +59,9 @@ struct network_target *
 winsock2_reopen_udp6_target( struct network_target *target );
 
 int
-winsock2_sendto_tcp_target( struct network_target *target,
-                            const char *msg,
-                            size_t msg_length );
-
-int
-winsock2_sendto_udp_target( struct network_target *target,
-                            const char *msg,
-                            size_t msg_length );
+winsock2_sendto_target( struct network_target *target,
+                        const char *msg,
+                        size_t msg_length );
 
 struct network_target *
 winsock2_set_network_port( struct network_target *target, const char *port );

--- a/include/private/config/wrapper.h
+++ b/include/private/config/wrapper.h
@@ -26,16 +26,10 @@
 /* definition of config_sendto_network_target and config_network_free_all */
 #  ifdef STUMPLESS_NETWORK_TARGETS_SUPPORTED
 #    include "private/target/network.h"
+#    define config_network_free_all network_free_all
 #    define config_network_target_is_open network_target_is_open
 #    define config_open_network_target open_network_target
 #    define config_sendto_network_target sendto_network_target
-#    ifdef HAVE_SYS_SOCKET_H
-#      include "private/config/have_sys_socket.h"
-#      define config_network_free_all() sys_socket_free_all()
-#    elif HAVE_WINSOCK2_H
-#      include "private/config/have_winsock2.h"
-#      define config_network_free_all() winsock2_free_all()
-#    endif
 #  else
 #    include "private/target.h"
 #    define config_network_free_all() ( ( void ) 0 )
@@ -133,6 +127,7 @@
 #    define config_init_tcp6 sys_socket_init_network_target
 #    define config_init_udp4 sys_socket_init_network_target
 #    define config_init_udp6 sys_socket_init_network_target
+#    define config_network_cleanup() ( ( void ) 0 )
 #    define config_open_tcp4_target sys_socket_open_tcp4_target
 #    define config_open_tcp6_target sys_socket_open_tcp6_target
 #    define config_open_udp4_target sys_socket_open_udp4_target
@@ -141,10 +136,10 @@
 #    define config_reopen_tcp6_target sys_socket_reopen_tcp6_target
 #    define config_reopen_udp4_target sys_socket_reopen_udp4_target
 #    define config_reopen_udp6_target sys_socket_reopen_udp6_target
-#    define config_sendto_tcp4_target sys_socket_sendto_tcp_target
-#    define config_sendto_tcp6_target sys_socket_sendto_tcp_target
-#    define config_sendto_udp4_target sys_socket_sendto_udp_target
-#    define config_sendto_udp6_target sys_socket_sendto_udp_target
+#    define config_sendto_tcp4_target sys_socket_sendto_target
+#    define config_sendto_tcp6_target sys_socket_sendto_target
+#    define config_sendto_udp4_target sys_socket_sendto_target
+#    define config_sendto_udp6_target sys_socket_sendto_target
 #    define config_tcp4_is_open sys_socket_network_target_is_open
 #    define config_tcp6_is_open sys_socket_network_target_is_open
 #    define config_udp4_is_open sys_socket_network_target_is_open
@@ -159,6 +154,7 @@
 #    define config_init_tcp6 winsock2_init_network_target
 #    define config_init_udp4 winsock2_init_network_target
 #    define config_init_udp6 winsock2_init_network_target
+#    define config_network_cleanup() winsock2_cleanup()
 #    define config_open_tcp4_target winsock2_open_tcp4_target
 #    define config_open_tcp6_target winsock2_open_tcp6_target
 #    define config_open_udp4_target winsock2_open_udp4_target
@@ -167,10 +163,10 @@
 #    define config_reopen_tcp6_target winsock2_reopen_tcp6_target
 #    define config_reopen_udp4_target winsock2_reopen_udp4_target
 #    define config_reopen_udp6_target winsock2_reopen_udp6_target
-#    define config_sendto_tcp4_target winsock2_sendto_tcp_target
-#    define config_sendto_tcp6_target winsock2_sendto_tcp_target
-#    define config_sendto_udp4_target winsock2_sendto_udp_target
-#    define config_sendto_udp6_target winsock2_sendto_udp_target
+#    define config_sendto_tcp4_target winsock2_sendto_target
+#    define config_sendto_tcp6_target winsock2_sendto_target
+#    define config_sendto_udp4_target winsock2_sendto_target
+#    define config_sendto_udp6_target winsock2_sendto_target
 #    define config_tcp4_is_open winsock2_network_target_is_open
 #    define config_tcp6_is_open winsock2_network_target_is_open
 #    define config_udp4_is_open winsock2_network_target_is_open

--- a/include/private/target/network.h
+++ b/include/private/target/network.h
@@ -48,6 +48,9 @@ struct network_target {
 void
 destroy_network_target( struct network_target *target );
 
+void
+network_free_all( void );
+
 int
 network_target_is_open( const struct stumpless_target *target );
 

--- a/src/config/have_sys_socket.c
+++ b/src/config/have_sys_socket.c
@@ -212,7 +212,7 @@ sys_socket_sendto_target( struct network_target *target,
   if( result == -1 ){
     raise_socket_send_failure( "send failed with linux socket",
                                errno,
-                               "errno after the failed call");
+                               "errno after the failed call to send");
   }
 
   return result;

--- a/src/config/have_winsock2.c
+++ b/src/config/have_winsock2.c
@@ -29,9 +29,6 @@
 #include "private/strhelper.h"
 #include "private/target/network.h"
 
-static char *tcp_send_buffer = NULL;
-static size_t tcp_send_buffer_length = 0;
-
 static
 SOCKET
 winsock_open_socket( const char *destination,
@@ -105,10 +102,7 @@ winsock2_close_network_target( struct network_target *target ) {
 }
 
 void
-winsock2_free_all( void ) {
-  free_mem( tcp_send_buffer );
-  tcp_send_buffer_length = 0;
-
+winsock2_cleanup( void ) {
   WSACleanup(  );
 }
 
@@ -238,51 +232,9 @@ winsock2_reopen_udp6_target( struct network_target *target ) {
 }
 
 int
-winsock2_sendto_tcp_target( struct network_target *target,
-                            const char *msg,
-                            size_t msg_length ) {
-  int result;
-  size_t int_length;
-  size_t required_length;
-  char *new_buffer;
-
-  required_length = msg_length + 50;
-  if( tcp_send_buffer_length < required_length ) {
-    new_buffer = realloc_mem( tcp_send_buffer, required_length );
-
-    if( !new_buffer ) {
-      return -1;
-
-    } else {
-      tcp_send_buffer = new_buffer;
-      tcp_send_buffer_length = required_length;
-
-    }
-  }
-
-  snprintf( tcp_send_buffer, 50, "%zd ", msg_length );
-  int_length = strlen( tcp_send_buffer );
-  memcpy( tcp_send_buffer + int_length, msg, msg_length );
-
-  result = send( target->handle,
-                 tcp_send_buffer,
-                 cap_size_t_to_int( int_length + msg_length ),
-                 0 );
-
-  if( result == SOCKET_ERROR ) {
-    raise_socket_send_failure( "send failed with IPv4/TCP socket",
-                               WSAGetLastError(  ),
-                               "WSAGetLastError after the failed call" );
-    return -1;
-  }
-
-  return result;
-}
-
-int
-winsock2_sendto_udp_target( struct network_target *target,
-                            const char *msg,
-                            size_t msg_length ) {
+winsock2_sendto_target( struct network_target *target,
+                        const char *msg,
+                        size_t msg_length ) {
   int result;
 
   result = send( target->handle,
@@ -291,7 +243,7 @@ winsock2_sendto_udp_target( struct network_target *target,
                  0 );
 
   if( result == SOCKET_ERROR ) {
-    raise_socket_send_failure( "send failed with IPv4/UDP socket",
+    raise_socket_send_failure( "send failed with winsock socket",
                                WSAGetLastError(  ),
                                "WSAGetLastError after the failed call" );
     return -1;


### PR DESCRIPTION
Remove the duplicate code from the network target to pass the SonarCloud code quality check.