### PR TITLE
implementing STUMPLESS_OPTION_PID

### DIFF
--- a/include/private/formatter.h
+++ b/include/private/formatter.h
@@ -20,6 +20,7 @@
 #  define __STUMPLESS_PRIVATE_FORMATTER_H
 
 #  include <stumpless/entry.h>
+#  include <stumpless/target.h>
 #  include "private/strbuilder.h"
 
 #  define RFC_5424_FULL_DATE_BUFFER_SIZE 11
@@ -32,7 +33,10 @@
 #  define RFC_5424_TIMESTAMP_BUFFER_SIZE 33
 #  define RFC_5424_WHOLE_TIME_BUFFER_SIZE 20
 
+#  define RFC_5424_NILVALUE '-'
+
 struct strbuilder *
-format_entry( const struct stumpless_entry *entry );
+format_entry( const struct stumpless_entry *entry,
+              struct stumpless_target *target );
 
 #endif /* __STUMPLESS_PRIVATE_FORMATTER_H */

--- a/include/stumpless/option.h
+++ b/include/stumpless/option.h
@@ -30,7 +30,7 @@
 
 #    include <syslog.h>
 
-/** Not currently supported. PIDs are always included in stumpless messages. */
+/** Option to include the PID in stumpless messages  */
 #    define STUMPLESS_OPTION_PID    LOG_PID
 /** Not currently supported. */
 #    define STUMPLESS_OPTION_CONS   LOG_CONS
@@ -44,7 +44,7 @@
 /* options normally defined in syslog.h */
 #  else
 
-/** Not currently supported. PIDs are always included in stumpless messages. */
+/** Option to include the PID in stumpless messages  */
 #    define STUMPLESS_OPTION_PID    1
 /** Not currently supported. */
 #    define STUMPLESS_OPTION_CONS   (1<<1)

--- a/src/formatter.c
+++ b/src/formatter.c
@@ -18,13 +18,16 @@
 
 #include <stddef.h>
 #include <stumpless/entry.h>
+#include <stumpless/option.h>
+#include <stumpless/target.h>
 #include "private/config/wrapper.h"
 #include "private/entry.h"
 #include "private/strbuilder.h"
 #include "private/formatter.h"
 
 struct strbuilder *
-format_entry( const struct stumpless_entry *entry ) {
+format_entry( const struct stumpless_entry *entry,
+              struct stumpless_target *target ) {
   char timestamp[RFC_5424_TIMESTAMP_BUFFER_SIZE];
   struct strbuilder *builder;
   size_t timestamp_size;
@@ -42,7 +45,11 @@ format_entry( const struct stumpless_entry *entry ) {
   builder = strbuilder_append_char( builder, ' ' );
   builder = strbuilder_append_app_name( builder, entry );
   builder = strbuilder_append_char( builder, ' ' );
-  builder = strbuilder_append_procid( builder );
+  if (target->options & STUMPLESS_OPTION_PID) {
+    builder = strbuilder_append_procid( builder );
+  } else {
+    builder = strbuilder_append_char( builder, RFC_5424_NILVALUE );
+  }
   builder = strbuilder_append_char( builder, ' ' );
   builder = strbuilder_append_msgid( builder, entry );
   builder = strbuilder_append_char( builder, ' ' );

--- a/src/target.c
+++ b/src/target.c
@@ -104,7 +104,7 @@ stumpless_add_entry( struct stumpless_target *target,
     return config_send_entry_to_wel_target( target->id, entry );
   }
 
-  builder = format_entry( entry );
+  builder = format_entry( entry, target );
   if( !builder ) {
     return -1;
   }

--- a/test/function/target.cpp
+++ b/test/function/target.cpp
@@ -18,9 +18,12 @@
 
 #include <cstddef>
 #include <cstdlib>
+#include <regex>
+#include <string.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stumpless.h>
+#include "private/target/buffer.h"
 #include "test/function/rfc5424.hpp"
 #include "test/helper/assert.hpp"
 
@@ -602,6 +605,72 @@ namespace {
 
     option = stumpless_get_option( target, STUMPLESS_OPTION_PID );
     EXPECT_TRUE( option );
+
+    stumpless_close_buffer_target( target );
+  }
+
+  TEST( WithPid, Pid) {
+    struct stumpless_target *target;
+    struct stumpless_target *target_result;
+    struct buffer_target* internal_buffer;
+    char buffer[300];
+    int result;
+    std::cmatch matches;
+    std::regex pid_regex(RFC_5424_REGEX_STRING);
+
+    target = stumpless_open_buffer_target( "test target",
+                                           buffer,
+                                           sizeof( buffer ),
+                                           STUMPLESS_OPTION_NONE,
+                                           STUMPLESS_FACILITY_USER );
+    ASSERT_TRUE( target != NULL );
+
+    internal_buffer = (struct buffer_target*) target->id;
+
+    result = stump( "test message" );
+    EXPECT_NO_ERROR;
+    EXPECT_GE( result, 0 );
+
+    if( !std::regex_match( buffer, matches, pid_regex ) ) {
+      FAIL(  ) << "produced invalid procid";
+    } else {
+      EXPECT_EQ( matches[RFC_5424_PROCID_MATCH_INDEX], '-' );
+    }
+
+    // reset buffer
+    memset(buffer, 0, sizeof(buffer));
+    internal_buffer->position = 0;
+
+    target_result = stumpless_set_option( target, STUMPLESS_OPTION_PID );
+    EXPECT_EQ( target_result, target );
+
+    result = stump( "test message 1" );
+    EXPECT_NO_ERROR;
+    EXPECT_GE( result, 0 );
+
+    if( !std::regex_match( buffer, matches, pid_regex ) ) {
+      FAIL(  ) << "produced invalid procid";
+    } else {
+      EXPECT_NE( matches[RFC_5424_PROCID_MATCH_INDEX], '-' );
+      std::stoi( matches[RFC_5424_PROCID_MATCH_INDEX] );
+    }
+
+    // reset buffer
+    memset(buffer, 0, sizeof(buffer));
+    internal_buffer->position = 0;
+
+    target_result = stumpless_unset_option( target, STUMPLESS_OPTION_PID );
+    EXPECT_EQ( target_result, target );
+
+    result = stump( "test message 2" );
+    EXPECT_NO_ERROR;
+    EXPECT_GE( result, 0 );
+
+    if( !std::regex_match( buffer, matches, pid_regex ) ) {
+      FAIL(  ) << "produced invalid procid";
+    } else {
+      EXPECT_EQ( matches[RFC_5424_PROCID_MATCH_INDEX], '-' );
+    }
 
     stumpless_close_buffer_target( target );
   }

--- a/tools/check_headers/stumpless.yml
+++ b/tools/check_headers/stumpless.yml
@@ -291,6 +291,7 @@
 "stumpless_open_tcp4_target": "stumpless/target/network.h"
 "stumpless_open_udp4_target": "stumpless/target/network.h"
 "STUMPLESS_OPTION_NONE": "stumpless/option.h"
+"STUMPLESS_OPTION_PID": "stumpless/option.h"
 "STUMPLESS_PATCH_VERSION": "stumpless/config.h"
 "STUMPLESS_PARAM_NOT_FOUND": "stumpless/error.h"
 "stumpless_perror": "stumpless/error.h"


### PR DESCRIPTION
This should implement STUMPLESS_OPTION_PID. By default this is disabled (will not display the PID). Should fix #77.