### PR TITLE
rename default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Coverage Report](https://codecov.io/gh/goatshriek/stumpless/branch/latest/graph/badge.svg)](https://codecov.io/gh/goatshriek/stumpless)
 [![SonarCloud Status](https://sonarcloud.io/api/project_badges/measure?project=stumpless&metric=alert_status)](https://sonarcloud.io/dashboard?id=stumpless)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg)](https://github.com/goatshriek/stumpless/blob/latest/docs/CODE_OF_CONDUCT.md)
 
 A logging library built with a
 [vision](https://github.com/goatshriek/stumpless/blob/latest/docs/vision.md):

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Stumpless
 
-[![Travis Build Status](https://travis-ci.org/goatshriek/stumpless.svg?branch=master)](https://travis-ci.org/goatshriek/stumpless)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/uwied5cn5jujl4d2/branch/master?svg=true)](https://ci.appveyor.com/project/goatshriek/stumpless)
-[![Coverage Report](https://codecov.io/gh/goatshriek/stumpless/branch/master/graph/badge.svg)](https://codecov.io/gh/goatshriek/stumpless)
+[![Travis Build Status](https://travis-ci.org/goatshriek/stumpless.svg?branch=latest)](https://travis-ci.org/goatshriek/stumpless)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/uwied5cn5jujl4d2/branch/latest?svg=true)](https://ci.appveyor.com/project/goatshriek/stumpless)
+[![Coverage Report](https://codecov.io/gh/goatshriek/stumpless/branch/latest/graph/badge.svg)](https://codecov.io/gh/goatshriek/stumpless)
 [![SonarCloud Status](https://sonarcloud.io/api/project_badges/measure?project=stumpless&metric=alert_status)](https://sonarcloud.io/dashboard?id=stumpless)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 A logging library built with a
-[vision](https://github.com/goatshriek/stumpless/blob/master/docs/vision.md):
+[vision](https://github.com/goatshriek/stumpless/blob/latest/docs/vision.md):
 a rich and intuitive interface, standards compliance, fast performance, and a
 small footprint.
 
@@ -87,7 +87,7 @@ stumpless_add_message( target,
 
 It's as easy as that! For more detailed examples of different targets and more
 complicated message structures, check out the
-[examples](https://github.com/goatshriek/stumpless/tree/master/docs/examples).
+[examples](https://github.com/goatshriek/stumpless/tree/latest/docs/examples).
 for detailed walkthroughs and annotated example code for using various features
 of the library.
 

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -2,75 +2,128 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community an inclusive and harassment-free experience for everyone,
-regardless of age, body size, disability, ethnicity, gender identity and
-expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community an inclusive and harassment-free experience for everyone, regardless
+of age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project owner at [joelanderson333@gmail.com]. Email
-sent to this address is only read by Joel Anderson. All complaints will be
-reviewed and investigated and will result in a response that is deemed necessary
-and appropriate to the circumstances. The project team is obligated to maintain
-confidentiality with regard to the reporter of an incident. Further details of
-specific enforcement policies may be posted separately.
+reported to the community leaders responsible for enforcement at
+joelanderson333@gmail.com. Email sent to this address is read only by Joel
+Anderson. All complaints will be reviewed and investigated promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
 

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -4,10 +4,11 @@
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-education, socio-economic status, nationality, personal appearance, race,
-religion, or sexual identity and orientation.
+our community an inclusive and harassment-free experience for everyone,
+regardless of age, body size, disability, ethnicity, gender identity and
+expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
 
 ## Our Standards
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -56,16 +56,20 @@ need attention and are relatively simple to fix, respectively.
 If you are brand new to the community at large and are looking for a little more
 detail on how to contribute, then this section should help you get started.
 
-Stumpless keeps the master branch as the main and stable branch, and develops
-the next version in a branch named after its semantic version. For most updates,
-you should fork the repository and create a new branch from the next version's
-branch. Don't forget to update the ChangeLog with your changes, and when you're
-ready open a pull request against the next version's branch in the main
-repository.
+Stumpless has a default branch named `latest` off of which all new feature
+branches are based. Once all changes planned for the next version have been
+implemented, a tag will be added for the commit named after the semantic version
+number and the `release` branch will be updated to point to this commit. In this
+way, `latest` always has the most up to date changes and `release` always points
+to the last complete version released.
+
+To create your own feature or update, you should fork the repository and create
+a new branch based on the `latest` branch. Don't forget to update the ChangeLog
+with your changes, and when you're ready open a pull request against `latest`.
 
 It is unusual, but you may find that it is more appropriate to base your branch
-on the master branch instead of the next version. Some examples of these types
-of changes are:
+on the `release` branch instead of `latest`. Some examples of these types of
+changes are:
  * updates to project documentation that is relevant to the current version of
    the project as well as the next
  * patches that need to be applied to the current version of the library in
@@ -84,9 +88,9 @@ starting material:
  * [Creating a Pull Request from a Fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork)
 
 To recap, your basic steps will be to fork the repository, create a new branch
-based on the latest version (or perhaps the master branch if you are special as
-described above), and when you are finished adding commits to it create a pull
-request back to this repository.
+based on `latest` (or perhaps `release` depending on the circumstances), and
+when you are finished adding commits to it create a pull request back to the
+main repository.
 
 And thanks for giving back to the community!
 

--- a/docs/cpp.md
+++ b/docs/cpp.md
@@ -10,7 +10,7 @@ defined in the `wrapture` directory of the source for Stumpless.
 ## Basic Usage
 The following snippets show some usage patterns specific to C++. If you're
 looking for basic usage of the C library, check out the main project
-[readme](https://github.com/goatshriek/stumpless/blob/master/README.md) for a
+[readme](https://github.com/goatshriek/stumpless/blob/latest/README.md) for a
 quick rundown of what you can do.
 
 Targets and entries can be created by instantiating the appropriate class, just


### PR DESCRIPTION
The branch scheme has been changed to have two long-lived branches. The default branch is now named `latest` and is what each new feature or change branch is based on. The other branch, `release`, is kept at the most recent semantic version release and serves as a more stable alternative to `latest` for anyone building from the source repository.

The Code of Conduct has also been updated to the latest version of the Contributor Covenant, 2.0.

The renaming of the `master` branch to `latest` also serves to remove language that may not be inclusive of all individuals. Stumpless seeks to make participation in its community inclusive and harassment-free, as detailed in the Code of Conduct. The project maintainers will work to make any changes necessary, such as this one, in order to keep this pledge.