### PR TITLE
fix leap year error

### DIFF
--- a/test/function/rfc5424.cpp
+++ b/test/function/rfc5424.cpp
@@ -58,7 +58,7 @@ void TestRFC5424Compliance(const char *syslog_msg){
       EXPECT_LE(day, 30);
       break;
     case 2:
-      if(month % 4 == 0){
+      if((year % 4 == 0 && year % 100 != 0) || year % 400 == 0){
         EXPECT_LE(day, 29);
       } else {
         EXPECT_LE(day, 28);


### PR DESCRIPTION
Testing fails on a leap day due to a botched conditional check.