### PR TITLE
add const qualifiers

### DIFF
--- a/include/private/cache.h
+++ b/include/private/cache.h
@@ -34,10 +34,10 @@ void *
 cache_alloc( struct cache *c );
 
 void
-cache_destroy( struct cache *c );
+cache_destroy( const struct cache *c );
 
 void
-cache_free( struct cache *c, const void *entry );
+cache_free( const struct cache *c, const void *entry );
 
 struct cache *
 cache_new( size_t size,

--- a/include/private/config/have_sys_socket.h
+++ b/include/private/config/have_sys_socket.h
@@ -23,7 +23,7 @@
 #  include "private/target/network.h"
 
 void
-sys_socket_close_network_target( struct network_target *target );
+sys_socket_close_network_target( const struct network_target *target );
 
 void
 sys_socket_init_network_target( struct network_target *target );

--- a/include/private/formatter.h
+++ b/include/private/formatter.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,6 @@
 #  define RFC_5424_WHOLE_TIME_BUFFER_SIZE 20
 
 struct strbuilder *
-format_entry( struct stumpless_entry *entry );
+format_entry( const struct stumpless_entry *entry );
 
 #endif /* __STUMPLESS_PRIVATE_FORMATTER_H */

--- a/include/private/strbuilder.h
+++ b/include/private/strbuilder.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ char *
 strbuilder_get_buffer( struct strbuilder *builder, size_t *length );
 
 void
-strbuilder_destroy( struct strbuilder *builder );
+strbuilder_destroy( const struct strbuilder *builder );
 
 struct strbuilder *
 strbuilder_new( void );

--- a/include/private/target.h
+++ b/include/private/target.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 #include <stumpless/target.h>
 
 void
-destroy_target( struct stumpless_target *target );
+destroy_target( const struct stumpless_target *target );
 
 struct stumpless_target *
 new_target( enum stumpless_target_type type,

--- a/include/private/target/buffer.h
+++ b/include/private/target/buffer.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ struct buffer_target {
 };
 
 void
-destroy_buffer_target( struct buffer_target *target );
+destroy_buffer_target( const struct buffer_target *target );
 
 struct buffer_target *
 new_buffer_target( char *buffer, size_t size );

--- a/include/private/target/network.h
+++ b/include/private/target/network.h
@@ -35,7 +35,7 @@ struct network_target {
 };
 
 void
-destroy_network_target( struct network_target *target );
+destroy_network_target( const struct network_target *target );
 
 void
 network_free_all( void );

--- a/include/private/target/socket.h
+++ b/include/private/target/socket.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ struct socket_target {
 };
 
 void
-destroy_socket_target( struct socket_target *trgt );
+destroy_socket_target( const struct socket_target *trgt );
 
 struct socket_target *
 new_socket_target( const char *dest, size_t dest_len,

--- a/include/private/target/stream.h
+++ b/include/private/target/stream.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ struct stream_target {
 };
 
 void
-destroy_stream_target( struct stream_target *target );
+destroy_stream_target( const struct stream_target *target );
 
 struct stream_target *
 new_stream_target( FILE *stream );

--- a/include/stumpless/target.h
+++ b/include/stumpless/target.h
@@ -170,7 +170,7 @@ stumplog( int priority, const char *message, ... );
  */
 int
 stumpless_add_entry( struct stumpless_target *target,
-                     struct stumpless_entry *entry );
+                     const struct stumpless_entry *entry );
 
 /**
  * Adds a log message with a priority to a given target.

--- a/include/stumpless/target/buffer.h
+++ b/include/stumpless/target/buffer.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ extern "C" {
  * @param target The buffer target to close.
  */
 void
-stumpless_close_buffer_target( struct stumpless_target *target );
+stumpless_close_buffer_target( const struct stumpless_target *target );
 
 /**
  * Creates a buffer target for the given buffer.

--- a/include/stumpless/target/network.h
+++ b/include/stumpless/target/network.h
@@ -113,7 +113,7 @@ stumpless_get_transport_port( const struct stumpless_target *target );
  * set appropriately.
  */
 size_t
-stumpless_get_udp_max_message_size( struct stumpless_target *target );
+stumpless_get_udp_max_message_size( const struct stumpless_target *target );
 
 /**
  * Creates a network target, but does not open it.

--- a/include/stumpless/target/network.h
+++ b/include/stumpless/target/network.h
@@ -78,7 +78,7 @@ enum stumpless_transport_protocol {
  * @param target The network target to close.
  */
 void
-stumpless_close_network_target( struct stumpless_target *target );
+stumpless_close_network_target( const struct stumpless_target *target );
 
 /**
  * Gets the destination of a network target.

--- a/include/stumpless/target/socket.h
+++ b/include/stumpless/target/socket.h
@@ -1,14 +1,14 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
- * 
+ * Copyright 2018-2020 Joel E. Anderson
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,7 +41,7 @@ extern "C" {
  * @param target The socket target to close.
  */
 void
-stumpless_close_socket_target( struct stumpless_target *target );
+stumpless_close_socket_target( const struct stumpless_target *target );
 
 /**
  * Opens a socket target.

--- a/include/stumpless/target/stream.h
+++ b/include/stumpless/target/stream.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ extern "C" {
  * @param target The stream target to close.
  */
 void
-stumpless_close_stream_target( struct stumpless_target *target );
+stumpless_close_stream_target( const struct stumpless_target *target );
 
 /**
  * Opens a stream target for the stderr stream.

--- a/src/cache.c
+++ b/src/cache.c
@@ -22,7 +22,7 @@
 #include "private/memory.h"
 
 static void
-init_page( struct cache *c, size_t page_index ) {
+init_page( const struct cache *c, size_t page_index ) {
   size_t entries_per_page;
   size_t i;
   char *current_page;
@@ -41,7 +41,7 @@ init_page( struct cache *c, size_t page_index ) {
 }
 
 static void
-teardown_page( struct cache *c, size_t page_index ) {
+teardown_page( const struct cache *c, size_t page_index ) {
   size_t entries_per_page;
   size_t i;
   char *current_page;
@@ -119,7 +119,7 @@ cache_alloc( struct cache *c ) {
 }
 
 void
-cache_destroy( struct cache *c ) {
+cache_destroy( const struct cache *c ) {
   size_t i;
 
   if( !c ) {
@@ -136,7 +136,7 @@ cache_destroy( struct cache *c ) {
 }
 
 void
-cache_free( struct cache *c, const void *entry ) {
+cache_free( const struct cache *c, const void *entry ) {
   size_t entry_index;
   size_t i;
   size_t entries_per_page;

--- a/src/config/have_gmtime_r.c
+++ b/src/config/have_gmtime_r.c
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018 Joel E. Anderson
- * 
+ * Copyright 2018-2020 Joel E. Anderson
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,7 +27,7 @@ gmtime_r_get_now( char *buffer ) {
   int gettime_result;
   struct tm now_tm;
   struct timespec now_ts;
-  struct tm *gmtime_result;
+  const struct tm *gmtime_result;
   size_t written;
 
   gettime_result = clock_gettime( CLOCK_REALTIME, &now_ts );

--- a/src/config/have_sys_socket.c
+++ b/src/config/have_sys_socket.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2019 Joel E. Anderson
+ * Copyright 2019-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ fail:
 }
 
 void
-sys_socket_close_network_target( struct network_target *target ) {
+sys_socket_close_network_target( const struct network_target *target ) {
   close( target->handle );
 }
 

--- a/src/entry.c
+++ b/src/entry.c
@@ -857,8 +857,8 @@ strbuilder_append_structured_data( struct strbuilder *builder,
                                    const struct stumpless_entry *entry ) {
   size_t i;
   size_t j;
-  struct stumpless_element *element;
-  struct stumpless_param *param;
+  const struct stumpless_element *element;
+  const struct stumpless_param *param;
 
   if( entry->element_count == 0 ) {
     return strbuilder_append_char( builder, '-' );

--- a/src/formatter.c
+++ b/src/formatter.c
@@ -24,7 +24,7 @@
 #include "private/formatter.h"
 
 struct strbuilder *
-format_entry( struct stumpless_entry *entry ) {
+format_entry( const struct stumpless_entry *entry ) {
   char timestamp[RFC_5424_TIMESTAMP_BUFFER_SIZE];
   struct strbuilder *builder;
   size_t timestamp_size;

--- a/src/strbuilder.c
+++ b/src/strbuilder.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ strbuilder_init( void *builder ) {
 
 static void
 strbuilder_teardown( void *builder ) {
-  struct strbuilder *b = ( struct strbuilder * ) builder;
+  const struct strbuilder *b = ( struct strbuilder * ) builder;
 
   free_mem( b->buffer );
 }
@@ -162,7 +162,7 @@ strbuilder_get_buffer( struct strbuilder *builder, size_t * length ) {
 }
 
 void
-strbuilder_destroy( struct strbuilder *builder ) {
+strbuilder_destroy( const struct strbuilder *builder ) {
   cache_free( strbuilder_cache, builder );
 }
 

--- a/src/target.c
+++ b/src/target.c
@@ -46,7 +46,7 @@ static struct stumpless_target *default_target = NULL;
 
 static
 void
-close_unsupported_target( struct stumpless_target *target ) {
+close_unsupported_target( const struct stumpless_target *target ) {
   ( void ) target;
 
   raise_target_unsupported( "attempted to close an unsupported target type" );
@@ -555,7 +555,7 @@ vstumpless_add_message( struct stumpless_target *target,
 /* private definitions */
 
 void
-destroy_target( struct stumpless_target *target ) {
+destroy_target( const struct stumpless_target *target ) {
   if( target == current_target ) {
     current_target = NULL;
   }

--- a/src/target.c
+++ b/src/target.c
@@ -87,7 +87,7 @@ stumplog( int priority, const char *message, ... ) {
 
 int
 stumpless_add_entry( struct stumpless_target *target,
-                     struct stumpless_entry *entry ) {
+                     const struct stumpless_entry *entry ) {
   struct strbuilder *builder;
   size_t builder_length;
   const char *buffer;

--- a/src/target/buffer.c
+++ b/src/target/buffer.c
@@ -27,7 +27,7 @@
 #include "private/target/buffer.h"
 
 void
-stumpless_close_buffer_target( struct stumpless_target *target ) {
+stumpless_close_buffer_target( const struct stumpless_target *target ) {
   clear_error(  );
 
   if( !target ) {

--- a/src/target/buffer.c
+++ b/src/target/buffer.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ fail:
 /* private definitions */
 
 void
-destroy_buffer_target( struct buffer_target *target ) {
+destroy_buffer_target( const struct buffer_target *target ) {
   free_mem( target );
 }
 

--- a/src/target/network.c
+++ b/src/target/network.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2019 Joel E. Anderson
+ * Copyright 2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -606,7 +606,7 @@ stumpless_set_destination( struct stumpless_target *target,
 
   net_target = target->id;
 
-  free_mem( ( void * ) net_target->destination );
+  free_mem( net_target->destination );
   net_target->destination = destination_copy;
 
   if( network_target_is_open( target ) ) {
@@ -654,7 +654,7 @@ stumpless_set_transport_port( struct stumpless_target *target,
 
   net_target = target->id;
 
-  free_mem( ( void * ) net_target->port );
+  free_mem( net_target->port );
   net_target->port = port_copy;
 
   if( network_target_is_open( target ) ) {
@@ -716,8 +716,8 @@ destroy_network_target( struct network_target *target ) {
 
   }
 
-  free_mem( ( void * ) target->destination );
-  free_mem( ( void * ) target->port );
+  free_mem( target->destination );
+  free_mem( target->port );
   free_mem( target );
 }
 

--- a/src/target/network.c
+++ b/src/target/network.c
@@ -328,9 +328,7 @@ stumpless_close_network_target( struct stumpless_target *target ) {
 
 const char *
 stumpless_get_destination( const struct stumpless_target *target ) {
-  struct network_target *net_target;
-
-  clear_error(  );
+  const struct network_target *net_target;
 
   if( !target ) {
     raise_argument_empty( "target is NULL" );
@@ -343,6 +341,7 @@ stumpless_get_destination( const struct stumpless_target *target ) {
     goto fail;
   }
 
+  clear_error(  );
   net_target = target->id;
   return net_target->destination;
 
@@ -352,9 +351,7 @@ fail:
 
 const char *
 stumpless_get_transport_port( const struct stumpless_target *target ) {
-  struct network_target *net_target;
-
-  clear_error(  );
+  const struct network_target *net_target;
 
   if( !target ) {
     raise_argument_empty( "target is NULL" );
@@ -367,6 +364,7 @@ stumpless_get_transport_port( const struct stumpless_target *target ) {
     goto fail;
   }
 
+  clear_error(  );
   net_target = target->id;
   return net_target->port;
 
@@ -376,9 +374,7 @@ fail:
 
 size_t
 stumpless_get_udp_max_message_size( struct stumpless_target *target ) {
-  struct network_target *net_target;
-
-  clear_error(  );
+  const struct network_target *net_target;
 
   if( !target ) {
     raise_argument_empty( "target is NULL" );
@@ -397,6 +393,7 @@ stumpless_get_udp_max_message_size( struct stumpless_target *target ) {
     goto fail;
   }
 
+  clear_error(  );
   return net_target->max_msg_size;
 
 fail:
@@ -579,9 +576,7 @@ stumpless_set_destination( struct stumpless_target *target,
                            const char *destination ) {
   const char *destination_copy;
   struct network_target *net_target;
-  struct network_target *result;
-
-  clear_error(  );
+  const struct network_target *result;
 
   if( !target ) {
     raise_argument_empty( "target is NULL" );
@@ -616,6 +611,7 @@ stumpless_set_destination( struct stumpless_target *target,
     }
   }
 
+  clear_error(  );
   return target;
 
 fail:
@@ -627,7 +623,7 @@ stumpless_set_transport_port( struct stumpless_target *target,
                               const char *port ) {
   struct network_target *net_target;
   const char *port_copy;
-  void *result;
+  const struct network_target *result;
 
   clear_error(  );
 
@@ -775,7 +771,7 @@ fail:
 
 struct stumpless_target *
 open_network_target( struct stumpless_target *target ) {
-  struct network_target *result;
+  const struct network_target *result;
 
   result = open_private_network_target( target->id );
   if( result ) {
@@ -792,7 +788,7 @@ open_new_network_target( const char *destination,
                          enum stumpless_network_protocol network,
                          enum stumpless_transport_protocol transport ) {
   struct network_target *target;
-  struct network_target *open_result;
+  const struct network_target *open_result;
 
   target = new_network_target( network, transport );
   if( !target ) {

--- a/src/target/network.c
+++ b/src/target/network.c
@@ -702,7 +702,7 @@ fail:
 /* private definitions */
 
 void
-destroy_network_target( struct network_target *target ) {
+destroy_network_target( const struct network_target *target ) {
 
   if( target->network == STUMPLESS_IPV4_NETWORK_PROTOCOL ) {
     destroy_ipv4_target( target );

--- a/src/target/network.c
+++ b/src/target/network.c
@@ -314,7 +314,7 @@ sendto_udp_target( struct network_target *target,
 /* public definitions */
 
 void
-stumpless_close_network_target( struct stumpless_target *target ) {
+stumpless_close_network_target( const struct stumpless_target *target ) {
   clear_error(  );
 
   if( !target ) {

--- a/src/target/network.c
+++ b/src/target/network.c
@@ -39,7 +39,7 @@ static size_t tcp_send_buffer_length = 0;
 
 static
 void
-destroy_ipv4_target( struct network_target *target ) {
+destroy_ipv4_target( const struct network_target *target ) {
 
   if( target->transport == STUMPLESS_TCP_TRANSPORT_PROTOCOL ) {
     config_close_tcp4_target( target );
@@ -52,7 +52,7 @@ destroy_ipv4_target( struct network_target *target ) {
 
 static
 void
-destroy_ipv6_target( struct network_target *target ) {
+destroy_ipv6_target( const struct network_target *target ) {
 
   if( target->transport == STUMPLESS_TCP_TRANSPORT_PROTOCOL ) {
     config_close_tcp6_target( target );
@@ -373,7 +373,7 @@ fail:
 }
 
 size_t
-stumpless_get_udp_max_message_size( struct stumpless_target *target ) {
+stumpless_get_udp_max_message_size( const struct stumpless_target *target ) {
   const struct network_target *net_target;
 
   if( !target ) {

--- a/src/target/socket.c
+++ b/src/target/socket.c
@@ -109,7 +109,7 @@ fail:
 /* private definitions */
 
 void
-destroy_socket_target( struct socket_target *trgt ) {
+destroy_socket_target( const struct socket_target *trgt ) {
   if( !trgt ) {
     return;
   }
@@ -178,7 +178,7 @@ sendto_socket_target( const struct socket_target *target,
                   msg,
                   msg_length,
                   0,
-                  ( struct sockaddr * ) &target->target_addr,
+                  ( const struct sockaddr * ) &target->target_addr,
                   target->target_addr_len );
 
   if( result == -1 ) {

--- a/src/target/socket.c
+++ b/src/target/socket.c
@@ -31,7 +31,7 @@
 #include "private/target/socket.h"
 
 void
-stumpless_close_socket_target( struct stumpless_target *target ) {
+stumpless_close_socket_target( const struct stumpless_target *target ) {
   if( !target ) {
     raise_argument_empty( "target is NULL" );
     return;

--- a/src/target/stream.c
+++ b/src/target/stream.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ fail:
 /* private definitions */
 
 void
-destroy_stream_target( struct stream_target *target ) {
+destroy_stream_target( const struct stream_target *target ) {
   free_mem( target );
 }
 

--- a/src/target/stream.c
+++ b/src/target/stream.c
@@ -27,14 +27,13 @@
 #include "private/target/stream.h"
 
 void
-stumpless_close_stream_target( struct stumpless_target *target ) {
-  clear_error(  );
-
+stumpless_close_stream_target( const struct stumpless_target *target ) {
   if( !target ) {
     raise_argument_empty( "target is NULL" );
     return;
   }
 
+  clear_error(  );
   destroy_stream_target( target->id );
   destroy_target( target );
 }


### PR DESCRIPTION
Several function signatures and local variables did not have a const qualifier where they could, which is generally bad practice and could miss some compiler optimizations. This change adds them where appropriate, and also cleans up some type casts that were stale.
