### PR TITLE
add project roadmap

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,10 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
- - Compile-time log level filtering.
- - Thread-safe operation.
- - Simpler socket functions (will break existing usage).
- - Non-blocking network logging (may change existing usage).
+For a detailed look at the project's future, including planned features and bug
+fixes, check out the
+[roadmap](https://github.com/goatshriek/stumpless/blob/master/docs/roadmap.md).
 
 ## [1.5.0] - 2020-02-21
 ### Added

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -74,9 +74,28 @@ takes longer than expected.
    open, as they will attempt to bind to the same socket name and will fail as
    it already exists. For details on the progress of this bug, see
    [issue #54](https://github.com/goatshriek/stumpless/issues/54).
+ * [CHANGE] **Python language bindings to Wrapture instead of SWIG**
+   The [Wrapture](https://github.com/goatshriek/wrapture) project is being
+   built to provide clean, readable, and explicit language binding functionality
+   from C to other target languages, specifically to support Stumpless. Once
+   Python is added as a target language, this will be utilized to create the
+   associated library bindings, replacing SWIG and removing the dependency. In
+   the future, other language bindings will be added using Wrapture as they are
+   added to the tool.
 
 ## Unallocated to a release
- * [ADD] **Python language bindings**
+ * [ADD] **Ruby language bindings**
+ * [ADD] **C# language bindings**
+ * [ADD] **TCL language bindings**
+ * [ADD] **Java language bindings**
+ * [ADD] **Powershell language bindings**
+ * [ADD] **Perl language bindings**
+ * [ADD] **journald logging target**
+ * [ADD] **Target chaining**
+   In some cases a log message needs to be sent to multiple destinations, such
+   as to a local file as well as a network server. Target chains will allow this
+   stream to be defined as a logging target, and a logging call only made to
+   this instead of manually logging to each target.
 
 ## A Note about Github issues and projects
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,6 +40,40 @@ takes longer than expected.
    user experience to have a native, object-oriented interface to use. This
    would allow higher-level language features like operator overloading and
    runtime polymorphism to be used to create a cleaner API.
+ * [ADD] **Logging functions that can be compiled out**
+   A common logging idiom is to log at different verbosity levels, and use
+   different levels in different contexts, for example debug during development,
+   and then only informational in production workloads. This feature will add
+   function calls that will be removed when the code is compiled with specific
+   flags, allowing builds that do not need lower-level logs to stay fast and
+   efficient without requiring code changes or modification tools in the build
+   pipeline.
+
+## 2.0.0 (next major release)
+ * [ADD] **Thread safety for all library calls and structures**
+   This is a critical feature for a logging library that needs to be run in a
+   huge variety of contexts with minimal overhead work to implement it. Adding
+   this feature will likely change how structures are interacted with in the
+   library, as things like direct struct access will need to have a thread-safe
+   alternative. This implementation will be done as granularly as possible, and
+   will not use any static library-wide locks in order to avoid throughput
+   issues in the future.
+ * [FIX] **Current target is invalid after closure**
+   The current target is set to to the last opened target, or it can be manually
+   set by the user using the `stumpless_set_current_target` function. However,
+   if this target is closed the current target pointer is not changed, and will
+   still point to the invalid memory. See
+   [issue #52](https://github.com/goatshriek/stumpless/issues/52) for details on
+   the progress of this bug.
+ * [FIX] **Socket targets may fail to bind to a local socket**
+   Socket targets can be opened with a local socket name provided, but this may
+   also be set to `NULL`, in which case a local socket is generated (see the
+   documentation of `stumpless_open_socket_target` for details). However, this
+   socket is always the same, which means that if a target is not properly
+   closed the local socket will remain. Successive targets will be unable to
+   open, as they will attempt to bind to the same socket name and will fail as
+   it already exists. For details on the progress of this bug, see
+   [issue #54](https://github.com/goatshriek/stumpless/issues/54).
 
 ## A Note about Github issues and projects
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,6 +95,7 @@ takes longer than expected.
  * [ADD] **AWS/S3 logging target**
  * [ADD] **Database logging target**
  * [ADD] **REST endpoint logging target**
+ * [CHANGE] **Make network logging non-blocking**
  * [ADD] **Target chaining**
    In some cases a log message needs to be sent to multiple destinations, such
    as to a local file as well as a network server. Target chains will allow this

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,6 +75,9 @@ takes longer than expected.
    it already exists. For details on the progress of this bug, see
    [issue #54](https://github.com/goatshriek/stumpless/issues/54).
 
+## Unallocated to a release
+ * [ADD] **Python language bindings**
+
 ## A Note about Github issues and projects
 
 A fair question to ask is why the roadmap is not being managed within the issue

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -91,11 +91,17 @@ takes longer than expected.
  * [ADD] **Powershell language bindings**
  * [ADD] **Perl language bindings**
  * [ADD] **journald logging target**
+ * [ADD] **Function callback logging target**
  * [ADD] **Target chaining**
    In some cases a log message needs to be sent to multiple destinations, such
    as to a local file as well as a network server. Target chains will allow this
    stream to be defined as a logging target, and a logging call only made to
    this instead of manually logging to each target.
+ * [ADD] **Filters**
+   While message severity codes can be used to filter which log messages make
+   it through a target at runtime, this is limited and inflexible. Instead, a
+   generic filter structure that can filter on a wide variety of properties of
+   each log entry and even use custom functions to filter messages.
 
 ## A Note about Github issues and projects
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,67 @@
+# The Future of Stumpless
+
+See below for details about upcoming releases of Stumpless. If you have feedback
+or want to make a suggestion, please submit an issue on the project's
+[Github page](https://github.com/goatshriek/stumpless).
+
+## What you'll find here and what you wont
+
+Stumpless is under active development, and has a long list of new features and
+improvements waiting to be implemented. Some of these are detailed in the issues
+list on the project Github website, but this is certainly not a comprehensive
+list of planned updates. Similarly, work that is in progress on new features is
+tracked as a project on the Github repository, but future planned work does not
+exist there either. Instead, the plans for future direction are kept here, in
+the project roadmap.
+
+Items are added to the roadmap once they have been identified, assessed for
+level of effort, and prioritized based on community needs. Each item is assigned
+to a semantic version, along with its change type, a description, and the
+reasoning behind it. Where they exist, you will see references to issues on the
+Github repository where you can go for more details on the origin of the
+request. Once a version is in work, you will be able to find a corresponding
+project on the Github repository with each roadmap item listed as a task. Once
+all tasks are complete, the version will be released and the next started.
+
+Once an item has been implemented it will be removed from the roadmap. If you
+would like to see a history of changes on the existing codebase, check out the
+ChangeLog (ChangeLog.md in the project root) to see what was included in each
+version of the library. In most cases, roadmap items will be removed from this
+document and placed there upon completion.
+
+Note that the timelines associated with each change are vague at best. The
+project team is not currently big enough to realistically make any promises, so
+timing is often left out to prevent folks from feeling cheated if something
+takes longer than expected.
+
+## 1.5.0 (next minor release)
+ * [ADD] **C++ language bindings**
+   While it is possible to use C code directly from C++, it would be a better
+   user experience to have a native, object-oriented interface to use. This
+   would allow higher-level language features like operator overloading and
+   runtime polymorphism to be used to create a cleaner API.
+
+## A Note about Github issues and projects
+
+A fair question to ask is why the roadmap is not being managed within the issue
+and project features of Github itself, since this is where the project is
+currently hosted. Indeed, suggestions submitted by the community are tracked as
+issues, and projects are already created for ongoing work. There are a few
+reasons that a separate roadmap is maintained:
+ * **Issues are used to exclusively track bugs and community requests.**
+   This certainly isn't a hard and fast rule, and isn't followed by many other
+   projects, but it is how Wrapture is managed. Keeping the issue count as a
+   clear indicator of known problems and community requests lets the project
+   maintainers (and anyone interested in looking at how well it is being
+   maintained) immediately see how much outstanding work exists. Of course,
+   the roadmap may have features requested by the community or enhancements made
+   clear by bug reports, but it will also have a number of features and tweaks
+   that have a lower priority.
+ * **Project direction should come packaged with the product.**
+   Again this isn't a commonly followed rule, but it is one that the project
+   author follows. Anyone that obtains the source code of the project at a
+   single point in time should be able to quickly see the current direction of
+   the project. Maintaining the roadmap within the version control of the source
+   itself facilitates this, the same way that licensing and copyright
+   notifications are traditionally bundled with code. And if you don't care,
+   you can always ignore them.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -92,6 +92,9 @@ takes longer than expected.
  * [ADD] **Perl language bindings**
  * [ADD] **journald logging target**
  * [ADD] **Function callback logging target**
+ * [ADD] **AWS/S3 logging target**
+ * [ADD] **Database logging target**
+ * [ADD] **REST endpoint logging target**
  * [ADD] **Target chaining**
    In some cases a log message needs to be sent to multiple destinations, such
    as to a local file as well as a network server. Target chains will allow this


### PR DESCRIPTION
A project's roadmap gives users a way to see the current intended direction.
This includes what features are currently identified for which versions and
descriptions of the features themselves.