### PR TITLE
Added stumpless_version_cmp

### DIFF
--- a/include/stumpless/version.h
+++ b/include/stumpless/version.h
@@ -45,6 +45,21 @@ struct stumpless_version *
 stumpless_get_version( void );
 
 /**
+ * Compares the version of two given stumpless_version struct.
+ * @param version_x,version_y Two given version(const) to be compared.
+ * `
+ * @return 0 if version numbers are the same, <br />
+ *         1 if version_y->patch > version_x->patch,   <br />
+ *         10 if version_y->minor > version_x->minor,  <br />
+ *         100 if version_y->major > version_x->major, <br />
+ *         666 if one of the version pointers is null. <br />
+ */
+int
+stumpless_version_cmp( const struct stumpless_version * version_x, 
+                        const struct stumpless_version * version_y);
+
+
+/**
  * Creates a string representation of the given version.
  *
  * This string will be NULL-terminated, and will appear in the standard

--- a/include/stumpless/version.h
+++ b/include/stumpless/version.h
@@ -45,18 +45,21 @@ struct stumpless_version *
 stumpless_get_version( void );
 
 /**
- * Compares the version of two given stumpless_version struct.
+ * Compares the version of two given stumpless_version struct. 
+ * 
+ * This function make use of a similar convention used by the standard library's strcmp function.
+ * 
  * @param version_x,version_y Two given version(const) to be compared.
- * `
- * @return 0 if version numbers are the same, <br />
- *         1 if version_y->patch > version_x->patch,   <br />
- *         10 if version_y->minor > version_x->minor,  <br />
- *         100 if version_y->major > version_x->major, <br />
- *         666 if one of the version pointers is null. <br />
+ * 
+ * @return 0 if version numbers are the same,                           <br />
+ *         1 if version_x->patch - version_y->patch > 0,    -1   if < 0 <br />
+ *         10 if version_x->minor - version_y->minor > 0,   -10  if < 0 <br />
+ *         100 if version_x->major - version_y->major > 0,  -100 if < 0 <br />
+ *         INT_MAX if one of the version pointers is null.              <br />
  */
 int
 stumpless_version_cmp( const struct stumpless_version * version_x, 
-                        const struct stumpless_version * version_y);
+                       const struct stumpless_version * version_y );
 
 
 /**

--- a/src/version.c
+++ b/src/version.c
@@ -41,6 +41,31 @@ stumpless_get_version( void ) {
   return version;
 }
 
+int
+stumpless_version_cmp ( const struct stumpless_version * version_x, 
+                         const struct stumpless_version * version_y) {
+  if ( version_x == NULL || version_y == NULL ) {
+    return 666;
+  }
+  
+  if( version_y->major != version_x->major ) {
+    return ( version_y->major - version_x->major )/
+	    ( version_y->major - version_x->major ) * 100;
+  }
+  
+  if( version_y->minor != version_x->minor ) {
+    return ( version_y->minor - version_x->minor )/
+	    ( version_y->minor - version_x->minor ) * 10;
+  }
+  
+  if( version_y->patch != version_x->patch ) {
+    return ( version_y->patch - version_x->patch )/
+	    ( version_y->patch - version_x->patch ) * 1;
+  }
+
+  return 0;
+}
+
 char *
 stumpless_version_to_string( const struct stumpless_version *version ) {
   struct strbuilder *builder;

--- a/src/version.c
+++ b/src/version.c
@@ -17,7 +17,6 @@
  */
 
 #include <stddef.h>
-#include <stdlib.h>
 #include <limits.h>
 #include <stumpless/config.h>
 #include <stumpless/version.h>

--- a/src/version.c
+++ b/src/version.c
@@ -17,6 +17,8 @@
  */
 
 #include <stddef.h>
+#include <stdlib.h>
+#include <limits.h>
 #include <stumpless/config.h>
 #include <stumpless/version.h>
 #include "private/error.h"
@@ -43,24 +45,25 @@ stumpless_get_version( void ) {
 
 int
 stumpless_version_cmp ( const struct stumpless_version * version_x, 
-                         const struct stumpless_version * version_y) {
+                        const struct stumpless_version * version_y ) {
   if ( version_x == NULL || version_y == NULL ) {
-    return 666;
+    raise_argument_empty( "NULL version struct given." );
+    return INT_MAX;
   }
   
-  if( version_y->major != version_x->major ) {
-    return ( version_y->major - version_x->major )/
-	    ( version_y->major - version_x->major ) * 100;
+  if( version_x->major != version_y->major ) {
+    return ( version_x->major - version_y->major )/
+	    abs( version_x->major - version_y->major ) * 100;
   }
   
   if( version_y->minor != version_x->minor ) {
-    return ( version_y->minor - version_x->minor )/
-	    ( version_y->minor - version_x->minor ) * 10;
+    return ( version_x->minor - version_y->minor )/
+	    abs( version_x->minor - version_y->minor ) * 10;
   }
   
-  if( version_y->patch != version_x->patch ) {
-    return ( version_y->patch - version_x->patch )/
-	    ( version_y->patch - version_x->patch ) * 1;
+  if( version_x->patch != version_y->patch ) {
+    return ( version_x->patch - version_y->patch )/
+	    abs( version_x->patch - version_y->patch );
   }
 
   return 0;

--- a/src/version.c
+++ b/src/version.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <stdlib.h>
 #include <stddef.h>
 #include <limits.h>
 #include <stumpless/config.h>

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -137,3 +137,4 @@ EXPORTS
   stump                                         @134
   vstump                                        @135
   stumpless_get_error_id_string                 @136
+  stumpless_version_cmp                         @137

--- a/test/function/version.cpp
+++ b/test/function/version.cpp
@@ -105,21 +105,21 @@ namespace {
     struct stumpless_version version_x = {1, 5, 0};
     struct stumpless_version version_y = {1, 6, 0};
 
-    EXPECT_EQ( stumpless_version_cmp( &version_x, &version_y ), 10 );
+    EXPECT_EQ( stumpless_version_cmp( &version_x, &version_y ), -10 );
   }
 
   TEST( VersionCmp, BasicMajor ) {
     struct stumpless_version version_x = {1, 5, 0};
     struct stumpless_version version_y = {2, 6, 0};
 
-    EXPECT_EQ( stumpless_version_cmp( &version_x, &version_y ), 100 );
+    EXPECT_EQ( stumpless_version_cmp( &version_x, &version_y ), -100 );
   }
 
   TEST( VersionCmp, NullVersion ) {
     struct stumpless_version version_x = {1, 5, 0};
     struct stumpless_version * version_y = NULL;
 
-    EXPECT_EQ( stumpless_version_cmp( &version_x, version_y ), 666 );
+    EXPECT_EQ( stumpless_version_cmp( &version_x, version_y ), INT_MAX );
   }
 
   TEST( VersionToString, Basic ) {

--- a/test/function/version.cpp
+++ b/test/function/version.cpp
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <limits.h>
 #include <cstddef>
 #include <cstdlib>
 #include <gmock/gmock.h>

--- a/test/function/version.cpp
+++ b/test/function/version.cpp
@@ -87,6 +87,41 @@ namespace {
     stumpless_set_malloc( malloc );
   }
 
+  TEST( VersionCmp, BasicSame ) {
+    struct stumpless_version version_x = {1, 5, 0};
+    struct stumpless_version version_y = {1, 5, 0};
+
+    EXPECT_EQ( stumpless_version_cmp( &version_x, &version_y ), 0 );
+  }
+
+  TEST( VersionCmp, BasicPatch ) {
+    struct stumpless_version version_x = {1, 5, 2};
+    struct stumpless_version version_y = {1, 5, 1};
+
+    EXPECT_EQ( stumpless_version_cmp( &version_x, &version_y ), 1 );
+  }
+
+  TEST( VersionCmp, BasicMinor ) {
+    struct stumpless_version version_x = {1, 5, 0};
+    struct stumpless_version version_y = {1, 6, 0};
+
+    EXPECT_EQ( stumpless_version_cmp( &version_x, &version_y ), 10 );
+  }
+
+  TEST( VersionCmp, BasicMajor ) {
+    struct stumpless_version version_x = {1, 5, 0};
+    struct stumpless_version version_y = {2, 6, 0};
+
+    EXPECT_EQ( stumpless_version_cmp( &version_x, &version_y ), 100 );
+  }
+
+  TEST( VersionCmp, NullVersion ) {
+    struct stumpless_version version_x = {1, 5, 0};
+    struct stumpless_version * version_y = NULL;
+
+    EXPECT_EQ( stumpless_version_cmp( &version_x, version_y ), 666 );
+  }
+
   TEST( VersionToString, Basic ) {
     struct stumpless_version version = {1, 5, 0};
     char *string_result;

--- a/tools/check_headers/stumpless.yml
+++ b/tools/check_headers/stumpless.yml
@@ -343,6 +343,7 @@
 "STUMPLESS_UDP_TRANSPORT_PROTOCOL": "stumpless/target/network.h"
 "stumpless_unset_option": "stumpless/target.h"
 "STUMPLESS_VERSION": "stumpless/config.h"
+"abs": "stdlib.h"
 "stumpless_version_to_string": "stumpless/version.h"
 "STUMPLESS_WINDOWS_EVENT_LOG_TARGET": "stumpless/target.h"
 "STUMPLESS_WINDOWS_EVENT_LOG_CLOSE_FAILURE": "stumpless/error.h"


### PR DESCRIPTION
This should fix #98 .

1. Added `stumpless_version_cmp`
 And its docs.

2. Added entry in `src/windows/stumpless.def`

3. Added test for `stumpless_version_cmp`
Null version case and basic test case.