### PR TITLE
deprecate ambiguous destructors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Test
         run: |
           make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
       - name: Thread Safety Tests
         run: |
           make check-thread-safety
@@ -128,6 +129,7 @@ jobs:
       - name: Test
         run: |
           make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
       - name: Run Examples
         run: |
           make examples
@@ -179,6 +181,7 @@ jobs:
       - name: Test
         run: |
           make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
   linux-es-es:
     name: "linux, es-es"
     runs-on: "ubuntu-20.04"
@@ -198,6 +201,7 @@ jobs:
       - name: Test
         run: |
           make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
   linux-fr-fr:
     name: "linux, fr-fr"
     runs-on: "ubuntu-20.04"
@@ -217,6 +221,7 @@ jobs:
       - name: Test
         run: |
           make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
   linux-sv-se:
     name: "linux, sv-se"
     runs-on: "ubuntu-20.04"
@@ -236,6 +241,7 @@ jobs:
       - name: Test
         run: |
           make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
   linux-sk-sk:
     name: "linux, sk-sk"
     runs-on: "ubuntu-20.04"
@@ -255,6 +261,7 @@ jobs:
       - name: Test
         run: |
           make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
   mac-debug:
     name: "mac, debug"
     runs-on: "macos-11.0"
@@ -269,6 +276,7 @@ jobs:
       - name: Test
         run: |
           make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
       - name: Thread Safety Tests
         run: |
           make check-thread-safety
@@ -307,6 +315,7 @@ jobs:
       - name: Test
         run: |
           make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
       - name: Thread Safety Tests
         run: |
           make check-thread-safety
@@ -348,6 +357,7 @@ jobs:
       - name: Test
         run: |
           make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
       - name: Run Examples
         run: |
           make examples

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Test
         run: |
           make check
-          if [[ grep -q "DEPRECATED" Testing/Temporary/LastTest.log ]]; then exit 1; fi
+          if grep -q "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
       - name: Thread Safety Tests
         run: |
           make check-thread-safety

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Test
         run: |
           make check
-          if grep -q "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
       - name: Thread Safety Tests
         run: |
           make check-thread-safety

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,7 @@ jobs:
           cmake .
           ./build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-output make all
           wget -q https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.5.0.2216-linux.zip
-          ls
           unzip -qq -o sonar-scanner-cli-4.5.0.2216-linux.zip
-          ls
           chmod +x sonar-scanner-4.5.0.2216-linux/bin/sonar-scanner
           sonar-scanner-4.5.0.2216-linux/bin/sonar-scanner
         env:
@@ -50,6 +48,7 @@ jobs:
       - name: Test
         run: |
           make check
+          if [[ grep -q "DEPRECATED" Testing/Temporary/LastTest.log ]]; then exit 1; fi
       - name: Thread Safety Tests
         run: |
           make check-thread-safety

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ option(ENABLE_SOCKET_TARGETS "support unix domain socket targets" ON)
 option(ENABLE_WINDOWS_EVENT_LOG_TARGETS "support windows event log targets" ON)
 option(COVERAGE "Include coverage information" OFF)
 
+string(CONCAT enable_deprecation_warnings_help_string
+  "Print warnings to the standard output when deprecated functionality is used."
+)
+option(ENABLE_DEPRECATION_WARNINGS ${enable_deprecation_warnings_help_string} ON)
+
 string(CONCAT default_facility_help_string
   "The facility code to use for messages where one is not explicitly provided."
 )
@@ -125,6 +130,12 @@ check_symbol_exists(sysconf unistd.h HAVE_UNISTD_SYSCONF)
 check_symbol_exists(wcstombs_s windows.h HAVE_WCSTOMBS_S)
 
 find_program(HAVE_WRAPTURE NAMES wrapture)
+
+if(ENABLE_DEPRECATION_WARNINGS)
+  set(STUMPLESS_DEPRECATION_WARNINGS_ENABLED TRUE)
+else()
+  set(STUMPLESS_DEPRECATION_WARNINGS_ENABLED OFF)
+endif()
 
 if(EXISTS "/var/run/syslog")
   set(STUMPLESS_DEFAULT_SOCKET "/var/run/syslog")

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/stumpless/blob/master/docs/roadmap.md).
 
-## [2.0.0] - 2020-12-09
+## [2.0.0] - 2020-12-10
 ### Added
  - Localization framework for error messages and other library strings.
  - Thread safety for all functionality.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/stumpless/blob/master/docs/roadmap.md).
 
-## [2.0.0] - 2020-12-06
+## [2.0.0] - 2020-12-09
 ### Added
  - Localization framework for error messages and other library strings.
  - Thread safety for all functionality.
@@ -51,6 +51,16 @@ fixes, check out the
    need to be adjusted on a target, use the `stumpless_set_option` and
    `stumpless_set_default_facility` functions after the target has been
    created.
+
+### Deprecated
+ - `stumpless_destroy_entry` has been deprecated in favor of the more
+   descriptive and deliberate `stumpless_destroy_entry_and_contents` and
+   `stumpless_destroy_entry_only` functions in order to avoid unintentional
+   memory leaks and use-after-free mistakes.
+ - `stumpless_destroy_element` has been deprecated in favor of the more
+   descriptive and deliberate `stumpless_destroy_element_and_contents` and
+   `stumpless_destroy_element_only` functions in order to avoid
+   unintentional memory leaks and use-after-free mistakes.
 
 ### Fixed
  - Memory leak in opening of network targets on systems using `sys/socket.h`

--- a/docs/examples/entry/entry_example.c
+++ b/docs/examples/entry/entry_example.c
@@ -26,6 +26,11 @@ main( int argc, char **argv ) {
   struct stumpless_entry *formatted_entry;
   struct stumpless_entry *failed_login_entry;
   struct stumpless_target *stdout_target;
+  struct stumpless_param *user;
+  struct stumpless_param *token;
+  struct stumpless_element *context;
+  struct stumpless_entry *refresh_entry;
+  struct stumpless_entry *logout_entry;
 
 
   // creating a logging target for standard out to see the result of logging
@@ -97,12 +102,39 @@ main( int argc, char **argv ) {
   // closing the target once we are finished
   stumpless_close_target( stdout_target );
 
-  // destroying all the resources before finishing up
-  stumpless_destroy_entry( basic_entry );
-  stumpless_destroy_entry( formatted_entry );
 
-  // we include the contents here to make sure the structured data is cleaned up
+  // destroying all the resources before finishing up
+  stumpless_destroy_entry_and_contents( basic_entry );
+  stumpless_destroy_entry_and_contents( formatted_entry );
   stumpless_destroy_entry_and_contents( failed_login_entry );
+
+
+  // creating two entries with shared elements and params
+  user = stumpless_new_param( "username", "thomas" );
+  token = stumpless_new_param( "token", "0xdeadbeef" );
+  context = stumpless_new_element( "context" );
+  stumpless_add_param( context, user );
+  stumpless_add_param( context, token );
+  refresh_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                                       STUMPLESS_SEVERITY_NOTICE,
+                                       "company-web-portal",
+                                       "refresh-request",
+                                       "user requested a refresh" );
+  stumpless_add_element( refresh_entry, context );
+
+  logout_entry = stumpless_new_entry( STUMPLESS_FACILITY_AUTH,
+                                      STUMPLESS_SEVERITY_NOTICE,
+                                      "company-web-portal",
+                                      "logout",
+                                      "user logged out" );
+  stumpless_add_element( logout_entry, context );
+
+
+  // destroying the shared resources individually
+  stumpless_destroy_entry_only( logout_entry );
+  stumpless_destroy_entry_only( refresh_entry );
+  stumpless_destroy_element_and_contents( context );
+ 
 
   // final call required to completely free all resources (caches, etc.)
   stumpless_free_all(  );

--- a/docs/examples/entry/entry_example.c
+++ b/docs/examples/entry/entry_example.c
@@ -134,7 +134,7 @@ main( int argc, char **argv ) {
   stumpless_destroy_entry_only( logout_entry );
   stumpless_destroy_entry_only( refresh_entry );
   stumpless_destroy_element_and_contents( context );
- 
+
 
   // final call required to completely free all resources (caches, etc.)
   stumpless_free_all(  );

--- a/docs/examples/file/file_example.c
+++ b/docs/examples/file/file_example.c
@@ -80,7 +80,7 @@ main( int argc, char **argv ) {
 
 
   // destroying all the other resources before finishing up:
-  stumpless_destroy_entry( entry );
+  stumpless_destroy_entry_and_contents( entry );
   stumpless_free_all(  );
 
 

--- a/docs/examples/network/tcp_example.c
+++ b/docs/examples/network/tcp_example.c
@@ -125,7 +125,7 @@ main( int argc, char **argv ) {
 
 
   // destroying all the other resources before finishing up:
-  stumpless_destroy_entry( basic_entry );
+  stumpless_destroy_entry_and_contents( basic_entry );
   stumpless_free_all(  );
 
   return EXIT_SUCCESS;

--- a/docs/examples/network/udp_example.c
+++ b/docs/examples/network/udp_example.c
@@ -109,7 +109,7 @@ main( int argc, char **argv ) {
 
 
   // destroying all the other resources before finishing up:
-  stumpless_destroy_entry( basic_entry );
+  stumpless_destroy_entry_and_contents( basic_entry );
   stumpless_free_all(  );
 
   return EXIT_SUCCESS;

--- a/docs/examples/socket/socket_example.c
+++ b/docs/examples/socket/socket_example.c
@@ -101,7 +101,7 @@ main( int argc, char **argv ) {
 
 
   // destroying all the other resources before finishing up:
-  stumpless_destroy_entry( entry );
+  stumpless_destroy_entry_and_contents( entry );
   stumpless_free_all(  );
 
   return EXIT_SUCCESS;

--- a/docs/examples/stream/stream_example.c
+++ b/docs/examples/stream/stream_example.c
@@ -88,7 +88,7 @@ main( int argc, char **argv ) {
 
 
   // destroying all remaining resources
-  stumpless_destroy_entry( basic_entry );
+  stumpless_destroy_entry_and_contents( basic_entry );
 
 
   return EXIT_SUCCESS;

--- a/docs/examples/wel/wel_example.c
+++ b/docs/examples/wel/wel_example.c
@@ -182,8 +182,8 @@ main( int argc, char **argv ) {
 
 
   // destroying all remaining resources
-  stumpless_destroy_entry( basic_entry );
-  stumpless_destroy_entry( entry_with_params );
+  stumpless_destroy_entry_and_contents( basic_entry );
+  stumpless_destroy_entry_and_contents( entry_with_params );
   stumpless_destroy_param( child_name );
   stumpless_destroy_param( tree_type );
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,19 +5,6 @@ or want to make a suggestion, please submit an issue on the project's
 [Github page](https://github.com/goatshriek/stumpless).
 
 ## 2.0.0 (next major and minor release)
- * [DEPRECATE] **entry and element destructor synonyms**
-   Currently, there are two forms of the destructors for these two structures:
-   one that destroys the object itself, and one that destroys the object and all
-   of the ones that it contains. The former is named `destroy_..._only` while
-   the latter is named `destroy_..._and_contents`. The latter has a synonym
-   named simply `destroy`, which does not convey its behavior well. This alias
-   will be deprecated, and removed in the next major release in order to prevent
-   confusion and misuse of the two forms.
- * [CHANGE] **Destructors no longer clear errors**
-   As destruction functions do not throw any errors by design, they should not
-   clear the error flags. Clearing them can especially cause confusion in other
-   language bindings, where the calling of the destructor is not explicit and
-   may be difficult to track down.
  * [CHANGE] **Facilities and severities will be defined by enumerations**
    Enumerations are a cleaner way to represent the set values, and can be made
    compatible with the `syslog.h` values if their backing `int` values match.

--- a/include/private/deprecate.h
+++ b/include/private/deprecate.h
@@ -23,7 +23,7 @@
 
 #  ifdef STUMPLESS_DEPRECATION_WARNINGS_ENABLED
 #    include <stdio.h>
-#    define warn_of_deprecation( WARNING ) printf( WARNING )
+#    define warn_of_deprecation( WARNING ) printf( "DEPRECATED: " WARNING "\n" )
 #  else
 #    define warn_of_deprecation( WARNING ) ( ( void ) 0 )
 #  endif

--- a/include/private/deprecate.h
+++ b/include/private/deprecate.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Copyright 2020 Joel E. Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __STUMPLESS_PRIVATE_DEPRECATE_H
+#  define __STUMPLESS_PRIVATE_DEPRECATE_H
+
+
+
+#endif /* __STUMPLESS_PRIVATE_DEPRECATE_H */

--- a/include/private/deprecate.h
+++ b/include/private/deprecate.h
@@ -19,6 +19,13 @@
 #ifndef __STUMPLESS_PRIVATE_DEPRECATE_H
 #  define __STUMPLESS_PRIVATE_DEPRECATE_H
 
+#  include <stumpless/config.h>
 
+#  ifdef STUMPLESS_DEPRECATION_WARNINGS_ENABLED
+#    include <stdio.h>
+#    define warn_of_deprecation( WARNING ) printf( WARNING )
+#  else
+#    define warn_of_deprecation( WARNING ) ( ( void ) 0 )
+#  endif
 
 #endif /* __STUMPLESS_PRIVATE_DEPRECATE_H */

--- a/include/stumpless/config.h.in
+++ b/include/stumpless/config.h.in
@@ -57,6 +57,9 @@
 /** Defined if Windows Event Log targets are supported by this build. */
 #cmakedefine STUMPLESS_WINDOWS_EVENT_LOG_TARGETS_SUPPORTED 1
 
+/** Defined if deprecation warnings are printed to standard output. */
+#cmakedefine STUMPLESS_DEPRECATION_WARNINGS_ENABLED 1
+
 /** The major version of this stumpless build. */
 #define STUMPLESS_MAJOR_VERSION @PROJECT_VERSION_MAJOR@
 

--- a/include/stumpless/element.h
+++ b/include/stumpless/element.h
@@ -198,6 +198,11 @@ stumpless_copy_element( const struct stumpless_element *element );
  * cancelled, as the cleanup of the lock may not be completed, and the memory
  * deallocation function may not be AC-Safe itself.
  *
+ * @deprecated This function has been deprecated in favor of the more
+ * descriptive and deliberate stumpless_destroy_element_and_contents and
+ * stumpless_destroy_element_only functions in order to avoid unintentional
+ * memory leaks and use-after-free mistakes.
+ *
  * @param element The element to destroy.
  */
 void

--- a/include/stumpless/entry.h
+++ b/include/stumpless/entry.h
@@ -234,6 +234,11 @@ stumpless_copy_entry( const struct stumpless_entry *entry );
  * cancelled, as the cleanup of the lock may not be completed, and the memory
  * deallocation function may not be AC-Safe itself.
  *
+ * @deprecated This function has been deprecated in favor of the more
+ * descriptive and deliberate stumpless_destroy_entry_and_contents and
+ * stumpless_destroy_entry_only functions in order to avoid unintentional
+ * memory leaks and use-after-free mistakes.
+ *
  * @param entry The entry to destroy.
  */
 void

--- a/src/element.c
+++ b/src/element.c
@@ -23,6 +23,7 @@
 #include <stumpless/param.h>
 #include "private/config/locale/wrapper.h"
 #include "private/config/wrapper/thread_safety.h"
+#include "private/deprecate.h"
 #include "private/element.h"
 #include "private/error.h"
 #include "private/memory.h"
@@ -119,6 +120,13 @@ fail:
 
 void
 stumpless_destroy_element( const struct stumpless_element *element ) {
+  warn_of_deprecation( "stumpless_destroy_element has been deprecated in favor "
+                       "of the more descriptive and deliberate "
+                       "stumpless_destroy_element_and_contents and "
+                       "stumpless_destroy_element_only functions in order to "
+                       "avoid unintentional memory leaks and use-after-free "
+                       "mistakes" );
+
   stumpless_destroy_element_and_contents( element );
 }
 

--- a/src/entry.c
+++ b/src/entry.c
@@ -72,7 +72,7 @@ stumpless_add_new_element( struct stumpless_entry *entry,
   result = stumpless_add_element( entry, new_element );
 
   if( !result ) {
-    stumpless_destroy_element( new_element );
+    stumpless_destroy_element_only( new_element );
   }
 
   return result;
@@ -204,7 +204,7 @@ stumpless_destroy_entry_and_contents( const struct stumpless_entry *entry ) {
   }
 
   for( i = 0; i < entry->element_count; i++ ) {
-    stumpless_destroy_element( entry->elements[i] );
+    stumpless_destroy_element_and_contents( entry->elements[i] );
   }
 
   unchecked_destroy_entry( entry );

--- a/src/entry.c
+++ b/src/entry.c
@@ -27,6 +27,7 @@
 #include "private/config/locale/wrapper.h"
 #include "private/config/wrapper.h"
 #include "private/config/wrapper/thread_safety.h"
+#include "private/deprecate.h"
 #include "private/element.h"
 #include "private/entry.h"
 #include "private/error.h"
@@ -184,6 +185,13 @@ cleanup_and_fail:
 
 void
 stumpless_destroy_entry( const struct stumpless_entry *entry ) {
+  warn_of_deprecation( "stumpless_destroy_entry has been deprecated in favor "
+                       "of the more descriptive and deliberate "
+                       "stumpless_destroy_entry_and_contents and "
+                       "stumpless_destroy_entry_only functions in order to "
+                       "avoid unintentional memory leaks and use-after-free "
+                       "mistakes" );
+
   stumpless_destroy_entry_and_contents( entry );
 }
 

--- a/src/target.c
+++ b/src/target.c
@@ -691,7 +691,7 @@ target_free_global( void ) {
 
 void
 target_free_thread( void ) {
-  stumpless_destroy_entry( cached_entry );
+  stumpless_destroy_entry_and_contents( cached_entry );
   cached_entry = NULL;
 }
 

--- a/test/function/config/network_unsupported.cpp
+++ b/test/function/config/network_unsupported.cpp
@@ -44,7 +44,7 @@ namespace {
     EXPECT_LT( result, 0 );
     EXPECT_ERROR_ID_EQ( STUMPLESS_TARGET_UNSUPPORTED );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
 
     target->type = STUMPLESS_BUFFER_TARGET;
     stumpless_close_buffer_target( target );

--- a/test/function/config/socket_unsupported.cpp
+++ b/test/function/config/socket_unsupported.cpp
@@ -67,6 +67,6 @@ namespace {
 
     EXPECT_ERROR_ID_EQ( STUMPLESS_TARGET_UNSUPPORTED );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
   }
 }

--- a/test/function/config/wel_supported.cpp
+++ b/test/function/config/wel_supported.cpp
@@ -61,8 +61,8 @@ namespace {
 
     virtual void
     TearDown( void ) {
-      stumpless_destroy_entry( simple_entry );
-      stumpless_destroy_entry( insertion_entry );
+      stumpless_destroy_entry_and_contents( simple_entry );
+      stumpless_destroy_entry_and_contents( insertion_entry );
     }
   };
 
@@ -198,7 +198,7 @@ namespace {
 
     EXPECT_TRUE( stumpless_get_error(  ) == NULL );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
     stumpless_destroy_param( param );
   }
 
@@ -229,7 +229,7 @@ namespace {
     EXPECT_EQ( entry_result, entry );
     EXPECT_TRUE( stumpless_get_error(  ) == NULL );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
     stumpless_destroy_param( param_1 );
     stumpless_destroy_param( param_2 );
   }
@@ -261,7 +261,7 @@ namespace {
     EXPECT_EQ( entry_result, entry );
     EXPECT_TRUE( stumpless_get_error(  ) == NULL );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
     stumpless_destroy_param( param_1 );
     stumpless_destroy_param( param_2 );
   }
@@ -291,7 +291,7 @@ namespace {
 
     EXPECT_TRUE( stumpless_get_error(  ) == NULL );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
   }
 
   TEST( WelSetInsertionStringTest, SetTwoStrings ) {
@@ -313,7 +313,7 @@ namespace {
     EXPECT_EQ( entry_result, entry );
     EXPECT_TRUE( stumpless_get_error(  ) == NULL );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
   }
 
   TEST( WelSetInsertionStringTest, SetTwoStringsOutOfOrder ) {
@@ -335,7 +335,7 @@ namespace {
     EXPECT_EQ( entry_result, entry );
     EXPECT_TRUE( stumpless_get_error(  ) == NULL );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
   }
 
   TEST( WelSetInsertionStringsTest, NullEntry ) {
@@ -363,7 +363,7 @@ namespace {
     EXPECT_NULL( result );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
   }
 
   TEST( WelSetInsertionStringsTest, TwoStrings ) {
@@ -394,6 +394,6 @@ namespace {
     EXPECT_TRUE( insertion != second );
     EXPECT_STREQ( insertion, second );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
   }
 }

--- a/test/function/config/wel_unsupported.cpp
+++ b/test/function/config/wel_unsupported.cpp
@@ -65,6 +65,6 @@ namespace {
     EXPECT_LT( result, 0 );
     EXPECT_ERROR_ID_EQ( STUMPLESS_TARGET_UNSUPPORTED );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
   }
 }

--- a/test/function/element.cpp
+++ b/test/function/element.cpp
@@ -753,7 +753,7 @@ namespace {
   }
 
   TEST( DestroyElementTest, NullElement ) {
-    stumpless_destroy_element( NULL );
+    stumpless_destroy_element_and_contents( NULL );
   }
 
   TEST( GetElementNameTest, NullElement ) {

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -703,7 +703,7 @@ namespace {
     EXPECT_NE( stumpless_get_element_by_index( basic_entry, 0 ),
                previous_element );
 
-    stumpless_destroy_element( previous_element );
+    stumpless_destroy_element_and_contents( previous_element );
   }
 
   TEST_F( EntryTest, SetElementDuplicateName ) {
@@ -723,7 +723,7 @@ namespace {
     EXPECT_EQ( stumpless_get_element_by_index( basic_entry, 0 ),
                previous_element );
 
-    stumpless_destroy_element( new_element );
+    stumpless_destroy_element_and_contents( new_element );
   }
 
   TEST_F( EntryTest, SetElementIndexOutOfBounds ) {
@@ -744,7 +744,7 @@ namespace {
     EXPECT_EQ( stumpless_get_element_by_index( basic_entry, 0 ),
                previous_element );
 
-    stumpless_destroy_element( new_element );
+    stumpless_destroy_element_and_contents( new_element );
   }
 
   TEST_F( EntryTest, SetElementNullElement ) {
@@ -1203,7 +1203,7 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
     ASSERT_TRUE( entry == NULL );
 
-    stumpless_destroy_element( element );
+    stumpless_destroy_element_and_contents( element );
 
     stumpless_free_all(  );
   }
@@ -1265,7 +1265,7 @@ namespace {
   }
 
   TEST( DestroyEntryTest, NullEntry ) {
-    stumpless_destroy_entry( NULL );
+    stumpless_destroy_entry_and_contents( NULL );
   }
 
   TEST( GetElementByIndexTest, NullEntry ) {
@@ -1462,7 +1462,7 @@ namespace {
     EXPECT_EQ( entry->message_length, expected_message_length );
     EXPECT_EQ( 0, memcmp( entry->message, expected_message, entry->message_length ) );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
 
     stumpless_free_all(  );
   }
@@ -1549,8 +1549,8 @@ namespace {
     set_malloc_result = stumpless_set_malloc( malloc );
     EXPECT_TRUE( set_malloc_result == malloc );
 
-    stumpless_destroy_entry( second_entry );
-    stumpless_destroy_entry( first_entry );
+    stumpless_destroy_entry_and_contents( second_entry );
+    stumpless_destroy_entry_and_contents( first_entry );
 
     stumpless_free_all(  );
   }
@@ -1574,7 +1574,7 @@ namespace {
     }
 
     for( i = 0; i < 500; i++ ) {
-      stumpless_destroy_entry( entry[i] );
+      stumpless_destroy_entry_and_contents( entry[i] );
     }
 
     stumpless_free_all(  );
@@ -1615,7 +1615,7 @@ namespace {
     ASSERT_NOT_NULL( entry->message );
     ASSERT_EQ( 0, memcmp( entry->message, message, message_length ) );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
 
     stumpless_free_all(  );
   }
@@ -1639,7 +1639,7 @@ namespace {
       EXPECT_EQ( entry->app_name_length, 1 );
     }
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
 
     stumpless_free_all(  );
   }
@@ -1662,7 +1662,7 @@ namespace {
       EXPECT_EQ( entry->message_length, 0 );
     }
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
 
     stumpless_free_all(  );
   }
@@ -1686,7 +1686,7 @@ namespace {
       EXPECT_EQ( entry->msgid_length, 1 );
     }
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
 
     stumpless_free_all(  );
   }
@@ -1731,7 +1731,7 @@ namespace {
 
     i--;
     while( i >= 0 ) {
-      stumpless_destroy_entry( entries[i] );
+      stumpless_destroy_entry_and_contents( entries[i] );
       i--;
     }
 
@@ -1761,7 +1761,7 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
     EXPECT_NULL( result );
 
-    stumpless_destroy_element( new_element );
+    stumpless_destroy_element_and_contents( new_element );
 
     stumpless_free_all(  );
   }
@@ -1818,7 +1818,7 @@ namespace {
     EXPECT_NULL( entry->message );
     EXPECT_EQ( 0, entry->message_length );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
 
     stumpless_free_all(  );
   }

--- a/test/function/error.cpp
+++ b/test/function/error.cpp
@@ -74,7 +74,7 @@ namespace {
     error = stumpless_get_error(  );
     EXPECT_NOT_NULL( error );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
     stumpless_close_buffer_target( target );
     fflush( error_file );
 
@@ -115,7 +115,7 @@ namespace {
     error = stumpless_get_error(  );
     EXPECT_NOT_NULL( error );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
     stumpless_close_buffer_target( target );
     fflush( error_file );
 

--- a/test/function/target.cpp
+++ b/test/function/target.cpp
@@ -196,7 +196,7 @@ namespace {
     EXPECT_LT( result, 0 );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
   }
 
   TEST( AddEntryTest, UnsupportedType ) {
@@ -225,7 +225,7 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_TARGET_UNSUPPORTED );
 
     stumpless_close_buffer_target( target );
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
   }
 
   TEST( AddLogTest, NullTarget ) {

--- a/test/function/target/buffer.cpp
+++ b/test/function/target/buffer.cpp
@@ -71,7 +71,7 @@ namespace {
 
     virtual void
     TearDown( void ) {
-      stumpless_destroy_entry( basic_entry );
+      stumpless_destroy_entry_and_contents( basic_entry );
       stumpless_close_buffer_target( target );
     }
   };
@@ -152,7 +152,7 @@ namespace {
     TestRFC5424Compliance( read_buffer );
     EXPECT_NE( read_buffer[read_result-1], ' ' );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
   }
 
   TEST_F( BufferTargetTest, IsOpen ) {
@@ -404,7 +404,7 @@ namespace {
     EXPECT_GT( read_result, 1 );
 
     stumpless_close_buffer_target( target );
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
     stumpless_free_all(  );
   }
 }

--- a/test/function/target/file.cpp
+++ b/test/function/target/file.cpp
@@ -56,7 +56,7 @@ namespace {
 
     virtual void
     TearDown( void ) {
-      stumpless_destroy_entry( basic_entry );
+      stumpless_destroy_entry_and_contents( basic_entry );
       stumpless_close_file_target( target );
       remove( filename );
     }
@@ -130,7 +130,7 @@ namespace {
       stumpless_add_entry( target, entry );
     }
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
     stumpless_close_file_target( target );
 
     std::ifstream infile( filename );

--- a/test/function/target/socket.cpp
+++ b/test/function/target/socket.cpp
@@ -165,7 +165,7 @@ namespace {
 
     EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ID );
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
   }
 
   TEST( SocketTargetCloseTest, Generic ) {

--- a/test/function/target/stream.cpp
+++ b/test/function/target/stream.cpp
@@ -60,7 +60,7 @@ namespace {
 
     virtual void
     TearDown( void ) {
-      stumpless_destroy_entry( basic_entry );
+      stumpless_destroy_entry_and_contents( basic_entry );
       stumpless_close_stream_target( target );
 
       fclose( stream );
@@ -146,7 +146,7 @@ namespace {
       stumpless_add_entry( target, entry );
     }
 
-    stumpless_destroy_entry( entry );
+    stumpless_destroy_entry_and_contents( entry );
     stumpless_close_stream_target( target );
     fclose( stream );
 
@@ -259,7 +259,7 @@ namespace {
     EXPECT_LT( result, 0 );
     EXPECT_ERROR_ID_EQ( STUMPLESS_STREAM_WRITE_FAILURE );
 
-    stumpless_destroy_entry( basic_entry );
+    stumpless_destroy_entry_and_contents( basic_entry );
     fclose( stream );
     stumpless_close_stream_target( target );
 

--- a/test/function/target/tcp4.cpp
+++ b/test/function/target/tcp4.cpp
@@ -77,7 +77,7 @@ namespace {
 
     virtual void
     TearDown( void ) {
-      stumpless_destroy_entry( basic_entry );
+      stumpless_destroy_entry_and_contents( basic_entry );
       stumpless_close_network_target( target );
       close_server_socket( handle );
 
@@ -289,7 +289,7 @@ namespace {
         close_server_socket( accepted );
 
         stumpless_close_network_target( target );
-        stumpless_destroy_entry( entry );
+        stumpless_destroy_entry_and_contents( entry );
       }
 
       close_server_socket( port_handle );
@@ -353,7 +353,7 @@ namespace {
       close_server_socket( accepted );
 
       stumpless_close_network_target( target );
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
     }
 
     close_server_socket( port_handle );
@@ -414,7 +414,7 @@ namespace {
       recv_from_handle( accepted, buffer, 2048 );
       EXPECT_TRUE( buffer[0] != '\0' );
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
       close_server_socket( accepted );
       stumpless_close_network_target( target );
 
@@ -484,7 +484,7 @@ namespace {
       recv_from_handle( accepted, buffer, 2048 );
       EXPECT_TRUE( buffer[0] != '\0' );
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
       close_server_socket( accepted );
       stumpless_close_network_target( target );
 

--- a/test/function/target/tcp6.cpp
+++ b/test/function/target/tcp6.cpp
@@ -77,7 +77,7 @@ namespace {
 
     virtual void
     TearDown( void ) {
-      stumpless_destroy_entry( basic_entry );
+      stumpless_destroy_entry_and_contents( basic_entry );
       stumpless_close_network_target( target );
       close_server_socket( handle );
 
@@ -318,7 +318,7 @@ namespace {
         close_server_socket( accepted );
 
         stumpless_close_network_target( target );
-        stumpless_destroy_entry( entry );
+        stumpless_destroy_entry_and_contents( entry );
       }
 
       close_server_socket( port_handle );
@@ -382,7 +382,7 @@ namespace {
       close_server_socket( accepted );
 
       stumpless_close_network_target( target );
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
     }
 
     close_server_socket( port_handle );
@@ -443,7 +443,7 @@ namespace {
       recv_from_handle( accepted, buffer, 2048 );
       EXPECT_TRUE( buffer[0] != '\0' );
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
       close_server_socket( accepted );
       stumpless_close_network_target( target );
 
@@ -513,7 +513,7 @@ namespace {
       recv_from_handle( accepted, buffer, 2048 );
       EXPECT_TRUE( buffer[0] != '\0' );
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
       close_server_socket( accepted );
       stumpless_close_network_target( target );
 

--- a/test/function/target/udp4.cpp
+++ b/test/function/target/udp4.cpp
@@ -82,7 +82,7 @@ namespace {
 
     virtual void
     TearDown( void ) {
-      stumpless_destroy_entry( basic_entry );
+      stumpless_destroy_entry_and_contents( basic_entry );
       stumpless_close_network_target( target );
       close_server_socket( handle );
     }
@@ -283,7 +283,7 @@ namespace {
         EXPECT_TRUE( buffer[0] != '\0' );
         TestRFC5424Compliance( buffer );
 
-        stumpless_destroy_entry( entry );
+        stumpless_destroy_entry_and_contents( entry );
       }
 
       close_server_socket( handle );
@@ -344,7 +344,7 @@ namespace {
       EXPECT_TRUE( buffer[0] != '\0' );
       TestRFC5424Compliance( buffer );
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
     }
 
     close_server_socket( handle );
@@ -397,7 +397,7 @@ namespace {
       EXPECT_TRUE( buffer[0] != '\0' );
       TestRFC5424Compliance( buffer );
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
     }
 
     close_server_socket( handle );
@@ -463,7 +463,7 @@ namespace {
       EXPECT_TRUE( buffer[0] != '\0' );
       TestRFC5424Compliance( buffer );
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
     }
 
     close_server_socket( handle );

--- a/test/function/target/udp6.cpp
+++ b/test/function/target/udp6.cpp
@@ -82,7 +82,7 @@ namespace {
 
     virtual void
     TearDown( void ) {
-      stumpless_destroy_entry( basic_entry );
+      stumpless_destroy_entry_and_contents( basic_entry );
       stumpless_close_network_target( target );
       close_server_socket( handle );
     }
@@ -307,7 +307,7 @@ namespace {
         EXPECT_TRUE( buffer[0] != '\0' );
         TestRFC5424Compliance( buffer );
 
-        stumpless_destroy_entry( entry );
+        stumpless_destroy_entry_and_contents( entry );
       }
 
       close_server_socket( handle );
@@ -367,7 +367,7 @@ namespace {
       EXPECT_TRUE( buffer[0] != '\0' );
       TestRFC5424Compliance( buffer );
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
     }
 
     close_server_socket( handle );
@@ -420,7 +420,7 @@ namespace {
       EXPECT_TRUE( buffer[0] != '\0' );
       TestRFC5424Compliance( buffer );
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
     }
 
     close_server_socket( handle );
@@ -486,7 +486,7 @@ namespace {
       EXPECT_TRUE( buffer[0] != '\0' );
       TestRFC5424Compliance( buffer );
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
     }
 
     close_server_socket( handle );

--- a/test/function/target/wel.cpp
+++ b/test/function/target/wel.cpp
@@ -79,9 +79,9 @@ namespace {
     virtual void
     TearDown( void ) {
       stumpless_close_wel_target( target );
-      stumpless_destroy_entry( simple_entry );
-      stumpless_destroy_entry( one_insertion_entry );
-      stumpless_destroy_entry( two_insertion_entry );
+      stumpless_destroy_entry_and_contents( simple_entry );
+      stumpless_destroy_entry_and_contents( one_insertion_entry );
+      stumpless_destroy_entry_and_contents( two_insertion_entry );
     }
   };
 

--- a/test/performance/target/network.cpp
+++ b/test/performance/target/network.cpp
@@ -65,7 +65,7 @@ class Tcp4Fixture : public ::benchmark::Fixture {
 
       close_server_socket( accepted );
       close_server_socket( handle );
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
       stumpless_close_network_target( target );
     }
 };
@@ -120,7 +120,7 @@ class Tcp6Fixture : public ::benchmark::Fixture {
 
       close_server_socket( accepted );
       close_server_socket( handle );
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
       stumpless_close_network_target( target );
     }
 };
@@ -168,7 +168,7 @@ class Udp4Fixture : public ::benchmark::Fixture {
       stumpless_set_realloc( realloc );
       stumpless_set_free( free );
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
       stumpless_close_network_target( target );
     }
 };
@@ -210,7 +210,7 @@ class Udp6Fixture : public ::benchmark::Fixture {
       stumpless_set_realloc( realloc );
       stumpless_set_free( free );
 
-      stumpless_destroy_entry( entry );
+      stumpless_destroy_entry_and_contents( entry );
       stumpless_close_network_target( target );
     }
 };

--- a/tools/check_headers/check_headers.rb
+++ b/tools/check_headers/check_headers.rb
@@ -114,8 +114,7 @@ ARGV.each do |source_glob|
         used_terms << word if file_terms.key?(word)
 
         if $deprecated_terms.include?(word)
-          puts "#{source_filename}: deprecated term #{word} used"
-          return_code = 1
+          puts "warning: deprecated term #{word} used in #{source_filename}"
         end
       end
     end

--- a/tools/check_headers/check_headers.rb
+++ b/tools/check_headers/check_headers.rb
@@ -31,6 +31,7 @@ require 'yaml'
 
 # script globals
 $header_alternates = {}
+$deprecated_terms = []
 
 def load_manifest(filename, term_hash)
   file_path = File.join(__dir__, filename)
@@ -39,6 +40,11 @@ def load_manifest(filename, term_hash)
   if manifest_terms.key?('header-alternates')
     $header_alternates.merge!(manifest_terms['header-alternates'])
     manifest_terms.delete('header-alternates')
+  end
+
+  if manifest_terms.key?('deprecated-terms')
+    $deprecated_terms.concat(manifest_terms['deprecated-terms'])
+    manifest_terms.delete('deprecated-terms')
   end
 
   term_hash.merge!(manifest_terms)
@@ -106,6 +112,11 @@ ARGV.each do |source_glob|
       line_terms.each do |word|
         used_terms << 'L10N_' if word.start_with?('L10N_')
         used_terms << word if file_terms.key?(word)
+
+        if $deprecated_terms.include?(word)
+          puts "#{source_filename}: deprecated term #{word} used"
+          return_code = 1
+        end
       end
     end
 

--- a/tools/check_headers/stumpless.yml
+++ b/tools/check_headers/stumpless.yml
@@ -1,6 +1,9 @@
 # options
 "header-alternates":
   "stumpless/.*\\.h": "stumpless.h"
+"deprecated-terms":
+  - "stumpless_destroy_element"
+  - "stumpless_destroy_entry"
 
 # terms
 "accept_tcp_connection": "test/helper/server.hpp"

--- a/tools/check_headers/stumpless.yml
+++ b/tools/check_headers/stumpless.yml
@@ -210,6 +210,7 @@
 "STUMPLESS_DEFAULT_TARGET_NAME": "stumpless/target.h"
 "STUMPLESS_DEFAULT_TRANSPORT_PORT": "stumpless/target/network.h"
 "STUMPLESS_DEFAULT_UDP_MAX_MESSAGE_SIZE": "stumpless/target/network.h"
+"STUMPLESS_DEPRECATION_WARNINGS_ENABLED": "stumpless/config.h"
 "stumpless_destroy_element": "stumpless/element.h"
 "stumpless_destroy_element_and_contents": "stumpless/element.h"
 "stumpless_destroy_element_only": "stumpless/element.h"

--- a/tools/check_headers/stumpless_private.yml
+++ b/tools/check_headers/stumpless_private.yml
@@ -59,6 +59,7 @@
 "unlock_wel_data": "private/config/wel_supported.h"
 "USE_LOCALE_EN_US": "private/config.h"
 "VALIDATE_ARG_NOT_NULL": "private/validate.h"
+"warn_of_deprecation": "private/deprecate.h"
 "windows compare_exchange_bool": "private/config/have_windows.h"
 "windows_compare_exchange_ptr": "private/config/have_windows.h"
 "windows_destroy_mutex": "private/config/have_windows.h"


### PR DESCRIPTION
There are two forms of the destructors for entry and element structures:  one that destroys the object itself, and one that destroys the object and all of the ones that it contains. The former is named `destroy_..._only` while the latter is named  `destroy_..._and_contents`. The latter has a synonym named simply `destroy_...`, which does not convey the nuance of its behavior at all. This alias has therefore been deprecated, and will be removed in release 3.0 in order to prevent confusion and misuse of the two forms.