### PR TITLE
add gtest and benchmark export targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,9 @@ string(CONCAT benchmark_path_help_string
   "In order for this to be used the directory must include ALL of the "
   "following at configuration time: the benchmark and benchmark_main "
   "libraries, and the benchmark/benchmark.h header. "
-  "An easy way to set this up is to perform a normal build first, and then "
-  "copy the necessary files out of the build directory into a separate folder "
-  "which can then be used in future builds."
+  "If the necessary files are not found, the benchmark library will be "
+  "downloaded and built when it is needed, and the export-benchmark target "
+  "can be used to populate the provided directory for future builds."
 )
 set(BENCHMARK_PATH ${PROJECT_BINARY_DIR}
   CACHE PATH ${benchmark_path_help_string}
@@ -56,9 +56,9 @@ string(CONCAT gtest_path_help_string
   "In order for this to be used the directory must include ALL of the "
   "following at configuration time: the gtest, gtest_main, and gmock "
   "libraries, the gtest/gtest.h header, and the gmock/gmock.h header. "
-  "An easy way to set this up is to perform a normal build first, and then "
-  "copy the necessary files out of the build directory into a separate folder "
-  "which can then be used in future builds."
+  "If the necessary files are not found, the gtest library will be "
+  "downloaded and built when it is needed, and the export-gtest target "
+  "can be used to populate the provided directory for future builds."
 )
 set(GTEST_PATH ${PROJECT_BINARY_DIR}
   CACHE PATH ${gtest_path_help_string}

--- a/tools/cmake/benchmark.cmake
+++ b/tools/cmake/benchmark.cmake
@@ -64,6 +64,13 @@ if(${benchmark_lib} STREQUAL "benchmark_lib-NOTFOUND" OR ${benchmark_main_lib} S
   )
 
   include_directories("${source_dir}/include")
+
+  add_custom_target(export-benchmark
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${local_benchmark_binary_dir} ${BENCHMARK_PATH}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${local_benchmark_static_dir} ${BENCHMARK_PATH}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${source_dir}/include" ${BENCHMARK_PATH}
+    DEPENDS benchmark
+  )
 else()
   add_found_library(
     LIB_NAME "libbenchmark"

--- a/tools/cmake/gtest.cmake
+++ b/tools/cmake/gtest.cmake
@@ -113,6 +113,15 @@ if(${gtest_lib} STREQUAL "gtest_lib-NOTFOUND" OR ${gtest_main_lib} STREQUAL "gte
   include_directories("${source_dir}/googletest/include"
                       "${source_dir}/googlemock/include"
   )
+
+  add_custom_target(export-gtest
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${local_gtest_binary_dir} ${GTEST_PATH}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${local_gtest_shared_dir} ${GTEST_PATH}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${local_gtest_static_dir} ${GTEST_PATH}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${source_dir}/googletest/include" ${GTEST_PATH}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${source_dir}/googlemock/include" ${GTEST_PATH}
+    DEPENDS gtest
+  )
 else()
   add_found_library(
     LIB_NAME "libgtest"


### PR DESCRIPTION
While `GTEST_PATH` and `BENCHMARK_PATH` provide easy ways to re-use library builds, creating these was a manual chore. This change adds the `export-gtest` and `export-benchmark` targets that will populate the provided directories if the required files were not found during the build configuration step.