### PR TITLE
remove unused local variable

### DIFF
--- a/include/test/helper/level_disabled.hpp
+++ b/include/test/helper/level_disabled.hpp
@@ -112,7 +112,6 @@ TEST_F( LevelEnabledTest, Stumplog##LEVEL_NAME ) {                             \
 }                                                                              \
                                                                                \
 TEST_F( LevelEnabledTest, Stumplog##LEVEL_NAME##SideEffects ) {                \
-  int result;                                                                  \
   int before_val = 555;                                                        \
                                                                                \
   stumplog_##LEVEL_LETTER( STUMPLESS_FACILITY_KERN |                           \


### PR DESCRIPTION
An unused local variable was causing compilation warnings in tests for the `stumplog` function being disabled.