### PR TITLE
add and refactor memory leak tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,7 @@ else()
   add_function_test(udp4_leak
     SOURCES
       test/function/leak/udp4.cpp
+      $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:test_helper_server>
     LIBRARIES ${network_libraries}
   )
@@ -342,6 +343,7 @@ else()
   add_function_test(udp6_leak
     SOURCES
       test/function/leak/udp6.cpp
+      $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:test_helper_server>
     LIBRARIES ${network_libraries}
   )
@@ -594,7 +596,9 @@ add_function_test(buffer
 )
 
 add_function_test(buffer_leak
-  SOURCES test/function/leak/buffer.cpp
+  SOURCES
+    test/function/leak/buffer.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
 )
 
 add_function_test(current_target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,6 +603,10 @@ add_function_test(element
   SOURCES test/function/element.cpp
 )
 
+add_function_test(element_leak
+  SOURCES test/function/leak/element.cpp
+)
+
 add_function_test(entry
   SOURCES test/function/entry.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,7 @@ else()
   add_function_test(tcp4_leak
     SOURCES
       test/function/leak/tcp4.cpp
+      $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:test_helper_server>
     LIBRARIES ${network_libraries}
   )
@@ -326,6 +327,7 @@ else()
   add_function_test(tcp6_leak
     SOURCES
       test/function/leak/tcp6.cpp
+      $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:test_helper_server>
     LIBRARIES ${network_libraries}
   )

--- a/include/test/helper/assert.hpp
+++ b/include/test/helper/assert.hpp
@@ -25,6 +25,8 @@
 
 #  define ASSERT_NOT_NULL( thing ) ASSERT_FALSE( (thing) == NULL )
 
+#  define ASSERT_NULL( thing ) ASSERT_TRUE( (thing) == NULL )
+
 #  define EXPECT_ERROR_ID_EQ( code ) \
 error = stumpless_get_error(  );     \
 EXPECT_TRUE( error != NULL );        \

--- a/include/test/helper/fixture.hpp
+++ b/include/test/helper/fixture.hpp
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Copyright 2020 Joel E. Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __STUMPLESS_TEST_HELPER_FIXTURE_HPP
+#  define __STUMPLESS_TEST_HELPER_FIXTURE_HPP
+
+#  include <stumpless.h>
+
+struct stumpless_entry *
+create_entry( void );
+
+#endif /* __STUMPLESS_TEST_HELPER_FIXTURE_HPP */

--- a/include/test/helper/memory_counter.hpp
+++ b/include/test/helper/memory_counter.hpp
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@
 #ifndef __STUMPLESS_TEST_HELPER_MEMORY_COUNTER_HPP
 #  define __STUMPLESS_TEST_HELPER_MEMORY_COUNTER_HPP
 
+#include <gtest/gtest.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <stumpless.h>
 
 struct memory_counter {
   size_t malloc_count;
@@ -35,7 +37,10 @@ PREFIX##_memory_counter.malloc_count = 0;                                      \
 PREFIX##_memory_counter.alloc_total = 0;                                       \
 PREFIX##_memory_counter.realloc_count = 0;                                     \
 PREFIX##_memory_counter.free_count = 0;                                        \
-PREFIX##_memory_counter.free_total = 0;
+PREFIX##_memory_counter.free_total = 0;                                        \
+stumpless_set_malloc( PREFIX##_memory_counter_malloc );                        \
+stumpless_set_realloc( PREFIX##_memory_counter_realloc );                      \
+stumpless_set_free( PREFIX##_memory_counter_free );
 
 
 #define NEW_MEMORY_COUNTER(PREFIX)                                             \
@@ -80,5 +85,9 @@ PREFIX##_memory_counter_free( void *mem ) {                                    \
   PREFIX##_memory_counter.free_total += PREFIX##_memory_counter_map[mem];      \
   free( mem );                                                                 \
 }
+
+#define ASSERT_NO_LEAK( PREFIX )                                               \
+ASSERT_EQ( PREFIX##_memory_counter.alloc_total,                                \
+           PREFIX##_memory_counter.free_total )
 
 #endif /* __STUMPLESS_TEST_HELPER_MEMORY_COUNTER_HPP */

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=stumpless
-sonar.sources=src
+sonar.sources=src,test/function/leak
 sonar.cfamily.build-wrapper-output=bw-output
 sonar.cfamily.gcov.reportsPath=.
 sonar.sourceEncoding=UTF-8

--- a/src/element.c
+++ b/src/element.c
@@ -31,13 +31,20 @@ stumpless_add_new_param( struct stumpless_element *element,
                          const char *param_name,
                          const char *param_value ) {
   struct stumpless_param *new_param;
+  struct stumpless_element *result;
 
   new_param = stumpless_new_param( param_name, param_value );
   if( !new_param ) {
     return NULL;
   }
 
-  return stumpless_add_param( element, new_param );
+  result = stumpless_add_param( element, new_param );
+
+  if( !result ) {
+    stumpless_destroy_param( new_param );
+  }
+
+  return result;
 }
 
 struct stumpless_element *

--- a/src/entry.c
+++ b/src/entry.c
@@ -79,13 +79,20 @@ struct stumpless_entry *
 stumpless_add_new_element( struct stumpless_entry *entry,
                            const char *name ) {
   struct stumpless_element *new_element;
+  struct stumpless_entry *result;
 
   new_element = stumpless_new_element( name );
   if( !new_element ) {
     return NULL;
   }
 
-  return stumpless_add_element( entry, new_element );
+  result = stumpless_add_element( entry, new_element );
+
+  if( !result ) {
+    stumpless_destroy_element( new_element );
+  }
+
+  return result;
 }
 
 struct stumpless_entry *

--- a/test/README.md
+++ b/test/README.md
@@ -1,5 +1,37 @@
 # Stumpless Testing
+Test support for stumpless is divided at a high level into the areas of focus,
+each of which is implemented and organized differently from the others so that
+the specific focus can be effectively tested.
 
-The testing setup for Stumpless consists of test for both the functionality
-and performance of the library. The tests themselves exist in the `function`
-and `performance` directories, respectively.
+## Functionality Tests
+The [`function`](./function) directory holds tests for basic functionality of
+the library. There is a large suite of unit tests implemented using the Google
+Test library. These tests are used to measure coverage as well, and check for
+memory leaks, startup conditions, and error scenarios in addition to the basic
+features of the library.
+
+## Memory Leak Tests
+Memory leaks are a concern for any application written in C, and so whenever a
+leak is found or suspected a test for it is implemented and added here to
+prevent regression. These tests are in the [`function/leak`](./function/leak)
+directory and focus on causing the leak and detecting it. These tests do not
+necessarily verify correct functionality around the potential leak, as that is
+the focus of the more general functionality tests.
+
+## Performance Tests
+Any changes that are made to the library in the name of improving performance
+are measured by a performance test in the [`performance`](./performance)
+directory. These tests are implemented using the Google Benchmark library and
+measure execution time, memory consumption, and the number of calls to some
+functions outside of the library (such as memory allocation routines).
+
+For a detailed guide on how to implement your own benchmark test, check out
+the documentation at [`docs/benchmark.md`](../docs/benchmark.md)
+
+## Test Helper Modules
+Of course there are some tasks that are needed in a number of tests and
+therefore should not be duplicated in each of them. A good example of this is
+the existence of a network server that can listen for messages when testing
+the network logging targets. These implementations are kept in the
+[`helper`](./helper) directory of the test suite.
+

--- a/test/function/leak/buffer.cpp
+++ b/test/function/leak/buffer.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018 Joel E. Anderson
+ * Copyright 2018-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,9 +39,6 @@ namespace {
     int add_result;
 
     INIT_MEMORY_COUNTER( buffer_leak );
-    stumpless_set_malloc( buffer_leak_memory_counter_malloc );
-    stumpless_set_realloc( buffer_leak_memory_counter_realloc );
-    stumpless_set_free( buffer_leak_memory_counter_free );
 
     target = stumpless_open_buffer_target( "buffer-leak-testing",
                                            buffer,
@@ -79,7 +76,6 @@ namespace {
 
     stumpless_free_all(  );
 
-    ASSERT_EQ( buffer_leak_memory_counter.alloc_total,
-               buffer_leak_memory_counter.free_total );
+    ASSERT_NO_LEAK( buffer_leak );
   }
 }

--- a/test/function/leak/buffer.cpp
+++ b/test/function/leak/buffer.cpp
@@ -19,6 +19,8 @@
 #include <stddef.h>
 #include <stumpless.h>
 #include <gtest/gtest.h>
+#include "test/helper/assert.hpp"
+#include "test/helper/fixture.hpp"
 #include "test/helper/memory_counter.hpp"
 
 #define TEST_BUFFER_LENGTH 2048
@@ -43,35 +45,19 @@ namespace {
     target = stumpless_open_buffer_target( "buffer-leak-testing",
                                            buffer,
                                            TEST_BUFFER_LENGTH,
-                                           0,
+                                           STUMPLESS_OPTION_NONE,
                                            STUMPLESS_FACILITY_USER );
-    ASSERT_TRUE( target != NULL );
+    ASSERT_NOT_NULL( target );
 
-    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                 STUMPLESS_SEVERITY_INFO,
-                                 "memory-leak-test",
-                                 "basic-entry",
-                                 "basic test message" );
-    ASSERT_TRUE( entry != NULL );
-
-    element = stumpless_new_element( "basic-element" );
-    ASSERT_TRUE( element != NULL );
-
-    result_entry = stumpless_add_element( entry, element );
-    ASSERT_TRUE( result_entry != NULL );
-
-    param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-    ASSERT_TRUE( param != NULL );
-
-    result_element = stumpless_add_param( element, param );
-    ASSERT_TRUE( result_element != NULL );
+    entry = create_entry(  );
+    ASSERT_NOT_NULL( entry );
 
     for( i = 0; i < 1000; i++ ) {
       add_result = stumpless_add_entry( target, entry );
-      ASSERT_GE( add_result, 0 );
+      EXPECT_NO_ERROR;
     }
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
     stumpless_close_buffer_target( target );
 
     stumpless_free_all(  );

--- a/test/function/leak/element.cpp
+++ b/test/function/leak/element.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2020 Joel E. Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stumpless.h>
+#include <gtest/gtest.h>
+#include "test/helper/assert.hpp"
+#include "test/helper/memory_counter.hpp"
+
+NEW_MEMORY_COUNTER( add_new_param )
+
+namespace {
+
+  TEST( AddNewParamLeakTest, ErrorCondition ) {
+    struct stumpless_element *element;
+    const struct stumpless_element *result;
+    const struct stumpless_error *error;
+
+    INIT_MEMORY_COUNTER( add_new_param );
+
+    element = stumpless_new_element( "test-element" );
+    EXPECT_NO_ERROR;
+    ASSERT_NOT_NULL( element );
+
+    result = stumpless_add_new_param( NULL, "param-name", "param-value" );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+    ASSERT_NULL( result );
+
+    stumpless_destroy_element_and_contents( element );
+
+    stumpless_free_all(  );
+
+    ASSERT_NO_LEAK( add_new_param );
+  }
+
+}

--- a/test/function/leak/entry.cpp
+++ b/test/function/leak/entry.cpp
@@ -22,18 +22,42 @@
 #include "test/helper/assert.hpp"
 #include "test/helper/memory_counter.hpp"
 
+NEW_MEMORY_COUNTER( add_new_element_leak )
 NEW_MEMORY_COUNTER( set_app_name_leak )
 
 namespace {
+
+  TEST( AddNewElementLeakTest, ErrorCondition ) {
+    struct stumpless_entry *entry;
+    const struct stumpless_entry *result;
+    const struct stumpless_error *error;
+
+    INIT_MEMORY_COUNTER( add_new_element_leak );
+
+    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                                 STUMPLESS_SEVERITY_INFO,
+                                 "app-name",
+                                 "msgid",
+                                 "the message" );
+    EXPECT_NO_ERROR;
+    ASSERT_NOT_NULL( entry );
+
+    result = stumpless_add_new_element( NULL, "new-element" );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+    ASSERT_NULL( result );
+
+    stumpless_destroy_entry( entry );
+
+    stumpless_free_all(  );
+
+    ASSERT_NO_LEAK( add_new_element_leak );
+  }
 
   TEST( SetAppNameLeakTest, TypicalUse ) {
     struct stumpless_entry *entry;
     const struct stumpless_entry *result;
 
     INIT_MEMORY_COUNTER( set_app_name_leak );
-    stumpless_set_malloc( set_app_name_leak_memory_counter_malloc );
-    stumpless_set_realloc( set_app_name_leak_memory_counter_realloc );
-    stumpless_set_free( set_app_name_leak_memory_counter_free );
 
     entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
                                  STUMPLESS_SEVERITY_INFO,
@@ -51,7 +75,6 @@ namespace {
 
     stumpless_free_all(  );
 
-    ASSERT_EQ( set_app_name_leak_memory_counter.alloc_total,
-               set_app_name_leak_memory_counter.free_total );
+    ASSERT_NO_LEAK( add_new_element_leak );
   }
 }

--- a/test/function/leak/entry.cpp
+++ b/test/function/leak/entry.cpp
@@ -46,7 +46,7 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
     ASSERT_NULL( result );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
 
     stumpless_free_all(  );
 
@@ -65,16 +65,16 @@ namespace {
                                  "msgid",
                                  "your message goes here" );
     EXPECT_NO_ERROR;
-    ASSERT_TRUE( entry != NULL );
+    ASSERT_NOT_NULL( entry );
 
     result = stumpless_set_entry_app_name( entry, "new-app-name" );
     EXPECT_NO_ERROR;
-    ASSERT_TRUE( result == entry );
+    ASSERT_EQ( result, entry );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
 
     stumpless_free_all(  );
 
-    ASSERT_NO_LEAK( add_new_element_leak );
+    ASSERT_NO_LEAK( set_app_name_leak );
   }
 }

--- a/test/function/leak/error.cpp
+++ b/test/function/leak/error.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2019 Joel E. Anderson
+ * Copyright 2019-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,6 @@ namespace {
     struct stumpless_error *error;
 
     INIT_MEMORY_COUNTER( free_all );
-    stumpless_set_malloc( free_all_memory_counter_malloc );
-    stumpless_set_realloc( free_all_memory_counter_realloc );
-    stumpless_set_free( free_all_memory_counter_free );
 
     // cause an error
     stumpless_new_param( NULL, NULL );
@@ -41,7 +38,6 @@ namespace {
 
     stumpless_free_all(  );
 
-    EXPECT_EQ( free_all_memory_counter.alloc_total,
-               free_all_memory_counter.free_total );
+    ASSERT_NO_LEAK( free_all );
   }
 }

--- a/test/function/leak/network.cpp
+++ b/test/function/leak/network.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2019 Joel E. Anderson
+ * Copyright 2019-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,6 @@ namespace {
     struct stumpless_target *result;
 
     INIT_MEMORY_COUNTER( set_port );
-    stumpless_set_malloc( set_port_memory_counter_malloc );
-    stumpless_set_realloc( set_port_memory_counter_realloc );
-    stumpless_set_free( set_port_memory_counter_free );
 
     target = stumpless_open_udp4_target( "set-port-leak",
                                          "127.0.0.1",
@@ -47,9 +44,7 @@ namespace {
 
     stumpless_free_all(  );
 
-    EXPECT_EQ( set_port_memory_counter.alloc_total,
-               set_port_memory_counter.free_total );
-
+    ASSERT_NO_LEAK( set_port );
   }
 
 }

--- a/test/function/leak/target.cpp
+++ b/test/function/leak/target.cpp
@@ -34,9 +34,6 @@ namespace {
     int add_result;
 
     INIT_MEMORY_COUNTER( add_message_leak );
-    stumpless_set_malloc( add_message_leak_memory_counter_malloc );
-    stumpless_set_realloc( add_message_leak_memory_counter_realloc );
-    stumpless_set_free( add_message_leak_memory_counter_free );
 
     target = stumpless_open_buffer_target( "add-message-leak-testing",
                                            buffer,
@@ -54,7 +51,6 @@ namespace {
 
     stumpless_free_all(  );
 
-    ASSERT_EQ( add_message_leak_memory_counter.alloc_total,
-               add_message_leak_memory_counter.free_total );
+    ASSERT_NO_LEAK( add_message_leak );
   }
 }

--- a/test/function/leak/tcp4.cpp
+++ b/test/function/leak/tcp4.cpp
@@ -19,6 +19,8 @@
 #include <stddef.h>
 #include <stumpless.h>
 #include <gtest/gtest.h>
+#include "test/helper/assert.hpp"
+#include "test/helper/fixture.hpp"
 #include "test/helper/memory_counter.hpp"
 #include "test/helper/server.hpp"
 
@@ -41,7 +43,6 @@ namespace {
     struct stumpless_param *param;
     size_t i;
     int add_result;
-    struct stumpless_error *error;
     socket_handle_t handle;
     socket_handle_t accepted = BAD_HANDLE;
     char buffer[1024];
@@ -53,33 +54,14 @@ namespace {
                                            "127.0.0.1",
                                            STUMPLESS_OPTION_NONE,
                                            STUMPLESS_FACILITY_USER );
-      ASSERT_TRUE( target != NULL );
+      ASSERT_NOT_NULL( target );
 
-      entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                   STUMPLESS_SEVERITY_INFO,
-                                   "memory-leak-test",
-                                   "basic-entry",
-                                   "basic test message" );
-      ASSERT_TRUE( entry != NULL );
-
-      element = stumpless_new_element( "basic-element" );
-      ASSERT_TRUE( element != NULL );
-
-      result_entry = stumpless_add_element( entry, element );
-      ASSERT_TRUE( result_entry != NULL );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      ASSERT_TRUE( param != NULL );
-
-      result_element = stumpless_add_param( element, param );
-      ASSERT_TRUE( result_element != NULL );
+      entry = create_entry(  );
+      ASSERT_NOT_NULL( entry );
 
       for( i = 0; i < 1000; i++ ) {
         add_result = stumpless_add_entry( target, entry );
-        EXPECT_GE( add_result, 0 );
-
-        error = stumpless_get_error(  );
-        EXPECT_TRUE( error == NULL );
+        EXPECT_NO_ERROR;
 
         if( accepted == BAD_HANDLE ) {
           accepted = accept_tcp_connection( handle );
@@ -88,7 +70,7 @@ namespace {
         recv_from_handle( accepted, buffer, 1024 );
       }
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
       stumpless_close_network_target( target );
 
       stumpless_free_all(  );

--- a/test/function/leak/tcp4.cpp
+++ b/test/function/leak/tcp4.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2019 Joel E. Anderson
+ * Copyright 2019-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,6 @@ namespace {
 
     handle = open_tcp_server_socket( AF_INET, "127.0.0.1", "514" );
     if( handle != BAD_HANDLE ) {
-      stumpless_set_malloc( tcp4_leak_memory_counter_malloc );
-      stumpless_set_realloc( tcp4_leak_memory_counter_realloc );
-      stumpless_set_free( tcp4_leak_memory_counter_free );
 
       target = stumpless_open_tcp4_target( "test-self",
                                            "127.0.0.1",
@@ -96,11 +93,10 @@ namespace {
 
       stumpless_free_all(  );
 
-      ASSERT_EQ( tcp4_leak_memory_counter.alloc_total,
-                 tcp4_leak_memory_counter.free_total );
-
       close_server_socket( handle );
       close_server_socket( accepted );
+
+      ASSERT_NO_LEAK( tcp4_leak );
     }
   }
 }

--- a/test/function/leak/tcp6.cpp
+++ b/test/function/leak/tcp6.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2019 Joel E. Anderson
+ * Copyright 2019-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,6 @@ namespace {
 
     handle = open_tcp_server_socket( AF_INET6, "::1", "514" );
     if( handle != BAD_HANDLE ) {
-      stumpless_set_malloc( tcp6_leak_memory_counter_malloc );
-      stumpless_set_realloc( tcp6_leak_memory_counter_realloc );
-      stumpless_set_free( tcp6_leak_memory_counter_free );
 
       target = stumpless_open_tcp6_target( "test-self",
                                            "::1",
@@ -96,11 +93,10 @@ namespace {
 
       stumpless_free_all(  );
 
-      ASSERT_EQ( tcp6_leak_memory_counter.alloc_total,
-                 tcp6_leak_memory_counter.free_total );
-
       close_server_socket( handle );
       close_server_socket( accepted );
+
+      ASSERT_NO_LEAK( tcp6_leak );
     }
   }
 }

--- a/test/function/leak/tcp6.cpp
+++ b/test/function/leak/tcp6.cpp
@@ -19,6 +19,8 @@
 #include <stddef.h>
 #include <stumpless.h>
 #include <gtest/gtest.h>
+#include "test/helper/assert.hpp"
+#include "test/helper/fixture.hpp"
 #include "test/helper/memory_counter.hpp"
 #include "test/helper/server.hpp"
 
@@ -41,7 +43,6 @@ namespace {
     struct stumpless_param *param;
     size_t i;
     int add_result;
-    struct stumpless_error *error;
     socket_handle_t handle;
     socket_handle_t accepted = BAD_HANDLE;
     char buffer[1024];
@@ -53,33 +54,14 @@ namespace {
                                            "::1",
                                            STUMPLESS_OPTION_NONE,
                                            STUMPLESS_FACILITY_USER );
-      ASSERT_TRUE( target != NULL );
+      ASSERT_NOT_NULL( target );
 
-      entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                   STUMPLESS_SEVERITY_INFO,
-                                   "memory-leak-test",
-                                   "basic-entry",
-                                   "basic test message" );
-      ASSERT_TRUE( entry != NULL );
-
-      element = stumpless_new_element( "basic-element" );
-      ASSERT_TRUE( element != NULL );
-
-      result_entry = stumpless_add_element( entry, element );
-      ASSERT_TRUE( result_entry != NULL );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      ASSERT_TRUE( param != NULL );
-
-      result_element = stumpless_add_param( element, param );
-      ASSERT_TRUE( result_element != NULL );
+      entry = create_entry(  );
+      ASSERT_NOT_NULL( entry );
 
       for( i = 0; i < 1000; i++ ) {
         add_result = stumpless_add_entry( target, entry );
-        EXPECT_GE( add_result, 0 );
-
-        error = stumpless_get_error(  );
-        EXPECT_TRUE( error == NULL );
+        EXPECT_NO_ERROR;
 
         if( accepted == BAD_HANDLE ) {
           accepted = accept_tcp_connection( handle );
@@ -88,7 +70,7 @@ namespace {
         recv_from_handle( accepted, buffer, 1024 );
       }
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
       stumpless_close_network_target( target );
 
       stumpless_free_all(  );

--- a/test/function/leak/udp4.cpp
+++ b/test/function/leak/udp4.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2019 Joel E. Anderson
+ * Copyright 2019-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,9 +38,6 @@ namespace {
     struct stumpless_target *result;
 
     INIT_MEMORY_COUNTER( set_port );
-    stumpless_set_malloc( set_port_memory_counter_malloc );
-    stumpless_set_realloc( set_port_memory_counter_realloc );
-    stumpless_set_free( set_port_memory_counter_free );
 
     target = stumpless_open_udp4_target( "set-port-leak",
                                          "127.0.0.1",
@@ -55,9 +52,7 @@ namespace {
 
     stumpless_free_all(  );
 
-    EXPECT_EQ( set_port_memory_counter.alloc_total,
-               set_port_memory_counter.free_total );
-
+    ASSERT_NO_LEAK( set_port );
   }
 
   TEST( Udp4TargetLeakTest, TypicalUse ) {
@@ -78,9 +73,7 @@ namespace {
       fixture_enabled = false;
     }
 
-    stumpless_set_malloc( udp4_leak_memory_counter_malloc );
-    stumpless_set_realloc( udp4_leak_memory_counter_realloc );
-    stumpless_set_free( udp4_leak_memory_counter_free );
+    INIT_MEMORY_COUNTER( udp4_leak );
 
     target = stumpless_open_udp4_target( "test-self",
                                          "127.0.0.1",
@@ -121,10 +114,8 @@ namespace {
     stumpless_close_network_target( target );
 
     stumpless_free_all(  );
-
-    EXPECT_EQ( udp4_leak_memory_counter.alloc_total,
-               udp4_leak_memory_counter.free_total );
-
     close_server_socket( handle );
+
+    ASSERT_NO_LEAK( udp4_leak );
   }
 }

--- a/test/function/leak/udp4.cpp
+++ b/test/function/leak/udp4.cpp
@@ -19,6 +19,8 @@
 #include <stddef.h>
 #include <stumpless.h>
 #include <gtest/gtest.h>
+#include "test/helper/assert.hpp"
+#include "test/helper/fixture.hpp"
 #include "test/helper/memory_counter.hpp"
 #include "test/helper/server.hpp"
 
@@ -43,10 +45,10 @@ namespace {
                                          "127.0.0.1",
                                          STUMPLESS_OPTION_NONE,
                                          STUMPLESS_FACILITY_USER );
-    ASSERT_TRUE( target != NULL );
+    ASSERT_NOT_NULL( target );
 
     result = stumpless_set_transport_port( target, "6514" );
-    ASSERT_TRUE( result != NULL );
+    ASSERT_NOT_NULL( result );
 
     stumpless_close_network_target( target );
 
@@ -64,7 +66,6 @@ namespace {
     struct stumpless_param *param;
     size_t i;
     int add_result;
-    struct stumpless_error *error;
     socket_handle_t handle;
     bool fixture_enabled = true;
 
@@ -79,38 +80,20 @@ namespace {
                                          "127.0.0.1",
                                          STUMPLESS_OPTION_NONE,
                                          STUMPLESS_FACILITY_USER );
-    ASSERT_TRUE( target != NULL );
+    ASSERT_NOT_NULL( target );
 
-    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                 STUMPLESS_SEVERITY_INFO,
-                                 "memory-leak-test",
-                                 "basic-entry",
-                                 "basic test message" );
-    ASSERT_TRUE( entry != NULL );
-
-    element = stumpless_new_element( "basic-element" );
-    ASSERT_TRUE( element != NULL );
-
-    result_entry = stumpless_add_element( entry, element );
-    ASSERT_TRUE( result_entry != NULL );
-
-    param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-    ASSERT_TRUE( param != NULL );
-
-    result_element = stumpless_add_param( element, param );
-    ASSERT_TRUE( result_element != NULL );
+    entry = create_entry(  );
+    ASSERT_NOT_NULL( entry );
 
     for( i = 0; i < 1000; i++ ) {
       add_result = stumpless_add_entry( target, entry );
       if( fixture_enabled ) {
+        EXPECT_NO_ERROR;
         EXPECT_GE( add_result, 0 );
-
-        error = stumpless_get_error(  );
-        EXPECT_TRUE( error == NULL );
       }
     }
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
     stumpless_close_network_target( target );
 
     stumpless_free_all(  );

--- a/test/function/leak/udp6.cpp
+++ b/test/function/leak/udp6.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2019 Joel E. Anderson
+ * Copyright 2019-2020 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,9 +38,6 @@ namespace {
     struct stumpless_target *result;
 
     INIT_MEMORY_COUNTER( set_port );
-    stumpless_set_malloc( set_port_memory_counter_malloc );
-    stumpless_set_realloc( set_port_memory_counter_realloc );
-    stumpless_set_free( set_port_memory_counter_free );
 
     target = stumpless_open_udp6_target( "set-port-leak",
                                          "::1",
@@ -55,9 +52,7 @@ namespace {
 
     stumpless_free_all(  );
 
-    EXPECT_EQ( set_port_memory_counter.alloc_total,
-               set_port_memory_counter.free_total );
-
+    ASSERT_NO_LEAK( set_port );
   }
 
   TEST( Udp6TargetLeakTest, TypicalUse ) {
@@ -78,9 +73,7 @@ namespace {
       fixture_enabled = false;
     }
 
-    stumpless_set_malloc( udp6_leak_memory_counter_malloc );
-    stumpless_set_realloc( udp6_leak_memory_counter_realloc );
-    stumpless_set_free( udp6_leak_memory_counter_free );
+    INIT_MEMORY_COUNTER( udp6_leak );
 
     target = stumpless_open_udp6_target( "test-self",
                                          "::1",
@@ -122,9 +115,8 @@ namespace {
 
     stumpless_free_all(  );
 
-    EXPECT_EQ( udp6_leak_memory_counter.alloc_total,
-               udp6_leak_memory_counter.free_total );
-
     close_server_socket( handle );
+
+    ASSERT_NO_LEAK( udp6_leak );
   }
 }

--- a/test/function/leak/udp6.cpp
+++ b/test/function/leak/udp6.cpp
@@ -19,6 +19,8 @@
 #include <stddef.h>
 #include <stumpless.h>
 #include <gtest/gtest.h>
+#include "test/helper/assert.hpp"
+#include "test/helper/fixture.hpp"
 #include "test/helper/memory_counter.hpp"
 #include "test/helper/server.hpp"
 
@@ -43,10 +45,10 @@ namespace {
                                          "::1",
                                          STUMPLESS_OPTION_NONE,
                                          STUMPLESS_FACILITY_USER );
-    ASSERT_TRUE( target != NULL );
+    ASSERT_NOT_NULL( target );
 
     result = stumpless_set_transport_port( target, "6514" );
-    ASSERT_TRUE( result != NULL );
+    ASSERT_NOT_NULL( result );
 
     stumpless_close_network_target( target );
 
@@ -79,38 +81,20 @@ namespace {
                                          "::1",
                                          STUMPLESS_OPTION_NONE,
                                          STUMPLESS_FACILITY_USER );
-    ASSERT_TRUE( target != NULL );
+    ASSERT_NOT_NULL( target );
 
-    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                 STUMPLESS_SEVERITY_INFO,
-                                 "memory-leak-test",
-                                 "basic-entry",
-                                 "basic test message" );
-    ASSERT_TRUE( entry != NULL );
-
-    element = stumpless_new_element( "basic-element" );
-    ASSERT_TRUE( element != NULL );
-
-    result_entry = stumpless_add_element( entry, element );
-    ASSERT_TRUE( result_entry != NULL );
-
-    param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-    ASSERT_TRUE( param != NULL );
-
-    result_element = stumpless_add_param( element, param );
-    ASSERT_TRUE( result_element != NULL );
+    entry = create_entry(  );
+    ASSERT_NOT_NULL( entry );
 
     for( i = 0; i < 1000; i++ ) {
       add_result = stumpless_add_entry( target, entry );
       if( fixture_enabled ) {
+        EXPECT_NO_ERROR;
         EXPECT_GE( add_result, 0 );
-
-        error = stumpless_get_error(  );
-        EXPECT_TRUE( error == NULL );
       }
     }
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
     stumpless_close_network_target( target );
 
     stumpless_free_all(  );

--- a/test/helper/fixture.cpp
+++ b/test/helper/fixture.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2020 Joel E. Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stumpless.h>
+#include "test/helper/fixture.hpp"
+
+struct stumpless_entry *
+create_entry( void ) {
+  struct stumpless_entry *entry;
+
+  entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                               STUMPLESS_SEVERITY_INFO,
+                               "fixture-app-name",
+                               "fixture-msgid",
+                               "fixture message" );
+
+  stumpless_add_new_element( entry, "fixture-element" );
+
+  stumpless_add_new_param_to_entry( entry,
+                                    "fixture-element",
+                                    "fixture-param-1",
+                                    "fixture-value-1" );
+
+  stumpless_add_new_param_to_entry( entry,
+                                    "fixture-element",
+                                    "fixture-param-2",
+                                    "fixture-value-2" );
+
+  return entry;
+}

--- a/tools/check_headers/gtest.yml
+++ b/tools/check_headers/gtest.yml
@@ -1,3 +1,4 @@
+"ASSERT_EQ": "gtest/gtest.h"
 "ASSERT_THAT": "gmock/gmock.h"
 "ASSERT_TRUE": "gtest/gtest.h"
 "BENCHMARK": "benchmark/benchmark.h"

--- a/tools/check_headers/stumpless.yml
+++ b/tools/check_headers/stumpless.yml
@@ -53,6 +53,7 @@
 "copy_cstring": "private/strhelper.h"
 "copy_cstring_with_length": "private/strhelper.h"
 "copy_wel_fields": "private/config/wel_supported.h"
+"create_entry": "test/helper/fixture.hpp"
 "cstring_to_sized_string": "private/strhelper.h"
 "destroy_buffer_target": "private/target/buffer.h"
 "destroy_file_target": "private/target/file.h"

--- a/tools/check_headers/stumpless.yml
+++ b/tools/check_headers/stumpless.yml
@@ -6,6 +6,7 @@
 "accept_tcp_connection": "test/helper/server.hpp"
 "alloc_mem": "private/memory.h"
 "ASSERT_NOT_NULL": "test/helper/assert.hpp"
+"ASSERT_NULL": "test/helper/assert.hpp"
 "cache_alloc": "private/cache.h"
 "cache_destroy": "private/cache.h"
 "cache_free": "private/cache.h"

--- a/tools/cmake/test.cmake
+++ b/tools/cmake/test.cmake
@@ -123,6 +123,21 @@ target_include_directories(rfc5424_checker
 )
 
 # helper libraries
+add_library(test_helper_fixture
+  EXCLUDE_FROM_ALL
+  OBJECT ${PROJECT_SOURCE_DIR}/test/helper/fixture.cpp
+)
+
+set_target_properties(test_helper_fixture
+  PROPERTIES
+  COMPILE_FLAGS "${function_test_compile_flags}"
+)
+
+target_include_directories(test_helper_fixture
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${CMAKE_BINARY_DIR}/include
+)
 add_library(test_helper_resolve
   EXCLUDE_FROM_ALL
   OBJECT ${PROJECT_SOURCE_DIR}/test/helper/resolve.cpp


### PR DESCRIPTION
Two functions (`stumpless_add_new_element` and `stumpless_add_new_param`) had memory leaks that could occur when there was an error during the addition of the new item. These leaks have been corrected and regression tests created for them.

The memory leak testing code has also been refactored as part of this change, adding a fixture library for creating entries and improving the memory counter tools with more included during initialization and a new assertion for leak checks.