### PR TITLE
improve stumpless_copy_element performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -791,6 +791,10 @@ add_custom_target(examples
 
 
 # performance tests
+add_performance_test(element
+  SOURCES test/performance/element.cpp
+)
+
 add_performance_test(entry
   SOURCES test/performance/entry.cpp
 )

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -83,7 +83,7 @@ static void CopyElement(benchmark::State& state){
   state.counters["CallsToFree"] = ( double ) copy_element_memory_counter.free_count;
   state.counters["MemoryFreed"] = ( double ) copy_element_memory_counter.free_total;
 }
-``` 
+```
 
 We can run this specific test with the following command, which will build the
 test if necessary and then execute it.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -85,8 +85,20 @@ static void CopyElement(benchmark::State& state){
 }
 ``` 
 
-pick up here.
+We can run this specific test with the following command, which will build the
+test if necessary and then execute it.
+
+```sh
+make performance-test-element && ./performance-test-element --benchmark_filter=CopyElement
+
+# sample output
+
+```
+
+If you got an error about the library being built as DEBUG, make sure that you
+pass the `-DCMAKE_BUILD_TYPE=Release` argument to cmake when you are building
+stumpless.
 
 This is a real example of an actual improvement made to stumpless, so if you
 want to see any of the tests or code in detail you can simply look at them in
-the source tree. The benchmark itself is in `test\performance\element.cpp`.
+the source tree.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -143,8 +143,8 @@ make performance-test-element && ./performance-test-element --benchmark_filter=C
 ```
 
 We immediately see that the number of calls to `realloc` dropped significantly,
-and the calls to `alloc` only moderately increased. The execution time is also
-lower, so we can declare success!
+and is clearly no longer tied to calls to CopyElement. The execution time is
+also lower, so we can declare success!
 
 If you run a number of benchmarks at once and want to compare all of the
 results, manually comparing this output can get difficult. Google Benchmark
@@ -189,11 +189,16 @@ python3 compare.py benchmarks ../../../../old.json ../../../../new.json
 ```
 
 This execution tells us that we have reduced the execution time of the function
-by just over 17 percent.
+by just over 17 percent. Note that the numbers are slightly different from our
+previous executions, but that the general trend still holds true. This relative
+nature is exactly why benchmark test results are only relevant when executed on
+the same machine in the same environment, under the same load if at all 
+possible.
 
 You can also pass the compare script two performance test executables, if you
-have them. However, if you implemented a new benchmark for your change then
-this method works as well.
+have them, and bypass the json output steps. However, if you implemented a new
+benchmark for your change then the latest build tree may not have a test, and
+you can simply rely on the above method.
 
 This is a real example of an actual improvement made to stumpless, so if you
 want to see any of the tests or code in detail you can simply look at them in

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -151,7 +151,9 @@ results, manually comparing this output can get difficult. Google Benchmark
 provides a python script in the `tools` folder that makes this much easier.
 In a normal build tree this is in `benchmark/src/benchmark/tools/`, and it is
 exported by the `export-benchmark` build target if you are using
-`BENCHMARK_PATH`.
+`BENCHMARK_PATH` (see the
+[development notes](https://github.com/goatshriek/stumpless/blob/latest/docs/development.md)
+for details on this option).
 
 Running the script is straightforward, as you simply need to export JSON output
 from each benchmark execution and then compare the results. If you want more
@@ -168,12 +170,12 @@ test, run it once with each library version, and then compare the results.
 make performance-test-element
 
 # run the test with our changes
-./performance-test-element --benchmark_filter=CopyElement --benchmark_output=new.json --benchmark_output_format=json
+./performance-test-element --benchmark_filter=CopyElement --benchmark_out=new.json --benchmark_out_format=json
 
 # and then swap out the library and run it again
 rm libstumpless.so.2.0.0
 cp ../build-latest/libstumpless.so.2.0.0 ./
-./performance-test-element --benchmark_filter=CopyElement --benchmark_output=old.json --benchmark_output_format=json
+./performance-test-element --benchmark_filter=CopyElement --benchmark_out=old.json --benchmark_out_format=json
 
 # compare results with the Google Benchmark tool
 cd benchmark/src/benchmark/tools
@@ -185,6 +187,13 @@ python3 compare.py benchmarks ../../../../old.json ../../../../new.json
 # ----------------------------------------------------------------------------------------------------------
 # CopyElement                -0.1791         -0.1747           663           545           663           547
 ```
+
+This execution tells us that we have reduced the execution time of the function
+by just over 17 percent.
+
+You can also pass the compare script two performance test executables, if you
+have them. However, if you implemented a new benchmark for your change then
+this method works as well.
 
 This is a real example of an actual improvement made to stumpless, so if you
 want to see any of the tests or code in detail you can simply look at them in

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,18 @@
+# Benchmark Testing with Stumpless
+
+High performance and efficiency is a core pillar of stumpless design, and as
+such a benchmarking framework is available to assist with this. This framework
+uses the [Google Benchmark](https://github.com/google/benchmark) library to
+measure execution time and other efficiency characteristics.
+
+Performance tests are named `performance-test-<item>` for various pieces of the
+library. You can use the `bench` target to build and execute all performance
+tests at once, or just the name of the executable if you only want to measure
+a single module.
+
+## Walkthrough: Improving `stumpless_copy_element`
+
+Walking through a benchmarking improvement change from beginning to end
+demonstrates all of these principles and how they are used to implement an
+actual improvement to the library. Let's analyze an improvement to the
+performance of `stumpless_copy_element` to do this.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -10,6 +10,13 @@ library. You can use the `bench` target to build and execute all performance
 tests at once, or just the name of the executable if you only want to measure
 a single module.
 
+Performance tests are NOT intended to be an absolute measurement of the
+performance of a function or the library as a whole. They are only useful for
+measuring the relative performance between two versions of code on the same
+machine in the same environment. This is why you will not see performance
+test results posted in any documentation. The results are only useful when
+compared to one another, typically during development of some change.
+
 ## Walkthrough: Improving `stumpless_copy_element`
 
 Walking through a benchmarking improvement change from beginning to end

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -23,3 +23,70 @@ Walking through a benchmarking improvement change from beginning to end
 demonstrates all of these principles and how they are used to implement an
 actual improvement to the library. Let's analyze an improvement to the
 performance of `stumpless_copy_element` to do this.
+
+An early version of `stumpless_copy_element` iterated through all of the
+params in the element, adding them to the copy one by one. The code for this
+looked like this snippet, which has been abbreviated to focus on the performance
+of the code:
+
+```c
+// first create a new element
+copy = stumpless_new_element( stumpless_get_element_name( element ) );
+
+// then handle all of the parameters
+for( i = 0; i < element->param_count; i++ ) {
+  // copy the parameter
+  param_copy = stumpless_copy_param( element->params[i] );
+
+  // and then add it
+  stumpless_add_param( copy, param_copy );
+}
+```
+
+While it is logical and easy to follow, this method is inefficient because
+`stumpless_add_param` reallocates the underlying array each time it is called.
+This means that the same piece of memory could be reallocated several times in
+a single call, increasing execution time and putting pressure on the memory
+manager. Let's change it to instead allocate the memory up front.
+
+Before we make any changes to the code itself, let's implement a benchmark test
+to measure the performance of the code as is. Our test code looks like this:
+
+```cpp
+static void CopyElement(benchmark::State& state){
+  struct stumpless_element *element;
+  const struct stumpless_element *result;
+
+  INIT_MEMORY_COUNTER( copy_element );
+  stumpless_set_malloc( copy_element_memory_counter_malloc );
+  stumpless_set_realloc( copy_element_memory_counter_realloc );
+  stumpless_set_free( copy_element_memory_counter_free );
+
+  element = stumpless_new_element( "copy-element-perf" );
+  stumpless_add_new_param( element, "param-1", "value-1" );
+  stumpless_add_new_param( element, "param-2", "value-2" );
+
+  for(auto _ : state){
+    result = stumpless_copy_element( element );
+    if( result <= 0 ) {
+      state.SkipWithError( "could not send an entry to the target" );
+    } else {
+      stumpless_destroy_element_and_contents( result );
+    }
+  }
+
+  stumpless_destroy_element_and_contents( element );
+
+  state.counters["CallsToAlloc"] = ( double ) copy_element_memory_counter.malloc_count;
+  state.counters["MemoryAllocated"] = ( double ) copy_element_memory_counter.alloc_total;
+  state.counters["CallsToRealloc"] = ( double ) copy_element_memory_counter.realloc_count;
+  state.counters["CallsToFree"] = ( double ) copy_element_memory_counter.free_count;
+  state.counters["MemoryFreed"] = ( double ) copy_element_memory_counter.free_total;
+}
+``` 
+
+pick up here.
+
+This is a real example of an actual improvement made to stumpless, so if you
+want to see any of the tests or code in detail you can simply look at them in
+the source tree. The benchmark itself is in `test\performance\element.cpp`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,3 +62,10 @@ cp -r gtest/src/gtest/googletest/include/ ../../gtestd/googletest/include/
 # then, on your next build, you could do this instead:
 mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DGTEST_PATH=../../gtestd ..
 ```
+
+## Other development notes
+
+For a detailed discussion of the performance testing framework used to gauge
+the speed and efficiency of various calls, check out the
+[benchmark](https://github.com/goatshriek/stumpless/blob/latest/docs/benchmark.md)
+documentation for the basic strategy and a full walkthrough of an example.

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,56 +11,70 @@ it will quickly become tedious to wait for the Google Test and/or Benchmark
 libraries to download and build each time as well. As an alternative, you can
 put a build of the libraries in some other location and simply tell the build
 process to use those instead using the `GTEST_PATH` and `BENCHMARK_PATH` build
-parameters. The following examples are for `GTEST_PATH`, but the same principles
-apply for `BENCHMARK_PATH` as well.
+parameters.
 
-This snippet shows how to download a fresh copy of Google Test via the hash,
-unzip it, and build it.
+You could download and build the library yourself, which may be the best course
+of action if you plan to re-use the build for other projects. If you do this,
+you just need to make sure that the correct libraries (in the case of gtest,
+`gtest`, `gtest_main`, and `gmock`) and headers (`gtest/gtest.h` and
+`gmock/gmock.h`) are found at the given path. If they are, then they will be
+used and gtest will not be downloaded and built again. If _any_ of them are
+missing though, a fresh copy will be downloaded and used anyway, so make sure
+everything is there!
 
-```sh
-wget https://github.com/google/googletest/archive/6f5fd0d7199b9a19faa9f499ecc266e6ae0329e7.zip
-unzip 6f5fd0d7199b9a19faa9f499ecc266e6ae0329e7.zip
-mv googletest-6f5fd0d7199b9a19faa9f499ecc266e6ae0329e7/ gtest/
-cd gtest
-cmake -Dgtest_force_shared_crt=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release .
-```
-
-Note that this uses a few flags that mirror what Stumpless uses to build of a
-freshly downloaded copy. The build type should match what you use in your own
-builds of Stumpless, so if you need one Release and one for Debug, simply repeat
-this process with two directories. `gtest` and `gtestd`, perhaps?
-
-When you build Stumpless itself, simply pass in the `GTEST_PATH` parameter,
-like so:
+Since downloading and building can be a pain, especially multiple times for 
+different build types, stumpless provides two build targets that will export
+built libraries for you to the path. This way, all you need to do is build
+stumpless as you would normally, and then use the `export-gtest` and/or
+`export-benchmark` targets to populate the path for future builds. This would
+look something like this (if you're using a `make` build system):
 
 ```sh
-mkdir build && cd build
-cmake -DGTEST_PATH=/path/to/built/gtest ../
-```
+# from the directory above your repo
+# just adjust the paths accordingly if you build somewhere else
 
-As long as the correct libraries (`gtest`, `gtest_main`, and `gmock`) and
-headers (`gtest/gtest.h` and `gmock/gmock.h`) are found at the given path, then
-they will be used and gtest will not be downloaded and built again. If _any_ of
-them are missing though, a fresh copy will be downloaded and used anyway, so
-make sure everything is there!
+# first we set up our folders to hold the libraries
+mkdir gtest
+mkdir benchmark
 
-If you don't want to download a version and build it yourself, you can copy the
-result of a normal build out into a separate directory and use it going forward.
-An example of this strategy would look like this:
+# next, we build the library as normal
+mkdir biuld
+cd build
+cmake -DGTEST_PATH=../gtest -DBENCHMARK_PATH=../benchmark ../stumpless
 
-```sh
-mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug ..
-make gtest # download and build gtest
+# in this build Google Test and Benchmark will be downloaded and built since
+# the paths we provided don't have anything in them
+make check
+make bench
 
-# copy the built libraries
-cp -r gtest/src/gtest-build/ ../../gtestd
+# to build the libraries and put them in the path for future builds, we just
+# execute these two targets:
+make export-gtest
+make export-benchmark
 
-# copy the required headers
-cp -r gtest/src/gtest/googlemock/include/ ../../gtestd/googlemock/include/
-cp -r gtest/src/gtest/googletest/include/ ../../gtestd/googletest/include/
+# these list commands show that the folders are now populated!
+ls ../gtest
+ls ../benchmark
 
-# then, on your next build, you could do this instead:
-mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DGTEST_PATH=../../gtestd ..
+# next time, you can use the exact same cmake command to use the previously
+# built versions instead of downloading fresh
+
+# if you want to try it out immediately:
+cd ..
+
+# clear out the previous build
+rm -rf build
+
+# and redo it!
+mkdir biuld
+cd build
+cmake -DGTEST_PATH=../gtest -DBENCHMARK_PATH=../benchmark ../stumpless
+
+# running the test suite or benchmark suite won't download the libraries this
+# time - it will go straight to compiling the tests and linking them against
+# the libraries in the PATH variables
+make check
+make bench
 ```
 
 ## Other development notes

--- a/src/element.c
+++ b/src/element.c
@@ -85,16 +85,19 @@ stumpless_copy_element( const struct stumpless_element *element ) {
     goto fail;
   }
 
+  copy->params = alloc_mem( element->param_count * sizeof( param_copy ) );
+  if( !copy->params ) {
+    goto fail_param_copy;
+  }
+
   for( i = 0; i < element->param_count; i++ ) {
     param_copy = stumpless_copy_param( element->params[i] );
     if( !param_copy ) {
       goto fail_param_copy;
     }
 
-    add_result = stumpless_add_param( copy, param_copy );
-    if( !add_result ) {
-      goto fail_param_copy;
-    }
+    copy->params[i] = param_copy;
+    copy->param_count++;
   }
 
   return copy;

--- a/src/element.c
+++ b/src/element.c
@@ -78,7 +78,6 @@ stumpless_copy_element( const struct stumpless_element *element ) {
   struct stumpless_element *copy;
   size_t i;
   struct stumpless_param *param_copy;
-  const struct stumpless_element *add_result;
 
   copy = stumpless_new_element( stumpless_get_element_name( element ) );
   if( !copy ) {

--- a/test/function/element.cpp
+++ b/test/function/element.cpp
@@ -248,11 +248,12 @@ namespace {
     ASSERT_NOT_NULL( set_realloc_result );
 
     result = stumpless_copy_element( element_with_params );
-    EXPECT_NULL( result );
-
-    EXPECT_ERROR_ID_EQ( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
+    EXPECT_NO_ERROR;
+    EXPECT_NE( result, element_with_params );
 
     stumpless_set_realloc( realloc );
+
+    stumpless_destroy_element_and_contents( result );
   }
 
   TEST_F( ElementTest, CopyWithoutParams ) {

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -335,10 +335,12 @@ namespace {
     ASSERT_NOT_NULL( set_realloc_result );
 
     result = stumpless_copy_entry( basic_entry );
-    EXPECT_ERROR_ID_EQ( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
-    EXPECT_NULL( result );
+    EXPECT_NO_ERROR;
+    EXPECT_NE( result, basic_entry );
 
     stumpless_set_realloc( realloc );
+
+    stumpless_destroy_entry_and_contents( result );
   }
 
   TEST_F( EntryTest, GetAppName ) {

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -335,12 +335,17 @@ namespace {
     ASSERT_NOT_NULL( set_realloc_result );
 
     result = stumpless_copy_entry( basic_entry );
-    EXPECT_NO_ERROR;
-    EXPECT_NE( result, basic_entry );
+
+    if( !result ) {
+      EXPECT_ERROR_ID_EQ( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
+    } else {
+      EXPECT_NO_ERROR;
+      EXPECT_NE( result, basic_entry );
+      stumpless_destroy_entry_and_contents( result );
+    }
 
     stumpless_set_realloc( realloc );
 
-    stumpless_destroy_entry_and_contents( result );
   }
 
   TEST_F( EntryTest, GetAppName ) {

--- a/test/performance/element.cpp
+++ b/test/performance/element.cpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2020 Joel E. Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <benchmark/benchmark.h>
+#include <stumpless.h>
+#include "test/helper/memory_counter.hpp"
+
+NEW_MEMORY_COUNTER( copy_element )
+
+static void CopyElement(benchmark::State& state){
+  struct stumpless_element *element;
+  const struct stumpless_element *result;
+
+  INIT_MEMORY_COUNTER( copy_element );
+  stumpless_set_malloc( copy_element_memory_counter_malloc );
+  stumpless_set_realloc( copy_element_memory_counter_realloc );
+  stumpless_set_free( copy_element_memory_counter_free );
+
+  element = stumpless_new_element( "copy-element-perf" );
+  stumpless_add_new_param( element, "param-1", "value-1" );
+  stumpless_add_new_param( element, "param-2", "value-2" );
+
+  for(auto _ : state){
+    result = stumpless_copy_element( element );
+    if( result <= 0 ) {
+      state.SkipWithError( "could not send an entry to the target" );
+    } else {
+      stumpless_destroy_element_and_contents( result );
+    }
+  }
+
+  stumpless_destroy_element_and_contents( element );
+
+  state.counters["CallsToAlloc"] = ( double ) copy_element_memory_counter.malloc_count;
+  state.counters["MemoryAllocated"] = ( double ) copy_element_memory_counter.alloc_total;
+  state.counters["CallsToRealloc"] = ( double ) copy_element_memory_counter.realloc_count;
+  state.counters["CallsToFree"] = ( double ) copy_element_memory_counter.free_count;
+  state.counters["MemoryFreed"] = ( double ) copy_element_memory_counter.free_total;
+}
+
+BENCHMARK(CopyElement);

--- a/tools/cmake/benchmark.cmake
+++ b/tools/cmake/benchmark.cmake
@@ -69,6 +69,7 @@ if(${benchmark_lib} STREQUAL "benchmark_lib-NOTFOUND" OR ${benchmark_main_lib} S
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${local_benchmark_binary_dir} ${BENCHMARK_PATH}
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${local_benchmark_static_dir} ${BENCHMARK_PATH}
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${source_dir}/include" ${BENCHMARK_PATH}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${source_dir}/tools" "${BENCHMARK_PATH}/tools"
     DEPENDS benchmark
   )
 else()


### PR DESCRIPTION
The `stumpless_copy_element` function made several calls to `realloc` in a single invocation, once for each param in the original element. This was inefficient, and has been changed to allocate the array for params once before each param is copied, reducing the number of memory management calls and the number of error checks needed during execution.