### PR TITLE
remove stumpless function

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,13 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/stumpless/blob/master/docs/roadmap.md).
 
+## [2.0.0] - 2020-08-16
+### Changed
+ - C++ namespace from `stumplesscpp` to `stumpless`.
+
+### Removed
+ - `stumpless` and `vstumpless` functions (use `stump` and `vstump` instead).
+
 ## [1.6.0] - 2020-07-16
 ### Added
  - A number of new functions for working with entries, elements, and params.

--- a/docs/examples/cpp/cpp_example.cpp
+++ b/docs/examples/cpp/cpp_example.cpp
@@ -7,7 +7,7 @@
 #include <StumplessException.hpp>
 #include <iostream>
 
-using namespace stumplesscpp;
+using namespace stumpless;
 
 int
 main( int argc, char **argv ) {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,11 +13,6 @@ or want to make a suggestion, please submit an issue on the project's
    alternative. This implementation will be done as granularly as possible, and
    will not use any static library-wide locks in order to avoid throughput
    issues in the future.
- * [CHANGE] **`stumpless` function will be removed (use `stump` instead)**
-   As currently named, the function makes it impossible to create a C++
-   namespace named after the library itself. Renaming this function will give it
-   a more meaningful name and also allow a cleaner namespace in the C++
-   bindings.
  * [DEPRECATE] **entry and element destructor synonyms**
    Currently, there are two forms of the destructors for these two structures:
    one that destroys the object itself, and one that destroys the object and all

--- a/include/stumpless/target.h
+++ b/include/stumpless/target.h
@@ -116,26 +116,6 @@ struct stumpless_target {
 int stump( const char *message, ... );
 
 /**
- * Logs a message to the default target.
- *
- * This is an alias for the stump function, which is preferred. This function
- * will be deprecated in a future release.
- *
- * @param message The message to log, optionally containing any format
- * specifiers valid in \c printf.
- *
- * @param ... Substitutions for any format specifiers provided in message. The
- * number of substitutions provided must exactly match the number of
- * specifiers given.
- *
- * @return A non-negative value if no error is encountered. If an error is
- * encountered, then a negative value is returned and an error code is set
- * appropriately.
- */
-int
-stumpless( const char *message, ... );
-
-/**
  * Logs a message to the default target with the given priority.
  *
  * This function can serve as a replacement for the traditional \c syslog
@@ -458,28 +438,6 @@ stumpless_unset_option( struct stumpless_target *target, int option );
  */
 int
 vstump( const char *message, va_list subs );
-
-/**
- * Logs a message to the default target.
- *
- * This is an alias for the vstump function, which is preferred. This function
- * will be deprecated in a future release.
- *
- * @param message The message to log, optionally containing any format
- * specifiers valid in \c printf.
- *
- * @param subs Substitutions for any format specifiers provided in message. The
- * number of substitutions provided must exactly match the number of
- * specifiers given. This list must be started via \c va_start before being
- * used, and \c va_end should be called afterwards, as this function does not
- * call it.
- *
- * @return A non-negative value if no error is encountered. If an error is
- * encountered, then a negative value is returned and an error code is set
- * appropriately.
- */
-int
-vstumpless( const char *message, va_list subs );
 
 /**
  * Logs a message to the default target with the given priority. Can serve as

--- a/src/target.c
+++ b/src/target.c
@@ -64,18 +64,6 @@ stump( const char *message, ... ) {
   return result;
 }
 
-int
-stumpless( const char *message, ... ) {
-  int result;
-  va_list subs;
-
-  va_start( subs, message );
-  result = vstump( message, subs );
-  va_end( subs );
-
-  return result;
-}
-
 void
 stumplog( int priority, const char *message, ... ) {
   va_list subs;
@@ -449,11 +437,6 @@ vstump( const char *message, va_list subs ) {
   }
 
   return vstumpless_add_message( target, message, subs );
-}
-
-int
-vstumpless( const char *message, va_list subs ) {
-  return vstump( message, subs );
 }
 
 void

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -1,6 +1,9 @@
 LIBRARY   STUMPLESS
 EXPORTS
-  stumpless                                     @1
+; added in v2.0.0
+  stumpless_version_cmp                         @1
+
+; added in v1.5.0 and earlier
   stumpless_add_element                         @2
   stumpless_add_entry                           @3
   stumpless_add_param                           @4
@@ -85,6 +88,7 @@ EXPORTS
   stumpless_destroy_element_and_contents        @83
   stumpless_destroy_element_only                @84
   stumpless_get_error_id                        @85
+
 ; added in v1.6.0
   stumpless_add_new_element                     @86
   stumpless_add_new_param                       @87
@@ -136,5 +140,6 @@ EXPORTS
   stumpless_set_param_value_by_name             @133
   stump                                         @134
   vstump                                        @135
+
+; added in v2.0.0
   stumpless_get_error_id_string                 @136
-  stumpless_version_cmp                         @137

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -71,7 +71,11 @@ EXPORTS
   stumpless_add_message                         @66
   stumpless_get_wel_insertion_string            @67
   stumpless_set_wel_insertion_strings           @68
-  vstumpless                                    @69
+
+; added in v2.0.0
+  stumpless_get_error_id_string                 @69
+
+; added in v1.5.0 and earlier
   vstumpless_add_message                        @70
   vstumpless_new_entry                          @71
   vstumpless_set_wel_insertion_strings          @72
@@ -140,6 +144,3 @@ EXPORTS
   stumpless_set_param_value_by_name             @133
   stump                                         @134
   vstump                                        @135
-
-; added in v2.0.0
-  stumpless_get_error_id_string                 @136

--- a/test/function/cpp/element.cpp
+++ b/test/function/cpp/element.cpp
@@ -20,7 +20,7 @@
 #include <gtest/gtest.h>
 #include <stumpless.hpp>
 
-using namespace stumplesscpp;
+using namespace stumpless;
 
 namespace {
 

--- a/test/function/cpp/entry.cpp
+++ b/test/function/cpp/entry.cpp
@@ -19,7 +19,7 @@
 #include <gtest/gtest.h>
 #include <stumpless.hpp>
 
-using namespace stumplesscpp;
+using namespace stumpless;
 
 namespace {
   TEST( BuildEntry, WithElement ) {

--- a/test/function/cpp/memory.cpp
+++ b/test/function/cpp/memory.cpp
@@ -21,7 +21,7 @@
 #include <gtest/gtest.h>
 #include <stumpless.hpp>
 
-using namespace stumplesscpp;
+using namespace stumpless;
 
 namespace {
 

--- a/test/function/cpp/param.cpp
+++ b/test/function/cpp/param.cpp
@@ -20,7 +20,7 @@
 #include <gtest/gtest.h>
 #include <stumpless.hpp>
 
-using namespace stumplesscpp;
+using namespace stumpless;
 
 namespace {
 

--- a/test/function/cpp/target/file.cpp
+++ b/test/function/cpp/target/file.cpp
@@ -23,7 +23,7 @@
 #include <stumpless.hpp>
 #include "test/function/rfc5424.hpp"
 
-using namespace stumplesscpp;
+using namespace stumpless;
 
 namespace {
 

--- a/test/function/cpp/target/network.cpp
+++ b/test/function/cpp/target/network.cpp
@@ -20,7 +20,7 @@
 #include <stumpless.h>
 #include <stumpless.hpp>
 
-using namespace stumplesscpp;
+using namespace stumpless;
 
 namespace {
   TEST( CppDefaultTransportPortTest, EqualToStumpless ) {

--- a/test/function/cpp/target/stream.cpp
+++ b/test/function/cpp/target/stream.cpp
@@ -21,7 +21,7 @@
 #include <stumpless.hpp>
 #include <stumpless/option.h>
 
-using namespace stumplesscpp;
+using namespace stumpless;
 
 namespace {
 

--- a/test/function/cpp/target/wel.cpp
+++ b/test/function/cpp/target/wel.cpp
@@ -19,7 +19,7 @@
 #include <gtest/gtest.h>
 #include <stumpless.hpp>
 
-using namespace stumplesscpp;
+using namespace stumpless;
 
 namespace {
   TEST( CppSetEntryCategories, Basics ) {

--- a/test/function/cpp/version.cpp
+++ b/test/function/cpp/version.cpp
@@ -19,7 +19,7 @@
 #include <gtest/gtest.h>
 #include <stumpless.hpp>
 
-using namespace stumplesscpp;
+using namespace stumpless;
 
 namespace {
 

--- a/test/function/target.cpp
+++ b/test/function/target.cpp
@@ -2,13 +2,13 @@
 
 /*
  * Copyright 2018-2020 Joel E. Anderson
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -620,28 +620,6 @@ namespace {
     ASSERT_TRUE( stumpless_get_current_target(  ) == target );
 
     result = stump( "test message" );
-    EXPECT_NO_ERROR;
-    EXPECT_GE( result, 0 );
-
-    TestRFC5424Compliance( buffer );
-
-    stumpless_close_buffer_target( target );
-  }
-
-  TEST( Stumpless, Basic ) {
-    char buffer[1000];
-    struct stumpless_target *target;
-    int result;
-
-    target = stumpless_open_buffer_target( "test target",
-                                           buffer,
-                                           sizeof( buffer ),
-                                           STUMPLESS_OPTION_NONE,
-                                           STUMPLESS_FACILITY_USER );
-    ASSERT_NOT_NULL( target );
-    ASSERT_TRUE( stumpless_get_current_target(  ) == target );
-
-    result = stumpless( "test message" );
     EXPECT_NO_ERROR;
     EXPECT_GE( result, 0 );
 

--- a/tools/check_headers/stumpless.yml
+++ b/tools/check_headers/stumpless.yml
@@ -188,7 +188,6 @@
 "stump_i_entry": "stumpless/level/info.h"
 "stump_i_log": "stumpless/level/info.h"
 "stump_i_message": "stumpless/level/info.h"
-"stumpless": "stumpless/target.h"
 "stumpless_add_entry": "stumpless/target.h"
 "stumpless_add_log": "stumpless/target.h"
 "stumpless_add_message": "stumpless/target.h"

--- a/tools/wrapture/buffer_target.yml
+++ b/tools/wrapture/buffer_target.yml
@@ -8,7 +8,7 @@ classes:
 
       Note that callers must handle the wrap-around case, and not assume that
       each read will end in a NULL character, in case a wrap-around occurs.
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     equivalent-struct:
       name: "stumpless_target"
       includes: "stumpless/target.h"

--- a/tools/wrapture/element.yml
+++ b/tools/wrapture/element.yml
@@ -6,7 +6,7 @@ classes:
 
       Elements must have a name, but may not have any parameters. Their
       components must comply with RFC 5424.
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     equivalent-struct:
       name: "stumpless_element"
       includes: "stumpless/element.h"

--- a/tools/wrapture/entry.yml
+++ b/tools/wrapture/entry.yml
@@ -5,7 +5,7 @@ classes:
       A log entry.
 
       Entries are the basic element of logging in Stumpless.
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     equivalent-struct:
       name: "stumpless_entry"
       includes: "stumpless/entry.h"

--- a/tools/wrapture/error.yml
+++ b/tools/wrapture/error.yml
@@ -3,7 +3,7 @@ enums:
   - name: "ErrorId"
     doc: >
       Unique identifiers for library errors.
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     includes: "stumpless/error.h"
     elements:
       - name: "ADDRESS_FAILURE"
@@ -89,7 +89,7 @@ enums:
 classes:
   - name: "StumplessException"
     doc: "A general problem has been encountered by the library."
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     parent:
       name: "std::exception"
       includes: "exception"

--- a/tools/wrapture/error_templates.yml
+++ b/tools/wrapture/error_templates.yml
@@ -2,7 +2,7 @@ version: "0.4.0"
 templates:
   - name: "error-class"
     value:
-      namespace: "stumplesscpp"
+      namespace: "stumpless"
       parent:
         name: "StumplessException"
         includes: "stumpless/StumplessException.hpp"

--- a/tools/wrapture/facility.yml
+++ b/tools/wrapture/facility.yml
@@ -10,7 +10,7 @@ enums:
       syslog.h if it was available during build, and if there is matching value
       in the standard. Check for the definition of STUMPLESS_SYSLOG_H_COMPATIBLE
       to see if you can rely on this behavior.
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     includes: "stumpless/entry.h"
     elements:
       - name: "KERNEL"

--- a/tools/wrapture/file_target.yml
+++ b/tools/wrapture/file_target.yml
@@ -6,7 +6,7 @@ classes:
       as needed, and logs are appended to any existing contents.
 
       Events logged to the file will be separated by a newline character.
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     constants:
       - name: "DEFAULT_FILE"
         type: "char *"

--- a/tools/wrapture/memory.yml
+++ b/tools/wrapture/memory.yml
@@ -2,7 +2,7 @@ version: "0.4.2"
 classes:
   - name: "MemoryManager"
     doc: "Container for memory management functions in Stumpless."
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     equivalent-struct:
       # this is a dummy struct simply to get wrapture to work
       name: "stumpless_version"

--- a/tools/wrapture/network_target.yml
+++ b/tools/wrapture/network_target.yml
@@ -2,7 +2,7 @@ version: "0.4.2"
 enums:
   - name: "NetworkProtocol"
     doc: "Network protocols used by network targets."
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     includes: "stumpless/target/network.h"
     elements:
       - name: "IPV4"
@@ -13,7 +13,7 @@ enums:
         value: "STUMPLESS_IPV6_NETWORK_PROTOCOL"
   - name: "TransportProtocol"
     doc: "Transport protocols used by network targets."
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     includes: "stumpless/target/network.h"
     elements:
       - name: "TCP"
@@ -27,7 +27,7 @@ classes:
     doc: >
       Network targets allow traditional syslog messages to be sent to a remote
       server. These can use either UDP or TCP over either IPv4 or IPv6.
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     equivalent-struct:
       name: "stumpless_target"
       includes: "stumpless/target.h"

--- a/tools/wrapture/param.yml
+++ b/tools/wrapture/param.yml
@@ -2,7 +2,7 @@ version: "0.4.2"
 classes:
   - name: "Param"
     doc: "A parameter within a structured data element."
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     type: "pointer"
     equivalent-struct:
       name: "stumpless_param"

--- a/tools/wrapture/severity.yml
+++ b/tools/wrapture/severity.yml
@@ -8,7 +8,7 @@ enums:
       The underlying values of this enumeration will match those provided in
       syslog.h if it was available during build. Check for the definition of
       STUMPLESS_SYSLOG_H_COMPATIBLE to see if you can rely on this behavior.
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     includes: "stumpless/entry.h"
     elements:
       - name: "EMERGENCY"

--- a/tools/wrapture/socket_target.yml
+++ b/tools/wrapture/socket_target.yml
@@ -5,7 +5,7 @@ classes:
       Socket targets allow logs to be sent to a Unix domain socket, like the
       frequently used /dev/log or /var/run/syslog sockets associated with syslog
       daemons.
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     equivalent-struct:
       name: "stumpless_target"
       includes: "stumpless/target.h"

--- a/tools/wrapture/stream_target.yml
+++ b/tools/wrapture/stream_target.yml
@@ -11,7 +11,7 @@ classes:
 
       Stream targets also provide a quick way to log to stderr and stdout, which
       is not possible with a FileTarget.
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     equivalent-struct:
       name: "stumpless_target"
       includes: "stumpless/target.h"

--- a/tools/wrapture/target.yml
+++ b/tools/wrapture/target.yml
@@ -2,7 +2,7 @@ version: "0.4.0"
 #enums:
 #  - name: "TargetType"
 #    doc: "types of targets"
-#    namespace: "stumplesscpp"
+#    namespace: "stumpless"
 #    includes: "stumpless/target.h"
 #    elements:
 #      - name: "BUFFER"

--- a/tools/wrapture/version.yml
+++ b/tools/wrapture/version.yml
@@ -2,7 +2,7 @@ version: "0.3.0"
 classes:
   - name: "Version"
     doc: "Describes this version of Stumpless."
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     equivalent-struct:
       name: "stumpless_version"
       includes: "stumpless/version.h"

--- a/tools/wrapture/wel_target.yml
+++ b/tools/wrapture/wel_target.yml
@@ -4,7 +4,7 @@ classes:
     doc: >
       Windows Event Log (WEL) targets allow messages to be sent to the Windows
       event handling system.
-    namespace: "stumplesscpp"
+    namespace: "stumpless"
     equivalent-struct:
       name: "stumpless_target"
       includes: "stumpless/target.h"


### PR DESCRIPTION
The `stumpless` function made it impossible for the C++ bindings to use the most direct namespace name of `stumpless`. For this reason the function has been removed along with the matching `vstumpless` function. These functions should be replaced with the `stump` and `vstump` functions introduced in v1.6.0.

The C++ namespace has also been changed from `stumplesscpp` to `stumpless`, and the documentation has also been updated to reflect the new namespace.