### PR TITLE
resolve sonarcloud violations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,14 @@
 name: "build"
+
 on:
   push:
   pull_request:
     branches:
       - latest
+
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
+
 jobs:
   linux-analysis:
     name: "code analysis"
@@ -170,106 +173,6 @@ jobs:
       - name: Build Documentation
         run: |
           make docs-cpp
-  linux-de-de:
-    name: "linux, de-de"
-    runs-on: "ubuntu-20.04"
-    env:
-      LANG: "de_DE.UTF-8"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Configure
-        run: |
-          cmake .
-      - name: Check Language
-        run: |
-          grep -q "STUMPLESS_LANGUAGE \"de-DE\"" include/stumpless/config.h
-      - name: Build
-        run: |
-          make all
-      - name: Test
-        run: |
-          make check
-          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
-  linux-es-es:
-    name: "linux, es-es"
-    runs-on: "ubuntu-20.04"
-    env:
-      LANG: "es_ES.UTF-8"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Configure
-        run: |
-          cmake .
-      - name: Check Language
-        run: |
-          grep -q "STUMPLESS_LANGUAGE \"es-ES\"" include/stumpless/config.h
-      - name: Build
-        run: |
-          make all
-      - name: Test
-        run: |
-          make check
-          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
-  linux-fr-fr:
-    name: "linux, fr-fr"
-    runs-on: "ubuntu-20.04"
-    env:
-      LANG: "fr_FR.UTF-8"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Configure
-        run: |
-          cmake .
-      - name: Check Language
-        run: |
-          grep -q "STUMPLESS_LANGUAGE \"fr-FR\"" include/stumpless/config.h
-      - name: Build
-        run: |
-          make all
-      - name: Test
-        run: |
-          make check
-          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
-  linux-sv-se:
-    name: "linux, sv-se"
-    runs-on: "ubuntu-20.04"
-    env:
-      LANG: "sv_SE.UTF-8"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Configure
-        run: |
-          cmake .
-      - name: Check Language
-        run: |
-          grep -q "STUMPLESS_LANGUAGE \"sv-SE\"" include/stumpless/config.h
-      - name: Build
-        run: |
-          make all
-      - name: Test
-        run: |
-          make check
-          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
-  linux-sk-sk:
-    name: "linux, sk-sk"
-    runs-on: "ubuntu-20.04"
-    env:
-      LANG: "sk_SK.UTF-8"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Configure
-        run: |
-          cmake .
-      - name: Check Language
-        run: |
-          grep -q "STUMPLESS_LANGUAGE \"sk-SK\"" include/stumpless/config.h
-      - name: Build
-        run: |
-          make all
-      - name: Test
-        run: |
-          make check
-          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
   mac-debug:
     name: "mac, debug"
     runs-on: "macos-11.0"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,13 +54,6 @@ jobs:
         run: |
           make check
           if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
-      - name: Codecov Upload
-        uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
-      - name: Thread Safety Tests
-        run: |
-          make check-thread-safety
       - name: Privileged Tests
         run: |
           sudo ./function-test-tcp4
@@ -71,6 +64,13 @@ jobs:
           sudo ./function-test-udp4_leak
           sudo ./function-test-udp6
           sudo ./function-test-udp6_leak
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
+      - name: Thread Safety Tests
+        run: |
+          make check-thread-safety
           sudo ./thread-safety-test-network
       - name: Run Examples
         run: |
@@ -93,13 +93,6 @@ jobs:
         run: |
           make check
           if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
-      - name: Codecov Upload
-        uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
-      - name: Thread Safety Tests
-        run: |
-          make check-thread-safety
       - name: Privileged Tests
         run: |
           sudo ./function-test-tcp4
@@ -110,6 +103,13 @@ jobs:
           sudo ./function-test-udp4_leak
           sudo ./function-test-udp6
           sudo ./function-test-udp6_leak
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
+      - name: Thread Safety Tests
+        run: |
+          make check-thread-safety
           sudo ./thread-safety-test-network
       - name: Run Examples
         run: |
@@ -188,13 +188,6 @@ jobs:
         run: |
           make check
           if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
-      - name: Codecov Upload
-        uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
-      - name: Thread Safety Tests
-        run: |
-          make check-thread-safety
       - name: Privileged Tests
         run: |
           sudo ./function-test-tcp4
@@ -205,6 +198,13 @@ jobs:
           sudo ./function-test-udp4_leak
           sudo ./function-test-udp6
           sudo ./function-test-udp6_leak
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
+      - name: Thread Safety Tests
+        run: |
+          make check-thread-safety
           sudo ./thread-safety-test-network
       - name: Run Examples
         run: |
@@ -227,13 +227,6 @@ jobs:
         run: |
           make check
           if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
-      - name: Codecov Upload
-        uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
-      - name: Thread Safety Tests
-        run: |
-          make check-thread-safety
       - name: Privileged Tests
         run: |
           sudo ./function-test-tcp4
@@ -244,6 +237,13 @@ jobs:
           sudo ./function-test-udp4_leak
           sudo ./function-test-udp6
           sudo ./function-test-udp6_leak
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
+      - name: Thread Safety Tests
+        run: |
+          make check-thread-safety
           sudo ./thread-safety-test-network
       - name: Run Examples
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,10 @@ jobs:
         run: |
           make check
           if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
       - name: Thread Safety Tests
         run: |
           make check-thread-safety
@@ -71,10 +75,6 @@ jobs:
       - name: Install
         run: |
           sudo make install
-      - name: Codecov Upload
-        uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
   linux-release:
     name: "linux, release"
     runs-on: "ubuntu-20.04"
@@ -90,6 +90,10 @@ jobs:
         run: |
           make check
           if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
       - name: Thread Safety Tests
         run: |
           make check-thread-safety
@@ -113,10 +117,6 @@ jobs:
       - name: Install
         run: |
           sudo make install
-      - name: Codecov Upload
-        uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
   linux-all-disabled:
     name: "linux, all features disabled"
     runs-on: "ubuntu-20.04"
@@ -132,16 +132,16 @@ jobs:
         run: |
           make check
           if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
       - name: Run Examples
         run: |
           make examples
       - name: Install
         run: |
           sudo make install
-      - name: Codecov Upload
-        uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
   linux-cpp:
     name: "linux, with c++"
     runs-on: "ubuntu-20.04"
@@ -157,7 +157,7 @@ jobs:
           sudo apt-get install doxygen
       - name: Configure
         run: |
-          cmake -DCOVERAGE=ON -DENABLE_CPP=ON .
+          cmake -DENABLE_CPP=ON .
       - name: Build
         run: |
           make all
@@ -179,7 +179,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Configure
         run: |
-          cmake -DCOVERAGE=ON .
+          cmake .
       - name: Check Language
         run: |
           grep -q "STUMPLESS_LANGUAGE \"de-DE\"" include/stumpless/config.h
@@ -199,7 +199,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Configure
         run: |
-          cmake -DCOVERAGE=ON .
+          cmake .
       - name: Check Language
         run: |
           grep -q "STUMPLESS_LANGUAGE \"es-ES\"" include/stumpless/config.h
@@ -219,7 +219,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Configure
         run: |
-          cmake -DCOVERAGE=ON .
+          cmake .
       - name: Check Language
         run: |
           grep -q "STUMPLESS_LANGUAGE \"fr-FR\"" include/stumpless/config.h
@@ -239,7 +239,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Configure
         run: |
-          cmake -DCOVERAGE=ON .
+          cmake .
       - name: Check Language
         run: |
           grep -q "STUMPLESS_LANGUAGE \"sv-SE\"" include/stumpless/config.h
@@ -259,7 +259,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Configure
         run: |
-          cmake -DCOVERAGE=ON .
+          cmake .
       - name: Check Language
         run: |
           grep -q "STUMPLESS_LANGUAGE \"sk-SK\"" include/stumpless/config.h
@@ -285,6 +285,10 @@ jobs:
         run: |
           make check
           if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
       - name: Thread Safety Tests
         run: |
           make check-thread-safety
@@ -305,10 +309,6 @@ jobs:
       - name: Install
         run: |
           sudo make install
-      - name: Codecov Upload
-        uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
   mac-release:
     name: "mac, release"
     runs-on: "macos-11.0"
@@ -324,6 +324,10 @@ jobs:
         run: |
           make check
           if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
       - name: Thread Safety Tests
         run: |
           make check-thread-safety
@@ -347,10 +351,6 @@ jobs:
       - name: Install
         run: |
           sudo make install
-      - name: Codecov Upload
-        uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
   mac-all-disabled:
     name: "mac, all features disabled"
     runs-on: "macos-11.0"
@@ -366,16 +366,16 @@ jobs:
         run: |
           make check
           if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
       - name: Run Examples
         run: |
           make examples
       - name: Install
         run: |
           sudo make install
-      - name: Codecov Upload
-        uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
   mac-cpp:
     name: "mac, with c++"
     runs-on: "macos-11.0"
@@ -391,7 +391,7 @@ jobs:
           brew install doxygen
       - name: Configure
         run: |
-          cmake -DCOVERAGE=ON -DENABLE_CPP=ON .
+          cmake -DENABLE_CPP=ON .
       - name: Build
         run: |
           make all

--- a/.github/workflows/locale.yml
+++ b/.github/workflows/locale.yml
@@ -1,0 +1,112 @@
+name: "Locale"
+
+on:
+  push:
+    branches: [ latest ]
+  pull_request:
+    branches: [ latest ]
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+jobs:
+  linux-de-de:
+    name: "linux, de-de"
+    runs-on: "ubuntu-20.04"
+    env:
+      LANG: "de_DE.UTF-8"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure
+        run: |
+          cmake .
+      - name: Check Language
+        run: |
+          grep -q "STUMPLESS_LANGUAGE \"de-DE\"" include/stumpless/config.h
+      - name: Build
+        run: |
+          make all
+      - name: Test
+        run: |
+          make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
+  linux-es-es:
+    name: "linux, es-es"
+    runs-on: "ubuntu-20.04"
+    env:
+      LANG: "es_ES.UTF-8"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure
+        run: |
+          cmake .
+      - name: Check Language
+        run: |
+          grep -q "STUMPLESS_LANGUAGE \"es-ES\"" include/stumpless/config.h
+      - name: Build
+        run: |
+          make all
+      - name: Test
+        run: |
+          make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
+  linux-fr-fr:
+    name: "linux, fr-fr"
+    runs-on: "ubuntu-20.04"
+    env:
+      LANG: "fr_FR.UTF-8"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure
+        run: |
+          cmake .
+      - name: Check Language
+        run: |
+          grep -q "STUMPLESS_LANGUAGE \"fr-FR\"" include/stumpless/config.h
+      - name: Build
+        run: |
+          make all
+      - name: Test
+        run: |
+          make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
+  linux-sk-sk:
+    name: "linux, sk-sk"
+    runs-on: "ubuntu-20.04"
+    env:
+      LANG: "sk_SK.UTF-8"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure
+        run: |
+          cmake .
+      - name: Check Language
+        run: |
+          grep -q "STUMPLESS_LANGUAGE \"sk-SK\"" include/stumpless/config.h
+      - name: Build
+        run: |
+          make all
+      - name: Test
+        run: |
+          make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi
+  linux-sv-se:
+    name: "linux, sv-se"
+    runs-on: "ubuntu-20.04"
+    env:
+      LANG: "sv_SE.UTF-8"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure
+        run: |
+          cmake .
+      - name: Check Language
+        run: |
+          grep -q "STUMPLESS_LANGUAGE \"sv-SE\"" include/stumpless/config.h
+      - name: Build
+        run: |
+          make all
+      - name: Test
+        run: |
+          make check
+          if grep "DEPRECATED" Testing/Temporary/LastTest.log; then exit 1; fi

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -62,7 +62,7 @@ appears in the CMake build script to include the new header.
 
 The last step is to add new CI builds for the new locale to make sure that
 there are no immediate problems and catch any future ones that arise. This is
-done by updating the `.github/workflows/build.yml` configuration file with a
+done by updating the `.github/workflows/locale.yml` configuration file with a
 build profile for the new language. This is relatively simple: just copy one of
 the existing jobs (for example `linux-es-es`) and update it to use your new
 locale.

--- a/include/private/formatter.h
+++ b/include/private/formatter.h
@@ -60,6 +60,6 @@
  */
 struct strbuilder *
 format_entry( const struct stumpless_entry *entry,
-              struct stumpless_target *target );
+              const struct stumpless_target *target );
 
 #endif /* __STUMPLESS_PRIVATE_FORMATTER_H */

--- a/src/config/have_gmtime_r.c
+++ b/src/config/have_gmtime_r.c
@@ -40,7 +40,10 @@ gmtime_r_get_now( char *buffer ) {
     return 0;
   }
 
-  written = strftime( buffer, RFC_5424_WHOLE_TIME_BUFFER_SIZE, "%FT%T", &now_tm );
+  written = strftime( buffer,
+                      RFC_5424_WHOLE_TIME_BUFFER_SIZE,
+                      "%FT%T",
+                      &now_tm );
   written += snprintf( buffer + written,
                        RFC_5424_TIME_SECFRAC_BUFFER_SIZE + 2,
                        ".%06ldZ",

--- a/src/config/have_unistd.c
+++ b/src/config/have_unistd.c
@@ -2,13 +2,13 @@
 
 /*
  * Copyright 2018-2020 Joel E. Anderson
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/config/no_vsnprintf_s.c
+++ b/src/config/no_vsnprintf_s.c
@@ -23,7 +23,9 @@
 #include "private/memory.h"
 
 char *
-no_vsnprintf_s_format_string( const char *format, va_list subs, size_t *length ) {
+no_vsnprintf_s_format_string( const char *format,
+                              va_list subs,
+                              size_t *length ) {
   char *buffer;
   size_t buffer_size = 128;
   int result;

--- a/src/entry.c
+++ b/src/entry.c
@@ -647,8 +647,9 @@ stumpless_set_entry_msgid( struct stumpless_entry *entry,
   VALIDATE_ARG_NOT_NULL( entry );
 
   effective_msgid = msgid ? msgid : "-";
-  if( !validate_msgid_length( effective_msgid ) || !validate_msgid_format( effective_msgid ) ) {
-      return NULL;
+  if( !validate_msgid_length( effective_msgid ) ||
+      !validate_msgid_format( effective_msgid ) ) {
+    return NULL;
   }
 
   new_msgid = copy_cstring_with_length( effective_msgid, &new_msgid_length );
@@ -876,8 +877,9 @@ vstumpless_new_entry( enum stumpless_facility facility,
   }
 
   effective_msgid = msgid ? msgid : "-";
-  if( !validate_msgid_length( effective_msgid ) || !validate_msgid_format( effective_msgid ) ) {
-      goto fail_msgid;
+  if( !validate_msgid_length( effective_msgid ) ||
+      !validate_msgid_format( effective_msgid ) ) {
+    goto fail_msgid;
   }
 
   msgid_length = &( entry->msgid_length );

--- a/src/error.c
+++ b/src/error.c
@@ -53,12 +53,12 @@ stumpless_get_error_id( const struct stumpless_error *err ) {
 
 const char *
 stumpless_get_error_id_string( enum stumpless_error_id id) {
-  int error_id_upper_bound = 
-	  sizeof( stumpless_error_enum_to_string ) / sizeof( char * );
+  int error_id_upper_bound = sizeof( stumpless_error_enum_to_string ) /
+                             sizeof( char * );
   if ( id >= 0 && id < error_id_upper_bound ) {
     return stumpless_error_enum_to_string[id];
   }
-  
+
   return "NO_SUCH_ERROR_ID";
 }
 
@@ -98,7 +98,6 @@ stumpless_perror( const char *prefix ) {
     fputs( stumpless_get_error_id_string(last_error.id), stream );
     fputc( ':', stream );
     fputc( ' ', stream );
-    
 
     fputs( last_error.message, stream );
 
@@ -233,7 +232,9 @@ raise_param_not_found( void ) {
 }
 
 void
-raise_socket_bind_failure( const char *message, int code, const char *code_type ) {
+raise_socket_bind_failure( const char *message,
+                           int code,
+                           const char *code_type ) {
   raise_error( STUMPLESS_SOCKET_BIND_FAILURE, message, code, code_type );
 }
 

--- a/src/formatter.c
+++ b/src/formatter.c
@@ -27,7 +27,7 @@
 
 struct strbuilder *
 format_entry( const struct stumpless_entry *entry,
-              struct stumpless_target *target ) {
+              const struct stumpless_target *target ) {
   char timestamp[RFC_5424_TIMESTAMP_BUFFER_SIZE];
   struct strbuilder *builder;
   size_t timestamp_size;

--- a/src/strbuilder.c
+++ b/src/strbuilder.c
@@ -172,7 +172,9 @@ strbuilder_new( void ) {
   size_t size;
 
   if( !strbuilder_cache ) {
-    strbuilder_cache = cache_new( sizeof( *builder ), strbuilder_init, strbuilder_teardown );
+    strbuilder_cache = cache_new( sizeof( *builder ),
+                                  strbuilder_init,
+                                  strbuilder_teardown );
 
     if( !strbuilder_cache ) {
       goto fail;

--- a/src/validate.c
+++ b/src/validate.c
@@ -29,7 +29,7 @@ bool validate_msgid_length(const char* msgid ) {
 
   if( msgid_char_length > max_msgid_length ) {
     raise_argument_too_big( L10N_STRING_TOO_LONG_ERROR_MESSAGE,
-                            msgid_char_length, 
+                            msgid_char_length,
                             L10N_STRING_LENGTH_ERROR_CODE_TYPE );
 
     validation_status = false;

--- a/src/version.c
+++ b/src/version.c
@@ -46,7 +46,7 @@ stumpless_get_version( void ) {
 }
 
 int
-stumpless_version_cmp ( const struct stumpless_version * version_x, 
+stumpless_version_cmp ( const struct stumpless_version * version_x,
                         const struct stumpless_version * version_y ) {
   if( !version_x ) {
     raise_argument_empty( L10N_NULL_ARG_ERROR_MESSAGE( "version_x" ) );
@@ -57,20 +57,20 @@ stumpless_version_cmp ( const struct stumpless_version * version_x,
     raise_argument_empty( L10N_NULL_ARG_ERROR_MESSAGE( "version_y" ) );
     return INT_MAX;
   }
-  
+
   if( version_x->major != version_y->major ) {
-    return ( version_x->major - version_y->major )/
-	    abs( version_x->major - version_y->major ) * 100;
+    return ( version_x->major - version_y->major ) /
+	       abs( version_x->major - version_y->major ) * 100;
   }
-  
+
   if( version_y->minor != version_x->minor ) {
-    return ( version_x->minor - version_y->minor )/
-	    abs( version_x->minor - version_y->minor ) * 10;
+    return ( version_x->minor - version_y->minor ) /
+           abs( version_x->minor - version_y->minor ) * 10;
   }
-  
+
   if( version_x->patch != version_y->patch ) {
-    return ( version_x->patch - version_y->patch )/
-	    abs( version_x->patch - version_y->patch );
+    return ( version_x->patch - version_y->patch ) /
+          abs( version_x->patch - version_y->patch );
   }
 
   return 0;


### PR DESCRIPTION
Resolves several minor code smells identified by sonarcloud scans. Also makes a few adjustments to the Github Actions so that locale tests only run for pull requests and pushes to `latest`, and moves coverage reports so that they are more consistent by not including thread safety tests.