### PR TITLE
add stumpless_param_to_string function

### DIFF
--- a/include/stumpless/param.h
+++ b/include/stumpless/param.h
@@ -161,6 +161,20 @@ stumpless_set_param_name( struct stumpless_param *param, const char *name );
 struct stumpless_param *
 stumpless_set_param_value( struct stumpless_param *param, const char *value );
 
+
+/**
+ * Returns the name and the value from param as a formatted string.
+ * The character buffer should be freed when no longer is needed by the caller.
+ *
+ * @param param The param to get the name and the value from.  
+ *
+ * @return The formatted string of <name>: <value> if no error is encountered.
+ * If an error is  encountered, then NULL is returned and an error code is set appropriately.
+ */
+
+const char *
+stumpless_param_to_string(const struct stumpless_param * param);
+
 #  ifdef __cplusplus
 }                               /* extern "C" */
 #  endif

--- a/src/param.c
+++ b/src/param.c
@@ -18,6 +18,7 @@
 
 #include <stddef.h>
 #include <stumpless/param.h>
+#include <string.h>
 #include "private/error.h"
 #include "private/memory.h"
 #include "private/strhelper.h"
@@ -139,3 +140,46 @@ stumpless_set_param_value( struct stumpless_param *param, const char *value ) {
 fail:
   return NULL;
 }
+
+const char *
+stumpless_param_to_string(const struct stumpless_param * param) {
+
+    char *format;
+    const char *name;
+    const char *value;
+    size_t value_len;
+    size_t name_len;
+
+    VALIDATE_ARG_NOT_NULL(param);
+
+    name  = stumpless_get_param_name(param);
+    value = stumpless_get_param_value(param);
+
+    name_len = param->name_length;
+    value_len = param->value_length;
+
+    /* <name>:<value> */
+    format = alloc_mem(value_len + name_len + 6);
+    if (format == NULL)
+        goto fail;
+   
+    
+
+    format[0] = '<';
+    memcpy(format + 1, name, name_len);
+    format[name_len + 1] = '>';
+    format[name_len + 2] = ':';
+    format[name_len + 3] = '<';
+    memcpy(format + name_len + 4, value, value_len);
+    format[name_len + value_len + 4] = '>';
+    format[name_len + value_len + 5] = '\0';
+
+
+    clear_error( );
+    return format;
+    
+fail:
+    return NULL;
+}
+
+

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -144,3 +144,4 @@ EXPORTS
   stumpless_set_param_value_by_name             @133
   stump                                         @134
   vstump                                        @135
+  stumpless_param_to_string                     @136

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -134,6 +134,37 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
   }
 
+
+  TEST_F( ParamTest, GetParamToString) {
+      const char *format;
+    
+      format = stumpless_param_to_string( basic_param );
+      ASSERT_NOT_NULL( format );
+
+      EXPECT_STREQ( format, "<basic-name>:<basic-value>" );
+      EXPECT_NO_ERROR;
+  }
+
+  TEST_F( ParamTest, ParamToStringMemoryFailure ) {
+    void * (*set_malloc_result)(size_t);
+    const struct stumpless_error *error;
+    const char *result;
+    
+    
+    // create the internal error struct
+    stumpless_get_param_name( NULL );
+
+    set_malloc_result = stumpless_set_malloc( [](size_t size)->void *{ return NULL; } );
+    ASSERT_NOT_NULL( set_malloc_result );
+
+    result = stumpless_param_to_string( basic_param );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
+
+    set_malloc_result = stumpless_set_malloc( malloc );
+    EXPECT_TRUE( set_malloc_result == malloc );
+  }
+
   /* non-fixture tests */
 
   TEST( CopyParamTest, NullParam ) {
@@ -319,6 +350,15 @@ namespace {
     const struct stumpless_error *error;
 
     result = stumpless_set_param_value( NULL, "new-value" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+  }
+
+  TEST( ParamToStringTest, NullParam) {
+    const char *result;
+    const struct stumpless_error *error;
+
+    result = stumpless_param_to_string( NULL );
     EXPECT_NULL( result );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
   }


### PR DESCRIPTION
Implemented param to string function as described in issue #128. It gets the param and return a formatted string like;
 \<name\>:\<value\> with memcpy and assignment. 