### PR TITLE
add validation on app name length

### DIFF
--- a/include/private/validate.h
+++ b/include/private/validate.h
@@ -61,13 +61,4 @@ bool validate_msgid_format( const char* msgid );
  */
 bool validate_app_name_length( const char* app_name);
 
-
-
-
-
-
-
-
-
-
 #endif /* __STUMPLESS_PRIVATE_VALIDATE_H */

--- a/include/private/validate.h
+++ b/include/private/validate.h
@@ -50,4 +50,24 @@ bool validate_msgid_length(const char* msgid );
  */
 bool validate_msgid_format( const char* msgid );
 
+/**
+ * Checks the length of app name.
+ *
+ * @param the app name
+ *
+ * @return True if the app name is less than allowed length 
+ * (48 characters not including NULL terminating),otherwise
+ * it will return false and raise STUMPLESS_ARGUMENT_TOO_BIG error.
+ */
+bool validate_app_name_length( const char* app_name);
+
+
+
+
+
+
+
+
+
+
 #endif /* __STUMPLESS_PRIVATE_VALIDATE_H */

--- a/include/stumpless/entry.h
+++ b/include/stumpless/entry.h
@@ -498,7 +498,7 @@ stumpless_set_element( struct stumpless_entry *entry,
  * entry. This will be copied in to the entry, and therefore may be modified
  * or freed after this call without affecting the entry. If this is NULL, then
  * a single '-' character will be used, as specified as the NILVALUE in RFC
- * 5424.
+ * 5424. The app name length is restricted to be 48 characters or less.
  *
  * @return The modified entry if no error is encountered. If an error is
  * encountered, then NULL is returned and an error code is set appropriately.
@@ -714,7 +714,8 @@ stumpless_set_entry_severity( struct stumpless_entry *entry, int severity );
  * \c STUMPLESS_SEVERITY value.
  *
  * @param app_name The app_name of the entry. If this is NULL, then it will be
- * blank in the entry (a single '-' character).
+ * blank in the entry (a single '-' character). The app name length is restricted
+ * to be 48 characters or less.
  *
  * @param msgid The message id of the entry. If this is NULL, then it will be
  * blank in the entry (a single '-' character).

--- a/include/stumpless/target.h
+++ b/include/stumpless/target.h
@@ -364,6 +364,7 @@ stumpless_set_option( struct stumpless_target *target, int option );
  * @param target The target to modify.
  *
  * @param app_name The new default app name, as a NULL-terminated string.
+ * The app name length is restricted to be 48 characters or less.
  *
  * @return The modified target if no error is encountered. If an error is
  * encountered, then NULL is returned and an error code is set appropriately.

--- a/src/entry.c
+++ b/src/entry.c
@@ -702,8 +702,6 @@ vstumpless_new_entry( int facility,
     goto fail_app_name;
   }
 
-  
-
   effective_msgid = msgid ? msgid : "-";
   if( !validate_msgid_length( effective_msgid ) || !validate_msgid_format( effective_msgid ) ) {
       goto fail_msgid;

--- a/src/entry.c
+++ b/src/entry.c
@@ -448,6 +448,11 @@ stumpless_set_entry_app_name( struct stumpless_entry *entry,
   VALIDATE_ARG_NOT_NULL( entry );
 
   effective_name = app_name ? app_name : "-";
+
+  if ( !validate_app_name_length( effective_name ) ) {
+      return NULL;
+  }
+
   temp_name = copy_cstring_with_length( effective_name, &temp_name_length );
   if( !temp_name ) {
     return NULL;
@@ -686,12 +691,18 @@ vstumpless_new_entry( int facility,
   }
 
   effective_app_name = app_name ? app_name : "-";
+  if ( !validate_app_name_length ( effective_app_name ) ) {
+      goto fail_app_name;
+  }
+
   app_name_length = &( entry->app_name_length );
   entry->app_name = copy_cstring_with_length( effective_app_name,
                                               app_name_length );
   if( !entry->app_name ) {
     goto fail_app_name;
   }
+
+  
 
   effective_msgid = msgid ? msgid : "-";
   if( !validate_msgid_length( effective_msgid ) || !validate_msgid_format( effective_msgid ) ) {

--- a/src/target.c
+++ b/src/target.c
@@ -324,6 +324,10 @@ stumpless_set_target_default_app_name( struct stumpless_target *target,
   VALIDATE_ARG_NOT_NULL( target );
   VALIDATE_ARG_NOT_NULL( app_name );
 
+  if ( !validate_app_name_length( app_name ) ) {
+      return NULL;
+  }
+
   app_name_length = &( target->default_app_name_length );
   sized_name = copy_cstring_with_length( app_name, app_name_length );
   if( !sized_name ) {

--- a/src/validate.c
+++ b/src/validate.c
@@ -50,3 +50,19 @@ bool validate_msgid_format( const char* msgid ) {
 
   return true;
 }
+
+bool validate_app_name_length( const char* app_name ) {
+    size_t max_app_name_length = 48;
+    size_t app_name_char_length = strlen( app_name );
+    bool validation_status = true;
+
+    if ( app_name_char_length > max_app_name_length ) {
+        raise_argument_too_big( L10N_STRING_TOO_LONG_ERROR_MESSAGE,
+                app_name_char_length,
+                L10N_STRING_LENGTH_ERROR_CODE_TYPE );
+
+        validation_status = false;
+    }
+
+    return validation_status;
+}

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -548,20 +548,20 @@ namespace {
   }
 
   TEST_F( EntryTest, SetAppName ) {
-      struct stumpless_entry *entry;
-      const char *previous_app_name;
-      const char *new_app_name = "new-app-name";
+    struct stumpless_entry *entry;
+    const char *previous_app_name;
+    const char *new_app_name = "new-app-name";
 
-      size_t new_app_name_length = strlen( new_app_name );
+    size_t new_app_name_length = strlen( new_app_name );
 
-      previous_app_name = basic_entry->app_name;
+    previous_app_name = basic_entry->app_name;
 
-      entry = stumpless_set_entry_app_name( basic_entry, new_app_name );
-      EXPECT_NO_ERROR;
-      EXPECT_EQ( entry, basic_entry );
+    entry = stumpless_set_entry_app_name( basic_entry, new_app_name );
+    EXPECT_NO_ERROR;
+    EXPECT_EQ( entry, basic_entry );
 
-      ASSERT_EQ( new_app_name_length, basic_entry->app_name_length );
-      ASSERT_EQ( 0, memcmp( basic_entry->app_name, new_app_name, new_app_name_length ) );
+    ASSERT_EQ( new_app_name_length, basic_entry->app_name_length );
+    ASSERT_EQ( 0, memcmp( basic_entry->app_name, new_app_name, new_app_name_length ) );
   }
 
   TEST_F( EntryTest, SetAppNameMemoryFailure ) {

--- a/test/function/target.cpp
+++ b/test/function/target.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 #include <stumpless.h>
 #include "private/target/buffer.h"
+#include "private/validate.h"
 #include "test/function/rfc5424.hpp"
 #include "test/helper/assert.hpp"
 
@@ -376,6 +377,25 @@ namespace {
     if( error ) {
       EXPECT_EQ( error->id, STUMPLESS_ARGUMENT_EMPTY );
     }
+  }
+
+  TEST( SetDefaultAppName, AppNameTargetRejected ) {
+      char buffer[100];
+      struct stumpless_target* target;
+      struct stumpless_target* target_result;
+      struct stumpless_error* error;
+
+      target = stumpless_open_buffer_target( "test target",
+              buffer,
+              sizeof( buffer ),
+              STUMPLESS_OPTION_NONE,
+              STUMPLESS_FACILITY_USER );
+      ASSERT_TRUE( target != NULL );
+
+
+      target_result = stumpless_set_target_default_app_name( target, "app-name-that-is-too-long-to-be-accepted-it-should-be-rejected1" );
+
+      EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
   }
 
   TEST( SetDefaultFacility, Local1 ) {

--- a/test/function/target.cpp
+++ b/test/function/target.cpp
@@ -23,7 +23,6 @@
 #include <gtest/gtest.h>
 #include <stumpless.h>
 #include "private/target/buffer.h"
-#include "private/validate.h"
 #include "test/function/rfc5424.hpp"
 #include "test/helper/assert.hpp"
 


### PR DESCRIPTION
implemented validate_app_name_length function. Now app name length is restricted to be 48 characters or less as described in issue #129 .