### PR TITLE
correct linguist for header files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,7 @@
 *.cpp   text eol=lf
 *.cmake text eol=lf
 *.def   text eol=crlf
-*.h     text eol=lf
+*.h     text eol=lf linguist-language=C
 *.i     text eol=lf
 *.mc    text eol=crlf
 *.pl    text eol=lf


### PR DESCRIPTION
Some header files were misidentified as Objective-C code, despite being plain C. This is corrected by updating the .gitattributes file with a specific rule for all *.h files.