### PR TITLE
fix memory leak of error structures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,6 +411,10 @@ add_function_test(error_leak
   SOURCES test/function/leak/error.cpp
 )
 
+add_function_test(error_memory_failure
+  SOURCES test/function/startup/error_memory_failure.cpp
+)
+
 add_function_test(file
   SOURCES
     test/function/target/file.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,6 +407,10 @@ add_function_test(error
   SOURCES test/function/error.cpp
 )
 
+add_function_test(error_leak
+  SOURCES test/function/leak/error.cpp
+)
+
 add_function_test(file
   SOURCES
     test/function/target/file.cpp

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Examples for file and socket targets.
  - Platform-specific default behavior.
 
-## [1.4.0] - 2019-02-19
+## [1.4.0] - 2019-02-20
 ### Added
  - Format specifier support for messages and entries.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,9 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Examples for file and socket targets.
  - Platform-specific default behavior.
 
-## [1.4.0] - 2019-02-18
+## [1.4.0] - 2019-02-19
 ### Added
  - Format specifier support for messages and entries.
+
+### Fixed
+ - Memory leak where error structures are not freed by stumpless_free_all.
 
 ## [1.3.1] - 2019-02-15
 ### Fixed

--- a/include/private/error.h
+++ b/include/private/error.h
@@ -25,6 +25,9 @@ void
 clear_error( void );
 
 void
+error_free_all( void );
+
+void
 raise_address_failure( const char *message, int code, const char *code_type );
 
 void

--- a/scripts/headers_check.pl
+++ b/scripts/headers_check.pl
@@ -72,6 +72,7 @@ my %manifest = (
   "DWORD" => "windows.h",
   "entry_free_all" => "private/entry.h",
   "errno" => "errno.h",
+  "error_free_all" => "private/error.h",
   "EVENTLOG_ERROR_TYPE" => "windows.h",
   "EVENTLOG_INFORMATION_TYPE" => "windows.h",
   "EVENTLOG_SUCCESS" => "windows.h",

--- a/src/error.c
+++ b/src/error.c
@@ -154,6 +154,10 @@ raise_invalid_id( void ) {
 
 void
 raise_memory_allocation_failure( void ) {
+  if( !last_error ) {
+    return;
+  }
+
   raise_error( STUMPLESS_MEMORY_ALLOCATION_FAILURE, NULL, 0, NULL );
 }
 

--- a/src/error.c
+++ b/src/error.c
@@ -18,9 +18,9 @@
 
 #include <stddef.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <stumpless/error.h>
 #include "private/error.h"
+#include "private/memory.h"
 
 static FILE *error_stream = NULL;
 static int error_stream_valid = 0;
@@ -83,6 +83,12 @@ clear_error( void ) {
 }
 
 void
+error_free_all( void ) {
+  free_mem( last_error );
+  last_error = NULL;
+}
+
+void
 raise_address_failure( const char *message, int code, const char *code_type ) {
   raise_error( STUMPLESS_ADDRESS_FAILURE, message, code, code_type );
 }
@@ -103,7 +109,7 @@ raise_error( enum stumpless_error_id id,
              int code,
              const char *code_type ) {
   if( !last_error ) {
-    last_error = malloc( sizeof( struct stumpless_error ) );
+    last_error = alloc_mem( sizeof( struct stumpless_error ) );
     if( !last_error ) {
       error_valid = 0;
       return;

--- a/src/memory.c
+++ b/src/memory.c
@@ -41,6 +41,7 @@ stumpless_free_all( void ) {
   entry_free_all(  );
   strbuilder_free_all(  );
   config_network_free_all(  );
+  error_free_all(  );
 }
 
 malloc_func_t

--- a/test/function/leak/error.cpp
+++ b/test/function/leak/error.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2019 Joel E. Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <stddef.h>
+#include <stumpless.h>
+#include "test/helper/memory_counter.hpp"
+
+NEW_MEMORY_COUNTER( free_all )
+
+namespace {
+
+  TEST( ErrorLeakTest, FreeAll ) {
+    struct stumpless_error *error;
+
+    INIT_MEMORY_COUNTER( free_all );
+    stumpless_set_malloc( free_all_memory_counter_malloc );
+    stumpless_set_realloc( free_all_memory_counter_realloc );
+    stumpless_set_free( free_all_memory_counter_free );
+
+    // cause an error
+    stumpless_new_param( NULL, NULL );
+
+    error = stumpless_get_error(  );
+    ASSERT_TRUE( error != NULL );
+
+    stumpless_free_all(  );
+
+    EXPECT_EQ( free_all_memory_counter.alloc_total,
+               free_all_memory_counter.free_total );
+  }
+
+}

--- a/test/function/leak/error.cpp
+++ b/test/function/leak/error.cpp
@@ -44,5 +44,4 @@ namespace {
     EXPECT_EQ( free_all_memory_counter.alloc_total,
                free_all_memory_counter.free_total );
   }
-
 }

--- a/test/function/startup/entry_memory_failure.cpp
+++ b/test/function/startup/entry_memory_failure.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018 Joel E. Anderson
+ * Copyright 2018-2019 Joel E. Anderson
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,9 @@ namespace {
     struct stumpless_entry *entry;
     struct stumpless_error *error;
     void *(*result)(size_t);
+
+    // cause a failure so that the error struct can be created
+    stumpless_new_param( NULL, NULL );
    
     result = stumpless_set_malloc( [](size_t size)->void *{ return NULL; } );
     ASSERT_TRUE( result != NULL );

--- a/test/function/startup/error_memory_failure.cpp
+++ b/test/function/startup/error_memory_failure.cpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2019 Joel E. Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <gtest/gtest.h>
+#include <stumpless.h>
+
+namespace {
+
+  TEST( ErrorMemoryAllocationFailureTest, Initialization ) {
+    void *(*result)(size_t);
+    struct stumpless_param *param;
+   
+    result = stumpless_set_malloc( [](size_t size)->void *{ return NULL; } );
+    ASSERT_TRUE( result != NULL );
+
+    // this will create an immediate failure
+    param = stumpless_new_param( NULL, NULL );
+
+    EXPECT_TRUE( param == NULL );
+
+    // this is fine - really we just want to ensure this doesn't crash
+    EXPECT_TRUE( stumpless_get_error(  ) == NULL );
+
+    stumpless_set_malloc( malloc );
+  }
+
+}

--- a/test/function/startup/error_memory_failure.cpp
+++ b/test/function/startup/error_memory_failure.cpp
@@ -26,7 +26,7 @@ namespace {
   TEST( ErrorMemoryAllocationFailureTest, Initialization ) {
     void *(*result)(size_t);
     struct stumpless_param *param;
-   
+
     result = stumpless_set_malloc( [](size_t size)->void *{ return NULL; } );
     ASSERT_TRUE( result != NULL );
 

--- a/test/function/startup/target/socket_add_malloc_failure.cpp
+++ b/test/function/startup/target/socket_add_malloc_failure.cpp
@@ -46,6 +46,9 @@ namespace {
     char buffer[1024];
     struct stumpless_entry *basic_entry;
 
+    // cause a failure so that the error struct can be created
+    stumpless_new_param( NULL, NULL );
+
     test_socket_addr.sun_family = AF_UNIX;
     memcpy(&test_socket_addr.sun_path, socket_name, strlen(socket_name)+1);
    
@@ -58,6 +61,7 @@ namespace {
     bind(test_socket, (struct sockaddr *) &test_socket_addr, sizeof(test_socket_addr));
 
     target = stumpless_open_socket_target( socket_name, "test-function-target-socket", 0, 0 );
+    ASSERT_TRUE( target != NULL );
 
     basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
                                        STUMPLESS_SEVERITY_INFO,

--- a/test/function/startup/target/socket_add_malloc_failure.cpp
+++ b/test/function/startup/target/socket_add_malloc_failure.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018 Joel E. Anderson
+ * Copyright 2018-2019 Joel E. Anderson
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/function/version.cpp
+++ b/test/function/version.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018 Joel E. Anderson
+ * Copyright 2018-2019 Joel E. Anderson
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/function/version.cpp
+++ b/test/function/version.cpp
@@ -53,6 +53,9 @@ namespace {
     struct stumpless_version *version;
     struct stumpless_error *error;
     void *(*result)(size_t);
+
+    // cause a failure so that the error struct can be created
+    stumpless_new_param( NULL, NULL );
    
     result = stumpless_set_malloc( [](size_t size)->void *{ return NULL; } );
     ASSERT_TRUE( result != NULL );


### PR DESCRIPTION
The common error structure was not freed after a call to stumpless_free_all, resulting in a potential memory leak.