### PR TITLE
add gitter references

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ easier:
  * interoperability with standard syslog daemons and library functions
  * an extensive unit testing suite and continuous integration
  * easy-access
-   [documentation](https://goatshriek.github.io/stumpless/docs/c/latest/index.html)
-   and
-   [examples](https://github.com/goatshriek/stumpless/tree/latest/docs/examples)
+   [documentation](https://goatshriek.github.io/stumpless/docs/c/latest/index.html),
+   [examples](https://github.com/goatshriek/stumpless/tree/latest/docs/examples),
+   and [support](https://gitter.im/stumpless/community).
 
 ## Quick Build and Install
 Stumpless only requires cmake and a cmake-supported build toolchain (like GCC
@@ -183,3 +183,6 @@ If you're curious about how something in stumpless works that isn't explained
 here, you can check the appropriate section of the documentation, stored in the
 docs folder of the repository. Folders in the repository contain their own
 README files that detail what they contain and any other relevant information.
+If you still can't find an answer, submit an issue or head over to
+[gitter](https://gitter.im/stumpless/community) and ask for some help.
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/uwied5cn5jujl4d2/branch/latest?svg=true)](https://ci.appveyor.com/project/goatshriek/stumpless)
 [![Coverage Report](https://codecov.io/gh/goatshriek/stumpless/branch/latest/graph/badge.svg)](https://codecov.io/gh/goatshriek/stumpless)
 [![SonarCloud Status](https://sonarcloud.io/api/project_badges/measure?project=stumpless&metric=alert_status)](https://sonarcloud.io/dashboard?id=stumpless)
+[![Gitter](https://badges.gitter.im/stumpless/community.svg)](https://gitter.im/stumpless/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg)](https://github.com/goatshriek/stumpless/blob/latest/docs/CODE_OF_CONDUCT.md)
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,10 +1,17 @@
 ## Help Stumpless Do Better, Suck Less
 
-Stumpless is a small project that aims to do a small thing well while staying as
-small as possible. If you've got a problem with the project, you have a great
-idea for a new feature, or you just want to find a way to contribute, then check
-out the guidelines below on how to get started. Also, please make sure that you
-adhere to the [Code of Conduct](CODE_OF_CONDUCT.md) however you participate.
+Stumpless aims to do a small thing well while staying as small as possible. If
+you've got a problem with the project, you have a great idea for a new feature,
+or you just want to find a way to contribute, then check out the guidelines
+below on how to get started. Also, please make sure that you adhere to the
+[Code of Conduct](CODE_OF_CONDUCT.md) however you participate.
+
+### **I know what I'm doing**
+
+If you're a regular user of the library and know it pretty well, you can give
+back to the community just by helping out others who have a question. Head over
+to the project's [gitter](https://gitter.im/stumpless/community) room and if
+there is a question that you can help with, don't hesitate to jump in!
 
 ### **It broke**
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,8 +51,8 @@ cmake ../stumpless
 vim ../stumpless/src/target.c
 
 # build and run the test suite
-# change the number of threads with the j parameter to make things faster:
-# a good starting place is your processor's core count
+# change the number of threads with the j parameter to make things faster
+# your processor's core count is a good starting place
 make -j 4 check
 
 # if you want to build a single test, you can do this using the executable


### PR DESCRIPTION
A gitter community has been created for the project. This change adds a README badge and references in the appropriate documentation so that it can be easily found when it is needed.