### PR TITLE
update travis ci link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stumpless
 
-[![Travis Build Status](https://travis-ci.org/goatshriek/stumpless.svg?branch=latest)](https://travis-ci.org/goatshriek/stumpless)
+[![Travis Build Status](https://travis-ci.com/goatshriek/stumpless.svg?branch=latest)](https://travis-ci.com/goatshriek/stumpless)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/uwied5cn5jujl4d2/branch/latest?svg=true)](https://ci.appveyor.com/project/goatshriek/stumpless)
 [![Coverage Report](https://codecov.io/gh/goatshriek/stumpless/branch/latest/graph/badge.svg)](https://codecov.io/gh/goatshriek/stumpless)
 [![SonarCloud Status](https://sonarcloud.io/api/project_badges/measure?project=stumpless&metric=alert_status)](https://sonarcloud.io/dashboard?id=stumpless)


### PR DESCRIPTION
With the migration from `travis-ci.org` to `travis-ci.com`, some links need to be updated to reflect the new domain.