### PR TITLE
cleanup leftover sockets after test suite

### DIFF
--- a/include/stumpless/memory.h
+++ b/include/stumpless/memory.h
@@ -37,14 +37,15 @@ extern "C" {
 #  endif
 
 /**
- * Frees all memory allocated internally, and performs any other necessary
- * cleanup.
+ * Closes the default target if it has been opened, frees all memory allocated
+ * internally, and performs any other necessary cleanup.
  *
  * This function serves as a final exit function, which should be called when
  * an application using the library is preparing to exit or when the library is
- * no longer needed. Before this function is called, all targets must be closed
- * and no pointers to any structs should be retained. Failing to do this will
- * result in undefined behavior.
+ * no longer needed. Before this function is called, all targets explicitly
+ * opened must be closed (with the exception of the default target, which is
+ * opened implicitly) and no pointers to any structs should be retained. Failing
+ * to do this will result in undefined behavior.
  *
  * Calling other functions after a call to this function is acceptable, however
  * execution times may be longer than usual as memory used to cache objects may

--- a/test/function/target/buffer.cpp
+++ b/test/function/target/buffer.cpp
@@ -196,6 +196,8 @@ namespace {
                stumpless_get_default_target(  ) );
     EXPECT_STRNE( stumpless_get_current_target(  )->name,
                   target_name );
+
+    stumpless_free_all(  );
   }
 
   TEST( BufferTargetCloseTest, NullTarget ) {

--- a/test/function/target/file.cpp
+++ b/test/function/target/file.cpp
@@ -95,6 +95,8 @@ namespace {
                stumpless_get_default_target(  ) );
     EXPECT_STRNE( stumpless_get_current_target(  )->name,
                   filename );
+
+    stumpless_free_all(  );
   }
 
   TEST( FileTargetCloseTest, NullTarget ) {

--- a/test/function/target/network.cpp
+++ b/test/function/target/network.cpp
@@ -61,6 +61,8 @@ namespace {
                stumpless_get_default_target(  ) );
     EXPECT_STRNE( stumpless_get_current_target(  )->name,
                   target_name );
+
+    stumpless_free_all(  );
   }
 
   TEST( NetworkTargetCloseTest, NullTarget ) {

--- a/test/function/target/socket.cpp
+++ b/test/function/target/socket.cpp
@@ -208,6 +208,8 @@ namespace {
                stumpless_get_default_target(  ) );
     EXPECT_STRNE( stumpless_get_current_target(  )->name,
                   target_name );
+
+    stumpless_free_all(  );
   }
 
   TEST( SocketTargetCloseTest, NullTarget ) {

--- a/test/function/target/stream.cpp
+++ b/test/function/target/stream.cpp
@@ -103,6 +103,8 @@ namespace {
                stumpless_get_default_target(  ) );
     EXPECT_STRNE( stumpless_get_current_target(  )->name,
                   filename );
+
+    stumpless_free_all(  );
   }
 
   TEST( StreamTargetCloseTest, NullTarget ) {


### PR DESCRIPTION
When running the test suite, several local sockets were left behind due to a failure of certain tests to clean up after opening the default target as a byproduct of some assertions. This changes adds the necessary calls to clean these up. It also updates the documentation of `stumpless_free_all` to make it clear that this function closes the default target if it has been opened.