### PR TITLE
make network examples run manually

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,11 +209,11 @@ else()
     LIBRARIES ${network_libraries}
   )
 
-  add_example(tcp
+  add_no_run_example(tcp
     ${PROJECT_SOURCE_DIR}/docs/examples/network/tcp_example.c
   )
 
-  add_example(udp
+  add_no_run_example(udp
     ${PROJECT_SOURCE_DIR}/docs/examples/network/udp_example.c
   )
 endif(NOT ENABLE_NETWORK_TARGETS)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Examples for socket targets.
  - Platform-specific default behavior.
 
-## [1.4.0] - 2019-02-20
+## [1.4.0] - 2019-02-21
 ### Added
  - Format specifier support for messages and entries.
  - Generic stumpless_close_target function.
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  - Memory leak where error structures are not freed by stumpless_free_all.
+
+### Changed
+ - Network examples are no longer run by the examples build target.
 
 ## [1.3.1] - 2019-02-15
 ### Fixed

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -7,7 +7,14 @@ starting place.
 
 If you want to actually compile and run the examples, you'll need to have the
 stumpless library available. If you don't want to install it on your system, you
-can also use the `examples` build target.
+can also use the `examples` build target. Note that some examples are built by
+this target, but aren't actually executed. This is because these examples work
+best after you modify them to suit your intentions. For example, the TCP example
+is configured to send logs to `example.com`, which will fail as this is
+obviously not a log server. You can either use the `examples` build target and
+then run these afterwards, or you could use the `example-<examplename>` build
+target to just build one at a time. For example, the `example-tcp` target will
+build the TCP example, after which you can execute it manually.
 
 If you want to see even more sample code after looking at the examples, you can
 check out the test suites available in the `test` folder of the repository.

--- a/tools/cmake/example.cmake
+++ b/tools/cmake/example.cmake
@@ -4,7 +4,7 @@ else()
   set(function_test_compile_flags "")
 endif(MSVC)
 
-macro(add_example name)
+function(add_no_run_example name)
   add_executable(example-${name}
     EXCLUDE_FROM_ALL
     ${ARGN}
@@ -24,6 +24,10 @@ macro(add_example name)
     ${PROJECT_SOURCE_DIR}/include
     ${CMAKE_BINARY_DIR}/include
   )
+endfunction(add_no_run_example)
+
+macro(add_example name)
+  add_no_run_example(${name} ${ARGN})
 
   list(APPEND STUMPLESS_EXAMPLE_RUNNERS run-example-${name})
   add_custom_target(run-example-${name}


### PR DESCRIPTION
Network examples (UDP and TCP) are currently responsible for a large proportion of the time spent in the CI builds, as well as generating unnecessary network traffic that will certainly be dropped. This change removes them from the examples build target so that they are only run manually, presumably after they've been modified to do something meaningful.