### PR TITLE
remove obsolete doxygen setting

### DIFF
--- a/tools/doxygen/CppDoxyfile.in
+++ b/tools/doxygen/CppDoxyfile.in
@@ -159,7 +159,6 @@ SEARCH_INCLUDES        = YES
 SKIP_FUNCTION_MACROS   = YES
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
-PERL_PATH              = /usr/bin/perl
 CLASS_DIAGRAMS         = YES
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = NO

--- a/tools/doxygen/Doxyfile.in
+++ b/tools/doxygen/Doxyfile.in
@@ -160,7 +160,6 @@ EXPAND_ONLY_PREDEF     = NO
 SKIP_FUNCTION_MACROS   = YES
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
-PERL_PATH              = /usr/bin/perl
 CLASS_DIAGRAMS         = YES
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = NO


### PR DESCRIPTION
Remove the obsolete `PERL_PATH` option from the Doxyfiles.