### PR TITLE
fix closing of current target

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/stumpless/blob/master/docs/roadmap.md).
 
-## [1.6.0] - 2020-07-15
+## [1.6.0] - 2020-07-16
 ### Added
  - A number of new functions for working with entries, elements, and params.
  - A rollup header, `stumpless.hpp`, for the C++ library to make use easier.
@@ -19,6 +19,9 @@ fixes, check out the
  - Added missing DLL exports of C++ library in standard Visual Studio builds.
  - Local socket names are generated using mkstemp instead of using a static
    counter ([issue #54](https://github.com/goatshriek/stumpless/issues/54)]).
+ - The current target is not left pointing at an invalid target structure
+   after the current target is closed
+   ([issue #52](https://github.com/goatshriek/stumpless/issues/52)).
 
 ## [1.5.0] - 2020-05-19
 ### Added

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,13 +35,6 @@ timing is often left out to prevent folks from feeling cheated if something
 takes longer than expected.
 
 ## 1.6.0 (next minor release)
- * [FIX] **Current target is invalid after closure**
-   The current target is set to to the last opened target, or it can be manually
-   set by the user using the `stumpless_set_current_target` function. However,
-   if this target is closed the current target pointer is not changed, and will
-   still point to the invalid memory. See
-   [issue #52](https://github.com/goatshriek/stumpless/issues/52) for details on
-   the progress of this bug.
 
 ## 2.0.0 (next major release)
  * [ADD] **Thread safety for all library calls and structures**

--- a/include/stumpless/target.h
+++ b/include/stumpless/target.h
@@ -240,6 +240,10 @@ stumpless_close_target( struct stumpless_target *target );
  * to stumpless_set_current_target(), or the default target if neither of the
  * former exists.
  *
+ * If the target that is designated as the current target is closed, then the
+ * current target will be reset to the default target until another target is
+ * opened.
+ *
  * Be careful not to confuse this target with the default target, which is the
  * target used when no suitable current target exists. While these may be the
  * same in some cases, they will not always be.

--- a/include/stumpless/target.h
+++ b/include/stumpless/target.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/target.c
+++ b/src/target.c
@@ -556,6 +556,10 @@ vstumpless_add_message( struct stumpless_target *target,
 
 void
 destroy_target( struct stumpless_target *target ) {
+  if( target == current_target ) {
+    current_target = NULL;
+  }
+
   free_mem( target->default_app_name );
   free_mem( target->default_msgid );
   free_mem( target->name );

--- a/test/function/target/buffer.cpp
+++ b/test/function/target/buffer.cpp
@@ -176,10 +176,11 @@ namespace {
   /* non-fixture tests */
 
   TEST( BufferTargetCloseTest, Generic ) {
+    const char *target_name = "normal target";
     struct stumpless_target *target;
     char buffer[100];
 
-    target = stumpless_open_buffer_target( "normal target",
+    target = stumpless_open_buffer_target( target_name,
                                            buffer,
                                            sizeof( buffer ),
                                            STUMPLESS_OPTION_NONE,
@@ -191,7 +192,10 @@ namespace {
     stumpless_close_target( target );
     EXPECT_NO_ERROR;
 
-    EXPECT_NE( stumpless_get_current_target(  ), target );
+    EXPECT_EQ( stumpless_get_current_target(  ),
+               stumpless_get_default_target(  ) );
+    EXPECT_STRNE( stumpless_get_current_target(  )->name,
+                  target_name );
   }
 
   TEST( BufferTargetCloseTest, NullTarget ) {

--- a/test/function/target/buffer.cpp
+++ b/test/function/target/buffer.cpp
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 #include <stumpless.h>
 #include "test/function/rfc5424.hpp"
+#include "test/helper/assert.hpp"
 
 #define TEST_BUFFER_LENGTH 8192
 
@@ -183,11 +184,14 @@ namespace {
                                            sizeof( buffer ),
                                            STUMPLESS_OPTION_NONE,
                                            STUMPLESS_FACILITY_USER );
-    EXPECT_TRUE( target != NULL );
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( target );
+    EXPECT_EQ( stumpless_get_current_target(  ), target );
 
     stumpless_close_target( target );
+    EXPECT_NO_ERROR;
 
-    EXPECT_TRUE( stumpless_get_error(  ) == NULL );
+    EXPECT_NE( stumpless_get_current_target(  ), target );
   }
 
   TEST( BufferTargetCloseTest, NullTarget ) {

--- a/test/function/target/file.cpp
+++ b/test/function/target/file.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include <stumpless.h>
 #include <gtest/gtest.h>
 #include "test/function/rfc5424.hpp"
+#include "test/helper/assert.hpp"
 
 namespace {
   class FileTargetTest : public::testing::Test {
@@ -83,11 +84,13 @@ namespace {
     target = stumpless_open_file_target( filename,
                                          STUMPLESS_OPTION_NONE,
                                          STUMPLESS_FACILITY_USER );
-    EXPECT_TRUE( target != NULL );
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( target );
+    EXPECT_EQ( stumpless_get_current_target(  ), target );
 
     stumpless_close_target( target );
-
-    EXPECT_TRUE( stumpless_get_error(  ) == NULL );
+    EXPECT_NO_ERROR;
+    EXPECT_NE( stumpless_get_current_target(  ), target );
   }
 
   TEST( FileTargetCloseTest, NullTarget ) {

--- a/test/function/target/file.cpp
+++ b/test/function/target/file.cpp
@@ -90,7 +90,11 @@ namespace {
 
     stumpless_close_target( target );
     EXPECT_NO_ERROR;
-    EXPECT_NE( stumpless_get_current_target(  ), target );
+
+    EXPECT_EQ( stumpless_get_current_target(  ),
+               stumpless_get_default_target(  ) );
+    EXPECT_STRNE( stumpless_get_current_target(  )->name,
+                  filename );
   }
 
   TEST( FileTargetCloseTest, NullTarget ) {

--- a/test/function/target/network.cpp
+++ b/test/function/target/network.cpp
@@ -28,6 +28,7 @@
 #include <stumpless.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "test/helper/assert.hpp"
 #include "test/helper/resolve.hpp"
 #include "test/helper/server.hpp"
 
@@ -48,11 +49,13 @@ namespace {
                                          "127.0.0.1",
                                          STUMPLESS_OPTION_NONE,
                                          STUMPLESS_FACILITY_USER );
-    EXPECT_TRUE( target != NULL );
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( target );
+    EXPECT_EQ( stumpless_get_current_target(  ), target );
 
     stumpless_close_target( target );
-
-    EXPECT_TRUE( stumpless_get_error(  ) == NULL );
+    EXPECT_NO_ERROR;
+    EXPECT_NE( stumpless_get_current_target(  ), target );
   }
 
   TEST( NetworkTargetCloseTest, NullTarget ) {

--- a/test/function/target/network.cpp
+++ b/test/function/target/network.cpp
@@ -43,9 +43,10 @@ using::testing::Not;
 namespace {
 
   TEST( NetworkTargetCloseTest, Generic ) {
+    const char *target_name = "generic-close-test";
     struct stumpless_target *target;
 
-    target = stumpless_open_udp4_target( "generic-close-test",
+    target = stumpless_open_udp4_target( target_name,
                                          "127.0.0.1",
                                          STUMPLESS_OPTION_NONE,
                                          STUMPLESS_FACILITY_USER );
@@ -55,7 +56,11 @@ namespace {
 
     stumpless_close_target( target );
     EXPECT_NO_ERROR;
-    EXPECT_NE( stumpless_get_current_target(  ), target );
+
+    EXPECT_EQ( stumpless_get_current_target(  ),
+               stumpless_get_default_target(  ) );
+    EXPECT_STRNE( stumpless_get_current_target(  )->name,
+                  target_name );
   }
 
   TEST( NetworkTargetCloseTest, NullTarget ) {

--- a/test/function/target/socket.cpp
+++ b/test/function/target/socket.cpp
@@ -189,9 +189,10 @@ namespace {
   }
 
   TEST( SocketTargetCloseTest, Generic ) {
+    const char *target_name = "generic-close-test";
     struct stumpless_target *target;
 
-    target = stumpless_open_socket_target( "generic-close-test",
+    target = stumpless_open_socket_target( target_name,
                                            NULL,
                                            STUMPLESS_OPTION_NONE,
                                            STUMPLESS_FACILITY_USER );
@@ -202,7 +203,11 @@ namespace {
 
     stumpless_close_target( target );
     EXPECT_NO_ERROR;
-    EXPECT_NE( stumpless_get_current_target(  ), target );
+
+    EXPECT_EQ( stumpless_get_current_target(  ),
+               stumpless_get_default_target(  ) );
+    EXPECT_STRNE( stumpless_get_current_target(  )->name,
+                  target_name );
   }
 
   TEST( SocketTargetCloseTest, NullTarget ) {

--- a/test/function/target/socket.cpp
+++ b/test/function/target/socket.cpp
@@ -198,9 +198,11 @@ namespace {
 
     EXPECT_NO_ERROR;
     ASSERT_NOT_NULL( target );
+    EXPECT_EQ( stumpless_get_current_target(  ), target );
 
     stumpless_close_target( target );
     EXPECT_NO_ERROR;
+    EXPECT_NE( stumpless_get_current_target(  ), target );
   }
 
   TEST( SocketTargetCloseTest, NullTarget ) {

--- a/test/function/target/stream.cpp
+++ b/test/function/target/stream.cpp
@@ -23,6 +23,7 @@
 #include <stumpless.h>
 #include <gtest/gtest.h>
 #include "test/function/rfc5424.hpp"
+#include "test/helper/assert.hpp"
 
 namespace {
   class StreamTargetTest : public::testing::Test {
@@ -85,17 +86,19 @@ namespace {
     struct stumpless_target *target;
 
     stream = fopen( filename, "w+" );
-    ASSERT_TRUE( stream != NULL );
+    ASSERT_NOT_NULL( stream );
 
     target = stumpless_open_stream_target( filename,
                                            stream,
                                            STUMPLESS_OPTION_NONE,
                                            STUMPLESS_FACILITY_USER );
-    EXPECT_TRUE( target != NULL );
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( target );
+    EXPECT_EQ( stumpless_get_current_target(  ), target );
 
     stumpless_close_target( target );
-
-    EXPECT_TRUE( stumpless_get_error(  ) == NULL );
+    EXPECT_NO_ERROR;
+    EXPECT_NE( stumpless_get_current_target(  ), target );
   }
 
   TEST( StreamTargetCloseTest, NullTarget ) {

--- a/test/function/target/stream.cpp
+++ b/test/function/target/stream.cpp
@@ -98,7 +98,11 @@ namespace {
 
     stumpless_close_target( target );
     EXPECT_NO_ERROR;
-    EXPECT_NE( stumpless_get_current_target(  ), target );
+
+    EXPECT_EQ( stumpless_get_current_target(  ),
+               stumpless_get_default_target(  ) );
+    EXPECT_STRNE( stumpless_get_current_target(  )->name,
+                  filename );
   }
 
   TEST( StreamTargetCloseTest, NullTarget ) {

--- a/test/function/target/wel.cpp
+++ b/test/function/target/wel.cpp
@@ -209,9 +209,10 @@ namespace {
   /* non-fixture tests */
 
   TEST( WelTargetCloseTest, Generic ) {
+    const char *target_name = "wel-target-test";
     struct stumpless_target *target;
 
-    target = stumpless_open_local_wel_target( "wel-target-test",
+    target = stumpless_open_local_wel_target( target_name,
                                               STUMPLESS_OPTION_NONE );
     EXPECT_NO_ERROR;
     EXPECT_NOT_NULL( target );
@@ -219,7 +220,11 @@ namespace {
 
     stumpless_close_target( target );
     EXPECT_NO_ERROR;
-    EXPECT_NE( stumpless_get_current_target(  ), target );
+
+    EXPECT_EQ( stumpless_get_current_target(  ),
+               stumpless_get_default_target(  ) );
+    EXPECT_STRNE( stumpless_get_current_target(  )->name,
+                  target_name );
   }
 
   TEST( WelTargetCloseTest, NullTarget ) {

--- a/test/function/target/wel.cpp
+++ b/test/function/target/wel.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/function/target/wel.cpp
+++ b/test/function/target/wel.cpp
@@ -24,6 +24,7 @@
 #include <stumpless.h>
 #include <windows.h>
 #include "test/function/windows/events.h"
+#include "test/helper/assert.hpp"
 
 using::testing::HasSubstr;
 
@@ -212,11 +213,13 @@ namespace {
 
     target = stumpless_open_local_wel_target( "wel-target-test",
                                               STUMPLESS_OPTION_NONE );
-    EXPECT_TRUE( target != NULL );
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( target );
+    EXPECT_EQ( stumpless_get_current_target(  ), target );
 
     stumpless_close_target( target );
-
-    EXPECT_TRUE( stumpless_get_error(  ) == NULL );
+    EXPECT_NO_ERROR;
+    EXPECT_NE( stumpless_get_current_target(  ), target );
   }
 
   TEST( WelTargetCloseTest, NullTarget ) {


### PR DESCRIPTION
The current target is set to to the last opened target, or it can be manually set with the `stumpless_set_current_target` function. However when this target is closed the current target pointer was not changed, and will still point to the invalid memory. This change corrects this behavior and adds tests for regression.

This is intended to correct #52.