### PR TITLE
minor documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ If you want to actually write some code or make an update yourself, take a look
 at the [development guide](docs/development.md) to get a detailed orientation.
 
 Or if you just want to say thanks or drop me a private message, please feel free
-to do so in an [email](joelanderson333@gmail.com)!
+to do so in an [email](mailto:joelanderson333@gmail.com)!
 
 ## Further Documentation
 If you're curious about how something in stumpless works that isn't explained

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -37,12 +37,18 @@ we'll review it for inclusion into the latest version. Make sure that you follow
 these guidelines:
  * Include a `Signed-off-by` tag in all of your commits (using the `-s` option
    of `git commit`).
- * Keep the number of commits in your request to a minimum. Having multiple
-   commits is fine if necessary to separate multiple changes, but make sure
-   that these are logical and add value to the commit history. For smaller
-   changes, your request may simply be squash merged, making sure to preserve
-   credit to you for the contribution. If you need a little guidance to get
-   started with adjusting the commit history of your change, check out
+ * If you're working on something that's relatively small, then you don't need
+   to worry about the number of commits in your branch, as it will be squashed
+   before it is merged into the `latest` branch. If you're working on something
+   marked as a `good first issue` for example, don't worry about keeping a clean
+   commit history and just focus on the fun stuff! You will be retained as the
+   author of the commit, to make sure that contribution credit is be reflected
+   in github. But if you're working on something larger, squashing it into a
+   single commit might not make a lot of sense, and so the number of commits
+   becomes more important. If you find yourself in this situation, try to make
+   sure that each commit is logical and adds value to the commit history. If
+   you need a little guidance to get started with adjusting the commit history
+   of your change, check out
    [this chapter](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
    from the Git Book about it, which covers several common adjustments.
  * If a commit resolves or is otherwise related to a particular issue, include

--- a/include/stumpless/option.h
+++ b/include/stumpless/option.h
@@ -27,34 +27,42 @@
 
 /* options defined in syslog.h */
 #  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-
 #    include <syslog.h>
+#  endif
 
-/** Option to include the PID in stumpless messages  */
+/** Option to include the PID in stumpless messages. */
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
 #    define STUMPLESS_OPTION_PID    LOG_PID
-/** Not currently supported. */
-#    define STUMPLESS_OPTION_CONS   LOG_CONS
-/** Not currently supported. */
-#    define STUMPLESS_OPTION_NDELAY LOG_NDELAY
-/** Not currently supported. */
-#    define STUMPLESS_OPTION_ODELAY LOG_ODELAY
-/** Not currently supported. */
-#    define STUMPLESS_OPTION_NOWAIT LOG_NOWAIT
-
-/* options normally defined in syslog.h */
 #  else
-
-/** Option to include the PID in stumpless messages  */
 #    define STUMPLESS_OPTION_PID    1
-/** Not currently supported. */
-#    define STUMPLESS_OPTION_CONS   (1<<1)
-/** Not currently supported. */
-#    define STUMPLESS_OPTION_NDELAY (1<<2)
-/** Not currently supported. */
-#    define STUMPLESS_OPTION_ODELAY (1<<3)
-/** Not currently supported. */
-#    define STUMPLESS_OPTION_NOWAIT (1<<4)
+#  endif
 
+/** Not currently supported. */
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_OPTION_CONS   LOG_CONS
+#  else
+#    define STUMPLESS_OPTION_CONS   (1<<1)
+#  endif
+
+/** Not currently supported. */
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_OPTION_NDELAY LOG_NDELAY
+#  else
+#    define STUMPLESS_OPTION_NDELAY (1<<2)
+#  endif
+
+/** Not currently supported. */
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_OPTION_ODELAY LOG_ODELAY
+#  else
+#    define STUMPLESS_OPTION_ODELAY (1<<3)
+#  endif
+
+/** Not currently supported. */
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_OPTION_NOWAIT LOG_NOWAIT
+#  else
+#    define STUMPLESS_OPTION_NOWAIT (1<<4)
 #  endif
 
 /** Empty option mask for explicit 'no option' use. */


### PR DESCRIPTION
Improvements to project documentation noted during review of #110. 

Several contributors have followed the guidance in the `docs/CONTRIBUTING.md` document which states that PRs should keep the number of commits to a minimum. However doing this requires force-pushing each change to a PR so that it remains a single commit, which makes it difficult to track changes to the PR as it develops. This change softens the language of the contribution guidelines to make it clear that smaller changes (such as first issue ones) do not need to worry about commit history cleanliness as they will be squash merged.

The current structure of the option header `include/stumpless/option.h` required the documentation of the option to be repeated in two places in the same file during implementation. Since this is a clear violation of the DRY principle and is no fault of the implementer of the option, the header has been restructured to only document each option once. This uses the same strategy as the `include/stumpless/level` headers which had similar issues during their development. This will simplify the documentation step of the remaining open issues for option implementation.

This change also corrects a broken email link in the main README.