### PR TITLE
add missing const qualifier to winsock

### DIFF
--- a/include/private/config/have_winsock2.h
+++ b/include/private/config/have_winsock2.h
@@ -24,7 +24,7 @@
 #  include "private/target/network.h"
 
 void
-winsock2_close_network_target( struct network_target *target );
+winsock2_close_network_target( const struct network_target *target );
 
 void
 winsock2_cleanup( void );

--- a/src/config/have_winsock2.c
+++ b/src/config/have_winsock2.c
@@ -94,7 +94,7 @@ fail:
 }
 
 void
-winsock2_close_network_target( struct network_target *target ) {
+winsock2_close_network_target( const struct network_target *target ) {
   closesocket( target->handle );
 }
 


### PR DESCRIPTION
Add a missing const qualifier to the winsock target handler in order to correct compilation warnings.