### PR TITLE
add missing c++ bindings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
           tools/check_headers/check_headers.rb "test/**/*.cpp"
       - name: Build Documentation
         run: |
+          sudo apt-get install doxygen
           cmake .
           make docs
       - name: Sonarcloud Analysis
@@ -151,6 +152,8 @@ jobs:
         run: |
           gem install bundler
           bundle install
+      - name: Install Packages
+          sudo apt-get install doxygen
       - name: Configure
         run: |
           cmake -DCOVERAGE=ON -DENABLE_CPP=ON .
@@ -382,6 +385,8 @@ jobs:
         run: |
           gem install bundler
           bundle install
+      - name: Install Packages
+          sudo apt-get install doxygen
       - name: Configure
         run: |
           cmake -DCOVERAGE=ON -DENABLE_CPP=ON .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,7 @@ jobs:
           gem install bundler
           bundle install
       - name: Install Packages
+        run: |
           sudo apt-get install doxygen
       - name: Configure
         run: |
@@ -386,6 +387,7 @@ jobs:
           gem install bundler
           bundle install
       - name: Install Packages
+        run: |
           sudo apt-get install doxygen
       - name: Configure
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,7 +388,7 @@ jobs:
           bundle install
       - name: Install Packages
         run: |
-          sudo apt-get install doxygen
+          brew install doxygen
       - name: Configure
         run: |
           cmake -DCOVERAGE=ON -DENABLE_CPP=ON .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
           tools/check_headers/check_headers.rb "test/**/*.cpp"
       - name: Build Documentation
         run: |
+          cmake .
           make docs
       - name: Sonarcloud Analysis
         run: |
@@ -162,6 +163,9 @@ jobs:
       - name: Install
         run: |
           sudo make install
+      - name: Build Documentation
+        run: |
+          make docs-cpp
   linux-de-de:
     name: "linux, de-de"
     runs-on: "ubuntu-20.04"
@@ -390,6 +394,9 @@ jobs:
       - name: Install
         run: |
           sudo make install
+      - name: Build Documentation
+        run: |
+          make docs-cpp
   windows-debug:
     name: "windows, debug"
     runs-on: "windows-2019"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/stumpless/blob/master/docs/roadmap.md).
 
-## [2.0.0] - 2020-12-10
+## [2.0.0] - 2020-12-15
 ### Added
  - Localization framework for error messages and other library strings.
  - Thread safety for all functionality.
@@ -21,6 +21,11 @@ fixes, check out the
     * `stumpless_get_target_default_msgid`
     * `stumpless_param_to_string`
     * `stumpless_read_buffer`
+  - The following C++ function bindings:
+    * `Entry.GetAppName`
+    * `Entry.GetMessage`
+    * `Entry.GetMsgid`
+    * `Version.Compare`
 
 ### Changed
  - C++ namespace from `stumplesscpp` to `stumpless`.

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'wrapture', '~> 0.4.2'
+gem 'wrapture', '~> 0.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,10 +5,9 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-linux
 
 DEPENDENCIES
   wrapture (~> 0.5.0)
 
 BUNDLED WITH
-   2.2.0
+   2.2.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    wrapture (0.4.2)
+    wrapture (0.5.0)
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
-  wrapture (~> 0.4.2)
+  wrapture (~> 0.5.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.0

--- a/test/function/cpp/entry.cpp
+++ b/test/function/cpp/entry.cpp
@@ -28,6 +28,7 @@ namespace {
   protected:
     Entry *basic_entry;
     const char *basic_app_name = "stumpless-cpp-testing";
+    const char *basic_message = "This is a basic entry.";
 
     virtual void
     SetUp( void ) {
@@ -50,6 +51,15 @@ namespace {
 
     result = basic_entry->GetAppName(  );
     EXPECT_STREQ( result, basic_app_name );
+
+    free( ( void * ) result );
+  }
+
+  TEST_F( CppEntryTest, GetMessage ) {
+    const char *result;
+
+    result = basic_entry->GetMessage(  );
+    EXPECT_STREQ( result, basic_message );
 
     free( ( void * ) result );
   }

--- a/test/function/cpp/entry.cpp
+++ b/test/function/cpp/entry.cpp
@@ -16,12 +16,46 @@
  * limitations under the License.
  */
 
+#include <cstdlib>
 #include <gtest/gtest.h>
 #include <stumpless.hpp>
 
 using namespace stumpless;
 
 namespace {
+
+  class CppEntryTest : public::testing::Test {
+  protected:
+    Entry *basic_entry;
+    const char *basic_app_name = "stumpless-cpp-testing";
+
+    virtual void
+    SetUp( void ) {
+      basic_entry = new Entry( Facility::USER,
+                               Severity::INFO,
+                               basic_app_name,
+                               "basic-msg",
+                               "This is a basic entry." );
+    }
+
+    virtual void
+    TearDown( void ) {
+      delete basic_entry;
+    }
+
+  };
+
+  TEST_F( CppEntryTest, GetAppName ) {
+    const char *result;
+
+    result = basic_entry->GetAppName(  );
+    EXPECT_STREQ( result, basic_app_name );
+
+    free( ( void * ) result );
+  }
+
+  /* non-fixture tests */
+
   TEST( BuildEntry, WithElement ) {
     Entry my_entry( Facility::USER,
                     Severity::INFO,

--- a/test/function/cpp/entry.cpp
+++ b/test/function/cpp/entry.cpp
@@ -28,6 +28,7 @@ namespace {
   protected:
     Entry *basic_entry;
     const char *basic_app_name = "stumpless-cpp-testing";
+    const char *basic_msgid = "basic-msgid";
     const char *basic_message = "This is a basic entry.";
 
     virtual void
@@ -35,7 +36,7 @@ namespace {
       basic_entry = new Entry( Facility::USER,
                                Severity::INFO,
                                basic_app_name,
-                               "basic-msg",
+                               basic_msgid,
                                "This is a basic entry." );
     }
 
@@ -60,6 +61,15 @@ namespace {
 
     result = basic_entry->GetMessage(  );
     EXPECT_STREQ( result, basic_message );
+
+    free( ( void * ) result );
+  }
+
+  TEST_F( CppEntryTest, GetMsgid ) {
+    const char *result;
+
+    result = basic_entry->GetMsgid(  );
+    EXPECT_STREQ( result, basic_msgid );
 
     free( ( void * ) result );
   }

--- a/test/function/cpp/version.cpp
+++ b/test/function/cpp/version.cpp
@@ -33,6 +33,22 @@ namespace {
     EXPECT_EQ( -100, old_version.Compare( new_version ) );
   }
 
+  TEST( Compare, MinorDifference ) {
+    Version old_version( 1, 5, 0 );
+    Version new_version( 1, 6, 0 );
+
+    EXPECT_EQ( 10, new_version.Compare( old_version ) );
+    EXPECT_EQ( -10, old_version.Compare( new_version ) );
+  }
+
+  TEST( Compare, PatchDifference ) {
+    Version old_version( 1, 6, 1 );
+    Version new_version( 1, 6, 2 );
+
+    EXPECT_EQ( 1, new_version.Compare( old_version ) );
+    EXPECT_EQ( -1, old_version.Compare( new_version ) );
+  }
+
   TEST( GetVersion, Function ) {
     Version current_version = Version::GetCurrent();
 

--- a/test/function/cpp/version.cpp
+++ b/test/function/cpp/version.cpp
@@ -25,6 +25,14 @@ namespace {
 
   class CppVersionTest : public ::testing::Test {};
 
+  TEST( Compare, MajorDifference ) {
+    Version old_version( 1, 6, 0 );
+    Version new_version( 2, 0, 0 );
+
+    EXPECT_EQ( 100, new_version.Compare( old_version ) );
+    EXPECT_EQ( -100, old_version.Compare( new_version ) );
+  }
+
   TEST( GetVersion, Function ) {
     Version current_version = Version::GetCurrent();
 

--- a/tools/check_headers/stumplesscpp.yml
+++ b/tools/check_headers/stumplesscpp.yml
@@ -9,6 +9,7 @@
 "Facility": "stumpless/Facility.hpp"
 "FileTarget": "stumpless/FileTarget.hpp"
 "FreeAll": "stumpless/MemoryManager.hpp"
+"GetAppName": "stumpless/Entry.hpp"
 "MemoryManager": "stumpless/MemoryManager.hpp"
 "NetworkTarget": "stumpless/NetworkTarget.hpp"
 "Param": "stumpless/Param.hpp"

--- a/tools/wrapture/entry.yml
+++ b/tools/wrapture/entry.yml
@@ -352,6 +352,25 @@ classes:
           return:
             type: "const char *"
           use-template: "pointer-return-error-check"
+      - name: "GetMsgid"
+        doc: >
+          Gets the msgid of this Entry.
+
+          The returned character buffer must be freed by the caller when it is
+          no longer needed to avoid memory leaks.
+
+          Available since release v2.0.0.
+        return:
+          doc: "The msgid of this Entry."
+          type: "const char *"
+        wrapped-function:
+          name: "stumpless_get_entry_msgid"
+          include: "stumpless/entry.h"
+          params:
+            - value: "equivalent-struct-pointer"
+          return:
+            type: "const char *"
+          use-template: "pointer-return-error-check"
       - name: "GetParam"
         doc: |
           Gets the Param from the Element at the given index from this Entry.

--- a/tools/wrapture/entry.yml
+++ b/tools/wrapture/entry.yml
@@ -1,4 +1,4 @@
-version: "0.5.1"
+version: "0.5.0"
 classes:
   - name: "Entry"
     doc: |
@@ -329,6 +329,29 @@ classes:
             - value: "equivalent-struct-pointer"
           return:
             type: "int"
+      - name: "GetMessage"
+        doc: >
+          Gets the message from this Entry.
+
+          Note that if this message was originally set using format specifiers,
+          the result will have them substituted instead of the original
+          placeholders.
+
+          The returned character buffer must be freed by the caller when it is
+          no longer needed to avoid memory leaks.
+
+          Available since release v2.0.0.
+        return:
+          doc: "The message of this Entry."
+          type: "const char *"
+        wrapped-function:
+          name: "stumpless_get_entry_message"
+          include: "stumpless/entry.h"
+          params:
+            - value: "equivalent-struct-pointer"
+          return:
+            type: "const char *"
+          use-template: "pointer-return-error-check"
       - name: "GetParam"
         doc: |
           Gets the Param from the Element at the given index from this Entry.

--- a/tools/wrapture/entry.yml
+++ b/tools/wrapture/entry.yml
@@ -1,4 +1,4 @@
-version: "0.4.2"
+version: "0.5.0"
 classes:
   - name: "Entry"
     doc: |
@@ -204,6 +204,25 @@ classes:
           return:
             type: "struct stumpless_entry *"
           use-template: "pointer-return-error-check"
+      - name: "GetAppName"
+        doc: >
+          Gets the app name from this Entry.
+
+          The returned character buffer must be freed by the caller when it is
+          no longer needed to avoid memory leaks.
+
+          Available since release v2.0.0.
+        return:
+          doc: "The app name of this Entry."
+          type: "const char *"
+        wrapped-function:
+          name: "stumpless_get_entry_app_name"
+          include: "stumpless/entry.h"
+          params:
+            - value: "equivalent-struct-pointer"
+          return:
+            type: "const char *"
+          use-template: "has-error-check"
       - name: "GetElement"
         doc: |
           Gets the Element at the given index in this Entry.

--- a/tools/wrapture/entry.yml
+++ b/tools/wrapture/entry.yml
@@ -1,4 +1,4 @@
-version: "0.5.0"
+version: "0.5.1"
 classes:
   - name: "Entry"
     doc: |
@@ -222,7 +222,7 @@ classes:
             - value: "equivalent-struct-pointer"
           return:
             type: "const char *"
-          use-template: "has-error-check"
+          use-template: "pointer-return-error-check"
       - name: "GetElement"
         doc: |
           Gets the Element at the given index in this Entry.
@@ -245,6 +245,9 @@ classes:
           params:
             - value: "equivalent-struct-pointer"
             - value: "index"
+          return:
+            type: "struct stumpless_element *"
+          use-template: "pointer-return-error-check"
       - name: "GetElement"
         doc: |
           Gets the Element with the given name from this Entry.
@@ -265,6 +268,9 @@ classes:
           params:
             - value: "equivalent-struct-pointer"
             - value: "name"
+          return:
+            type: "struct stumpless_element *"
+          use-template: "pointer-return-error-check"
       - name: "GetElementCount"
         doc: "Returns the number of elements in this Entry."
         return:
@@ -277,6 +283,11 @@ classes:
           includes: "stumpless/entry.h"
           params:
             - value: "equivalent-struct-pointer"
+          return:
+            type:
+              name: "size_t"
+              includes: "stddef.h"
+          use-template: "has-error-check"
       - name: "GetElementIndex"
         doc: |
           Gets the index of the Element with the given name from this Entry.

--- a/tools/wrapture/error_templates.yml
+++ b/tools/wrapture/error_templates.yml
@@ -1,4 +1,4 @@
-version: "0.4.0"
+version: "0.5.0"
 templates:
   - name: "error-class"
     value:
@@ -23,6 +23,22 @@ templates:
           - left-expression: "stumpless_get_error(  )"
             condition: "not-equals"
             right-expression: "NULL"
+        error-action:
+          name: "throw-exception"
+          constructor:
+            name: "StumplessException::newStumplessException"
+            includes:
+              - "stumpless/StumplessException.hpp"
+              - "stumpless/error.h"
+            params:
+              - value: "( struct stumpless_error * ) stumpless_get_error(  )"
+  - name: "has-error-check"
+    value:
+      error-check:
+        rules:
+          - left-expression: "stumpless_has_error(  )"
+            condition: "not-equals"
+            right-expression: "false"
         error-action:
           name: "throw-exception"
           constructor:

--- a/tools/wrapture/version.yml
+++ b/tools/wrapture/version.yml
@@ -1,4 +1,4 @@
-version: "0.3.0"
+version: "0.5.0"
 classes:
   - name: "Version"
     doc: "Describes this version of Stumpless."
@@ -21,6 +21,36 @@ classes:
         wrapped-function:
           name: "stumpless_get_version"
           includes: "stumpless/version.h"
+      - name: "Compare"
+        doc: >
+          Compares this Version with another one according to semantic
+          versioning rules.
+
+          Available since release v2.0.0.
+        params:
+          - name: "version"
+            doc: The Version to compare this one against.
+            type: "Version&"
+        return:
+          doc: >
+            0 if these each represent the same version number, a negative value
+            if this Version is lower (that is, older), and a postive value if
+            this Version is higher.
+
+            The magnitude of the return value will indicate the level that
+            differed, 1 denoting a patch level difference, 10 a minor version
+            number difference, and 100 a major version number difference.
+          type: "int"
+        wrapped-function:
+          name: "stumpless_version_cmp"
+          includes: "stumpless/version.h"
+          params:
+            - value: "equivalent-struct-pointer"
+            - value: "version"
+              type: "struct stumpless_version *"
+          return:
+            type: "int"
+          use-template: "has-error-check"
       - name: "ToString"
         return:
           type: "std::string"


### PR DESCRIPTION
There are some functions that did not have corresponding bindings in the C++ wrappers generated by wrapture. This change adds specs for these functions, and also updates wrapture to allow error checking and return codes to be handled properly in them.