### PR TITLE
fix sonarcloud violations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,7 @@ else()
   add_function_test(tcp6
     SOURCES
       test/function/target/tcp6.cpp
+      $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:rfc5424_checker>
       $<TARGET_OBJECTS:test_helper_resolve>
       $<TARGET_OBJECTS:test_helper_server>
@@ -822,91 +823,127 @@ add_function_test(get_error_stream
 )
 
 add_function_test(level_all_disabled
-  SOURCES test/function/level/all_disabled.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/all_disabled.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_DISABLE_ALL_LEVELS
 )
 
 add_function_test(level_all_enabled
-  SOURCES test/function/level/all_enabled.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/all_enabled.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
 )
 
 add_function_test(level_disabled_downto_alert
-  SOURCES test/function/level/enable_upto_emerg.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_emerg.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_DISABLE_DOWNTO_ALERT
 )
 
 add_function_test(level_disabled_downto_emerg
-  SOURCES test/function/level/all_disabled.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/all_disabled.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_DISABLE_DOWNTO_EMERG
 )
 
 add_function_test(level_disabled_downto_err
-  SOURCES test/function/level/enable_upto_crit.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_crit.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_DISABLE_DOWNTO_ERR
 )
 
 add_function_test(level_disabled_downto_crit
-  SOURCES test/function/level/enable_upto_alert.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_alert.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_DISABLE_DOWNTO_CRIT
 )
 
 add_function_test(level_disabled_downto_debug
-  SOURCES test/function/level/enable_upto_info.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_info.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_DISABLE_DOWNTO_DEBUG
 )
 
 add_function_test(level_disabled_downto_info
-  SOURCES test/function/level/enable_upto_notice.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_notice.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_DISABLE_DOWNTO_INFO
 )
 
 add_function_test(level_disabled_downto_notice
-  SOURCES test/function/level/enable_upto_warning.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_warning.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_DISABLE_DOWNTO_NOTICE
 )
 
 add_function_test(level_disabled_downto_warning
-  SOURCES test/function/level/enable_upto_err.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_err.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_DISABLE_DOWNTO_WARNING
 )
 
 add_function_test(level_enable_upto_alert
-  SOURCES test/function/level/enable_upto_alert.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_alert.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_ENABLE_UPTO_ALERT
 )
 
 add_function_test(level_enable_upto_crit
-  SOURCES test/function/level/enable_upto_crit.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_crit.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_ENABLE_UPTO_CRIT
 )
 
 add_function_test(level_enable_upto_debug
-  SOURCES test/function/level/all_enabled.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/all_enabled.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_ENABLE_UPTO_DEBUG
 )
 
 add_function_test(level_enable_upto_emerg
-  SOURCES test/function/level/enable_upto_emerg.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_emerg.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_ENABLE_UPTO_EMERG
 )
 
 add_function_test(level_enable_upto_err
-  SOURCES test/function/level/enable_upto_err.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_err.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_ENABLE_UPTO_ERR
 )
 
 add_function_test(level_enable_upto_info
-  SOURCES test/function/level/enable_upto_info.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_info.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_ENABLE_UPTO_INFO
 )
 
 add_function_test(level_enable_upto_notice
-  SOURCES test/function/level/enable_upto_notice.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_notice.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_ENABLE_UPTO_NOTICE
 )
 
 add_function_test(level_enable_upto_warning
-  SOURCES test/function/level/enable_upto_warning.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/function/level/enable_upto_warning.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
   COMPILE_DEFINITIONS STUMPLESS_ENABLE_UPTO_WARNING
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,8 +343,8 @@ else()
   add_function_test(tcp4
     SOURCES
       test/function/target/tcp4.cpp
-      $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:rfc5424_checker>
+      $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:test_helper_resolve>
       $<TARGET_OBJECTS:test_helper_server>
     LIBRARIES ${network_libraries}
@@ -353,8 +353,8 @@ else()
   add_function_test(tcp6
     SOURCES
       test/function/target/tcp6.cpp
-      $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:rfc5424_checker>
+      $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:test_helper_resolve>
       $<TARGET_OBJECTS:test_helper_server>
     LIBRARIES ${network_libraries}
@@ -364,6 +364,7 @@ else()
     SOURCES
       test/function/target/udp4.cpp
       $<TARGET_OBJECTS:rfc5424_checker>
+      $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:test_helper_resolve>
       $<TARGET_OBJECTS:test_helper_server>
     LIBRARIES ${network_libraries}
@@ -373,6 +374,7 @@ else()
     SOURCES
       test/function/target/udp6.cpp
       $<TARGET_OBJECTS:rfc5424_checker>
+      $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:test_helper_resolve>
       $<TARGET_OBJECTS:test_helper_server>
     LIBRARIES ${network_libraries}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,7 @@ else()
     SOURCES
       test/function/target/udp4.cpp
       $<TARGET_OBJECTS:rfc5424_checker>
+      $<TARGET_OBJECTS:test_function_target_udp>
       $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:test_helper_resolve>
       $<TARGET_OBJECTS:test_helper_server>
@@ -374,6 +375,7 @@ else()
     SOURCES
       test/function/target/udp6.cpp
       $<TARGET_OBJECTS:rfc5424_checker>
+      $<TARGET_OBJECTS:test_function_target_udp>
       $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:test_helper_resolve>
       $<TARGET_OBJECTS:test_helper_server>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,7 @@ else()
   add_function_test(tcp4
     SOURCES
       test/function/target/tcp4.cpp
+      $<TARGET_OBJECTS:test_helper_fixture>
       $<TARGET_OBJECTS:rfc5424_checker>
       $<TARGET_OBJECTS:test_helper_resolve>
       $<TARGET_OBJECTS:test_helper_server>

--- a/include/stumpless/target/function.h
+++ b/include/stumpless/target/function.h
@@ -71,6 +71,8 @@ typedef int ( *stumpless_log_func_t )( const struct stumpless_target *,
  * This function is not safe to call from threads that may be asynchronously
  * cancelled, as the memory deallocation function may not be AC-Safe itself.
  *
+ * @since v2.1.0
+ *
  * @param target The function target to close.
  */
 void
@@ -96,6 +98,8 @@ stumpless_close_function_target( const struct stumpless_target *target );
  * **Async Cancel Safety: AC-Unsafe heap**
  * This function is not safe to call from threads that may be asynchronously
  * cancelled, as the memory allocation function may not be AC-Safe itself.
+ *
+ * @since v2.1.0
  *
  * @param name The name of the logging target.
  *

--- a/include/test/function/rfc5424.hpp
+++ b/include/test/function/rfc5424.hpp
@@ -2,13 +2,13 @@
 
 /*
  * Copyright 2018 Joel E. Anderson
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/include/test/function/target/udp.hpp
+++ b/include/test/function/target/udp.hpp
@@ -2,13 +2,13 @@
 
 /*
  * Copyright 2021 Joel E. Anderson
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/include/test/function/target/udp.hpp
+++ b/include/test/function/target/udp.hpp
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Copyright 2021 Joel E. Anderson
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __STUMPLESS_TEST_FUNCTION_TARGET_UDP_HPP
+#  define __STUMPLESS_TEST_FUNCTION_TARGET_UDP_HPP
+
+#  include <stumpless.h>
+
+void TestTruncatedMessage( struct stumpless_target *target );
+
+#endif /* __STUMPLESS_TEST_FUNCTION_TARGET_UDP_HPP */

--- a/include/test/function/utf8.hpp
+++ b/include/test/function/utf8.hpp
@@ -2,13 +2,13 @@
 
 /*
  * Copyright 2018 Joel E. Anderson
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/include/test/helper/fixture.hpp
+++ b/include/test/helper/fixture.hpp
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,38 @@
 #ifndef __STUMPLESS_TEST_HELPER_FIXTURE_HPP
 #  define __STUMPLESS_TEST_HELPER_FIXTURE_HPP
 
+#  include <cstdlib>
+#  include <gtest/gtest.h>
 #  include <stumpless.h>
+
+#  define BUFFER_TARGET_FIXTURE_CLASS( CLASS_NAME )                            \
+class CLASS_NAME : public::testing::Test {                                     \
+protected:                                                                     \
+  char buffer[8192];                                                           \
+  struct stumpless_target *target;                                             \
+  struct stumpless_entry *basic_entry;                                         \
+  const char *basic_message;                                                   \
+                                                                               \
+  virtual void                                                                 \
+  SetUp( void ) {                                                              \
+    buffer[0] = '\0';                                                          \
+    target = stumpless_open_buffer_target( "info level testing",               \
+                                           buffer,                             \
+                                           sizeof( buffer ) );                 \
+                                                                               \
+    stumpless_set_target_default_app_name( target, "info-level-test" );        \
+    stumpless_set_target_default_msgid( target, "default-message" );           \
+    basic_entry = create_entry(  );                                            \
+    basic_message = stumpless_get_entry_message( basic_entry );                \
+  }                                                                            \
+                                                                               \
+  virtual void                                                                 \
+  TearDown( void ) {                                                           \
+    free( ( void * ) basic_message );                                          \
+    stumpless_destroy_entry_and_contents( basic_entry );                       \
+    stumpless_close_buffer_target( target );                                   \
+  }                                                                            \
+}
 
 struct stumpless_entry *
 create_empty_entry( void );

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=goatshriek-github
 sonar.projectKey=stumpless
-sonar.sources=src,test/thread_safety,test/function/leak,test/function/target/function.cpp,test/function/cpp/target/function.cpp,test/performance/target/function.cpp
+sonar.sources=src,test
 sonar.cfamily.threads=1
 sonar.cfamily.cache.enabled=false
 sonar.cfamily.build-wrapper-output=bw-output

--- a/src/entry.c
+++ b/src/entry.c
@@ -598,7 +598,8 @@ stumpless_set_entry_app_name( struct stumpless_entry *entry,
   VALIDATE_ARG_NOT_NULL( entry );
 
   effective_name = app_name ? app_name : "-";
-  if( !validate_app_name_length( effective_name ) | !validate_printable_ascii( effective_name )) {
+  if( !validate_app_name_length( effective_name ) ||
+      !validate_printable_ascii( effective_name ) ) {
     return NULL;
   }
 
@@ -865,7 +866,8 @@ vstumpless_new_entry( enum stumpless_facility facility,
   }
 
   effective_app_name = app_name ? app_name : "-";
-  if ( !validate_app_name_length ( effective_app_name ) | !validate_printable_ascii( effective_app_name )) {
+  if ( !validate_app_name_length ( effective_app_name ) ||
+       !validate_printable_ascii( effective_app_name ) ) {
       goto fail_app_name;
   }
 

--- a/src/target.c
+++ b/src/target.c
@@ -27,6 +27,7 @@
 #include <stumpless/target.h>
 #include <stumpless/target/buffer.h>
 #include <stumpless/target/file.h>
+#include <stumpless/target/function.h>
 #include <stumpless/target/stream.h>
 #include "private/config/locale/wrapper.h"
 #include "private/config/wrapper.h"
@@ -204,6 +205,10 @@ stumpless_close_target( struct stumpless_target *target ) {
 
     case STUMPLESS_FILE_TARGET:
       stumpless_close_file_target( target );
+      break;
+
+    case STUMPLESS_FUNCTION_TARGET:
+      stumpless_close_function_target( target );
       break;
 
     case STUMPLESS_NETWORK_TARGET:

--- a/src/target.c
+++ b/src/target.c
@@ -445,7 +445,8 @@ stumpless_set_target_default_app_name( struct stumpless_target *target,
   VALIDATE_ARG_NOT_NULL( target );
   VALIDATE_ARG_NOT_NULL( app_name );
 
-  if( !validate_app_name_length( app_name ) | !validate_printable_ascii( app_name ) ) {
+  if( !validate_app_name_length( app_name ) ||
+      !validate_printable_ascii( app_name ) ) {
     return NULL;
   }
 

--- a/test/function/level/all_disabled.cpp
+++ b/test/function/level/all_disabled.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,55 +17,14 @@
  */
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <stumpless.h>
+#include "test/helper/fixture.hpp"
 #include "test/helper/level_disabled.hpp"
-
-#define TEST_BUFFER_LENGTH 8192
 
 using::testing::HasSubstr;
 
 namespace {
 
-  class LevelEnabledTest : public::testing::Test {
-  protected:
-    char buffer[TEST_BUFFER_LENGTH];
-    struct stumpless_target *target;
-    struct stumpless_entry *basic_entry;
-    const char *basic_message = "basic test message";
-
-    virtual void
-    SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
-      buffer[0] = '\0';
-      target = stumpless_open_buffer_target( "info level testing",
-                                             buffer,
-                                             TEST_BUFFER_LENGTH );
-
-      stumpless_set_target_default_app_name( target, "info-level-test" );
-      stumpless_set_target_default_msgid( target, "default-message" );
-
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_INFO,
-                                        "stumpless-unit-test",
-                                        "basic-entry",
-                                        basic_message );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
-    }
-
-    virtual void
-    TearDown( void ) {
-      stumpless_destroy_entry_and_contents( basic_entry );
-      stumpless_close_buffer_target( target );
-    }
-  };
+  BUFFER_TARGET_FIXTURE_CLASS( LevelEnabledTest );
 
   TEST_LEVEL_DISABLED( EMERG, em );
   TEST_LEVEL_DISABLED( ALERT, a );

--- a/test/function/level/all_enabled.cpp
+++ b/test/function/level/all_enabled.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,55 +17,14 @@
  */
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <stumpless.h>
+#include "test/helper/fixture.hpp"
 #include "test/helper/level_enabled.hpp"
-
-#define TEST_BUFFER_LENGTH 8192
 
 using::testing::HasSubstr;
 
 namespace {
 
-  class LevelEnabledTest : public::testing::Test {
-  protected:
-    char buffer[TEST_BUFFER_LENGTH];
-    struct stumpless_target *target;
-    struct stumpless_entry *basic_entry;
-    const char *basic_message = "basic test message";
-
-    virtual void
-    SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
-      buffer[0] = '\0';
-      target = stumpless_open_buffer_target( "level enabled testing",
-                                             buffer,
-                                             TEST_BUFFER_LENGTH );
-
-      stumpless_set_target_default_app_name( target, "level-enabled-test" );
-      stumpless_set_target_default_msgid( target, "default-message" );
-
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_WARNING,
-                                        "stumpless-unit-test",
-                                        "basic-entry",
-                                        basic_message );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
-    }
-
-    virtual void
-    TearDown( void ) {
-      stumpless_destroy_entry_and_contents( basic_entry );
-      stumpless_close_buffer_target( target );
-    }
-  };
+  BUFFER_TARGET_FIXTURE_CLASS( LevelEnabledTest );
 
   TEST_LEVEL_ENABLED( EMERG, em );
   TEST_LEVEL_ENABLED( ALERT, a );

--- a/test/function/level/enable_upto_alert.cpp
+++ b/test/function/level/enable_upto_alert.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,56 +17,15 @@
  */
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <stumpless.h>
+#include "test/helper/fixture.hpp"
 #include "test/helper/level_disabled.hpp"
 #include "test/helper/level_enabled.hpp"
-
-#define TEST_BUFFER_LENGTH 8192
 
 using::testing::HasSubstr;
 
 namespace {
 
-  class LevelEnabledTest : public::testing::Test {
-  protected:
-    char buffer[TEST_BUFFER_LENGTH];
-    struct stumpless_target *target;
-    struct stumpless_entry *basic_entry;
-    const char *basic_message = "basic test message";
-
-    virtual void
-    SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
-      buffer[0] = '\0';
-      target = stumpless_open_buffer_target( "info level testing",
-                                             buffer,
-                                             TEST_BUFFER_LENGTH );
-
-      stumpless_set_target_default_app_name( target, "info-level-test" );
-      stumpless_set_target_default_msgid( target, "default-message" );
-
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_INFO,
-                                        "stumpless-unit-test",
-                                        "basic-entry",
-                                        basic_message );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
-    }
-
-    virtual void
-    TearDown( void ) {
-      stumpless_destroy_entry_and_contents( basic_entry );
-      stumpless_close_buffer_target( target );
-    }
-  };
+  BUFFER_TARGET_FIXTURE_CLASS( LevelEnabledTest );
 
   TEST_LEVEL_ENABLED( EMERG, em );
   TEST_LEVEL_ENABLED( ALERT, a );

--- a/test/function/level/enable_upto_crit.cpp
+++ b/test/function/level/enable_upto_crit.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,56 +17,16 @@
  */
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <stumpless.h>
+#include "test/helper/fixture.hpp"
 #include "test/helper/level_disabled.hpp"
 #include "test/helper/level_enabled.hpp"
 
-#define TEST_BUFFER_LENGTH 8192
 
 using::testing::HasSubstr;
 
 namespace {
 
-  class LevelEnabledTest : public::testing::Test {
-  protected:
-    char buffer[TEST_BUFFER_LENGTH];
-    struct stumpless_target *target;
-    struct stumpless_entry *basic_entry;
-    const char *basic_message = "basic test message";
-
-    virtual void
-    SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
-      buffer[0] = '\0';
-      target = stumpless_open_buffer_target( "info level testing",
-                                             buffer,
-                                             TEST_BUFFER_LENGTH );
-
-      stumpless_set_target_default_app_name( target, "info-level-test" );
-      stumpless_set_target_default_msgid( target, "default-message" );
-
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_INFO,
-                                        "stumpless-unit-test",
-                                        "basic-entry",
-                                        basic_message );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
-    }
-
-    virtual void
-    TearDown( void ) {
-      stumpless_destroy_entry_and_contents( basic_entry );
-      stumpless_close_buffer_target( target );
-    }
-  };
+  BUFFER_TARGET_FIXTURE_CLASS( LevelEnabledTest );
 
   TEST_LEVEL_ENABLED( EMERG, em );
   TEST_LEVEL_ENABLED( ALERT, a );

--- a/test/function/level/enable_upto_emerg.cpp
+++ b/test/function/level/enable_upto_emerg.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,56 +17,15 @@
  */
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <stumpless.h>
+#include "test/helper/fixture.hpp"
 #include "test/helper/level_disabled.hpp"
 #include "test/helper/level_enabled.hpp"
-
-#define TEST_BUFFER_LENGTH 8192
 
 using::testing::HasSubstr;
 
 namespace {
 
-  class LevelEnabledTest : public::testing::Test {
-  protected:
-    char buffer[TEST_BUFFER_LENGTH];
-    struct stumpless_target *target;
-    struct stumpless_entry *basic_entry;
-    const char *basic_message = "basic test message";
-
-    virtual void
-    SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
-      buffer[0] = '\0';
-      target = stumpless_open_buffer_target( "info level testing",
-                                             buffer,
-                                             TEST_BUFFER_LENGTH );
-
-      stumpless_set_target_default_app_name( target, "info-level-test" );
-      stumpless_set_target_default_msgid( target, "default-message" );
-
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_INFO,
-                                        "stumpless-unit-test",
-                                        "basic-entry",
-                                        basic_message );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
-    }
-
-    virtual void
-    TearDown( void ) {
-      stumpless_destroy_entry_and_contents( basic_entry );
-      stumpless_close_buffer_target( target );
-    }
-  };
+  BUFFER_TARGET_FIXTURE_CLASS( LevelEnabledTest );
 
   TEST_LEVEL_ENABLED( EMERG, em );
 

--- a/test/function/level/enable_upto_err.cpp
+++ b/test/function/level/enable_upto_err.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,56 +17,15 @@
  */
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <stumpless.h>
+#include "test/helper/fixture.hpp"
 #include "test/helper/level_disabled.hpp"
 #include "test/helper/level_enabled.hpp"
-
-#define TEST_BUFFER_LENGTH 8192
 
 using::testing::HasSubstr;
 
 namespace {
 
-  class LevelEnabledTest : public::testing::Test {
-  protected:
-    char buffer[TEST_BUFFER_LENGTH];
-    struct stumpless_target *target;
-    struct stumpless_entry *basic_entry;
-    const char *basic_message = "basic test message";
-
-    virtual void
-    SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
-      buffer[0] = '\0';
-      target = stumpless_open_buffer_target( "info level testing",
-                                             buffer,
-                                             TEST_BUFFER_LENGTH );
-
-      stumpless_set_target_default_app_name( target, "info-level-test" );
-      stumpless_set_target_default_msgid( target, "default-message" );
-
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_INFO,
-                                        "stumpless-unit-test",
-                                        "basic-entry",
-                                        basic_message );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
-    }
-
-    virtual void
-    TearDown( void ) {
-      stumpless_destroy_entry_and_contents( basic_entry );
-      stumpless_close_buffer_target( target );
-    }
-  };
+  BUFFER_TARGET_FIXTURE_CLASS( LevelEnabledTest );
 
   TEST_LEVEL_ENABLED( EMERG, em );
   TEST_LEVEL_ENABLED( ALERT, a );

--- a/test/function/level/enable_upto_info.cpp
+++ b/test/function/level/enable_upto_info.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,56 +17,15 @@
  */
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <stumpless.h>
+#include "test/helper/fixture.hpp"
 #include "test/helper/level_disabled.hpp"
 #include "test/helper/level_enabled.hpp"
-
-#define TEST_BUFFER_LENGTH 8192
 
 using::testing::HasSubstr;
 
 namespace {
 
-  class LevelEnabledTest : public::testing::Test {
-  protected:
-    char buffer[TEST_BUFFER_LENGTH];
-    struct stumpless_target *target;
-    struct stumpless_entry *basic_entry;
-    const char *basic_message = "basic test message";
-
-    virtual void
-    SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
-      buffer[0] = '\0';
-      target = stumpless_open_buffer_target( "info level testing",
-                                             buffer,
-                                             TEST_BUFFER_LENGTH );
-
-      stumpless_set_target_default_app_name( target, "info-level-test" );
-      stumpless_set_target_default_msgid( target, "default-message" );
-
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_INFO,
-                                        "stumpless-unit-test",
-                                        "basic-entry",
-                                        basic_message );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
-    }
-
-    virtual void
-    TearDown( void ) {
-      stumpless_destroy_entry_and_contents( basic_entry );
-      stumpless_close_buffer_target( target );
-    }
-  };
+  BUFFER_TARGET_FIXTURE_CLASS( LevelEnabledTest );
 
   TEST_LEVEL_ENABLED( EMERG, em );
   TEST_LEVEL_ENABLED( ALERT, a );

--- a/test/function/level/enable_upto_notice.cpp
+++ b/test/function/level/enable_upto_notice.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,56 +17,15 @@
  */
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <stumpless.h>
+#include "test/helper/fixture.hpp"
 #include "test/helper/level_disabled.hpp"
 #include "test/helper/level_enabled.hpp"
-
-#define TEST_BUFFER_LENGTH 8192
 
 using::testing::HasSubstr;
 
 namespace {
 
-  class LevelEnabledTest : public::testing::Test {
-  protected:
-    char buffer[TEST_BUFFER_LENGTH];
-    struct stumpless_target *target;
-    struct stumpless_entry *basic_entry;
-    const char *basic_message = "basic test message";
-
-    virtual void
-    SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
-      buffer[0] = '\0';
-      target = stumpless_open_buffer_target( "info level testing",
-                                             buffer,
-                                             TEST_BUFFER_LENGTH );
-
-      stumpless_set_target_default_app_name( target, "info-level-test" );
-      stumpless_set_target_default_msgid( target, "default-message" );
-
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_INFO,
-                                        "stumpless-unit-test",
-                                        "basic-entry",
-                                        basic_message );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
-    }
-
-    virtual void
-    TearDown( void ) {
-      stumpless_destroy_entry_and_contents( basic_entry );
-      stumpless_close_buffer_target( target );
-    }
-  };
+  BUFFER_TARGET_FIXTURE_CLASS( LevelEnabledTest );
 
   TEST_LEVEL_ENABLED( EMERG, em );
   TEST_LEVEL_ENABLED( ALERT, a );

--- a/test/function/level/enable_upto_warning.cpp
+++ b/test/function/level/enable_upto_warning.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,56 +17,15 @@
  */
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <stumpless.h>
+#include "test/helper/fixture.hpp"
 #include "test/helper/level_disabled.hpp"
 #include "test/helper/level_enabled.hpp"
-
-#define TEST_BUFFER_LENGTH 8192
 
 using::testing::HasSubstr;
 
 namespace {
 
-  class LevelEnabledTest : public::testing::Test {
-  protected:
-    char buffer[TEST_BUFFER_LENGTH];
-    struct stumpless_target *target;
-    struct stumpless_entry *basic_entry;
-    const char *basic_message = "basic test message";
-
-    virtual void
-    SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
-      buffer[0] = '\0';
-      target = stumpless_open_buffer_target( "info level testing",
-                                             buffer,
-                                             TEST_BUFFER_LENGTH );
-
-      stumpless_set_target_default_app_name( target, "info-level-test" );
-      stumpless_set_target_default_msgid( target, "default-message" );
-
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_INFO,
-                                        "stumpless-unit-test",
-                                        "basic-entry",
-                                        basic_message );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
-    }
-
-    virtual void
-    TearDown( void ) {
-      stumpless_destroy_entry_and_contents( basic_entry );
-      stumpless_close_buffer_target( target );
-    }
-  };
+  BUFFER_TARGET_FIXTURE_CLASS( LevelEnabledTest );
 
   TEST_LEVEL_ENABLED( EMERG, em );
   TEST_LEVEL_ENABLED( ALERT, a );

--- a/test/function/target/function.cpp
+++ b/test/function/target/function.cpp
@@ -91,12 +91,21 @@ namespace {
 
   /* non-fixture tests */
 
+  TEST( FunctionTargetCloseTest, GenericCloseFunction ) {
+    struct stumpless_target *target;
+
+    target = stumpless_open_function_target( "basic-target", basic_log_function );
+    stumpless_close_target( target );
+    EXPECT_NO_ERROR;
+    stumpless_free_all(  );
+  }
+
   TEST( FunctionTargetCloseTest, NullTarget ) {
     const struct stumpless_error *error;
 
     stumpless_close_function_target( NULL );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
-    stumpless_free_all( );
+    stumpless_free_all(  );
   }
 
   TEST( FunctionTargetCloseTest, WrongTargetType ) {

--- a/test/function/target/tcp4.cpp
+++ b/test/function/target/tcp4.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2019-2020 Joel E. Anderson
+ * Copyright 2019-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -237,15 +237,11 @@ namespace {
         ASSERT_NOT_NULL( target );
 
         destination_result = stumpless_get_destination( target );
-        EXPECT_TRUE( destination_result != NULL );
+        EXPECT_NOT_NULL( destination_result );
         EXPECT_STREQ( destination_result, original_destination );
 
-        entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                     STUMPLESS_SEVERITY_INFO,
-                                     "stumpless-unit-test",
-                                     "basic-entry",
-                                     "basic test message" );
-        EXPECT_TRUE( entry != NULL );
+        entry = create_entry(  );
+        EXPECT_NOT_NULL( entry );
 
         add_result = stumpless_add_entry( target, entry );
         EXPECT_GE( add_result, 0 );
@@ -263,7 +259,7 @@ namespace {
         EXPECT_TRUE( stumpless_target_is_open( target ) );
 
         destination_result = stumpless_get_destination( target );
-        EXPECT_TRUE( destination_result != NULL );
+        EXPECT_NOT_NULL( destination_result );
         EXPECT_STREQ( destination_result, new_destination );
 
         add_result = stumpless_add_entry( target, entry );

--- a/test/function/target/tcp4.cpp
+++ b/test/function/target/tcp4.cpp
@@ -26,6 +26,7 @@
 #include <gtest/gtest.h>
 #include "test/function/rfc5424.hpp"
 #include "test/helper/assert.hpp"
+#include "test/helper/fixture.hpp"
 #include "test/helper/resolve.hpp"
 
 #ifndef _WIN32
@@ -47,9 +48,6 @@ namespace {
 
     virtual void
     SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
       // setting up to receive the sent messages
       handle = open_tcp4_server_socket( "127.0.0.1", port );
       if( handle == BAD_HANDLE ) {
@@ -61,18 +59,7 @@ namespace {
 
       stumpless_set_target_default_app_name( target, "network-target-test" );
       stumpless_set_target_default_msgid( target, "default-message" );
-
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_INFO,
-                                         "stumpless-unit-test",
-                                         "basic-entry",
-                                         "basic test message" );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
+      basic_entry = create_entry(  );
     }
 
     virtual void
@@ -137,8 +124,7 @@ namespace {
 
     } else {
       port_result = stumpless_get_transport_port( target );
-
-      EXPECT_TRUE( port_result != NULL );
+      EXPECT_NOT_NULL( port_result );
       EXPECT_TRUE( port_result != port );
       EXPECT_STREQ( port_result, port );
     }
@@ -184,8 +170,8 @@ namespace {
     struct stumpless_target *target;
 
     target = stumpless_new_tcp4_target( "my-tcp4-target" );
-    EXPECT_TRUE( target != NULL );
-    EXPECT_TRUE( stumpless_get_error(  ) == NULL );
+    EXPECT_NOT_NULL( target );
+    EXPECT_NO_ERROR;
 
     EXPECT_FALSE( stumpless_target_is_open( target ) );
 

--- a/test/function/target/tcp4.cpp
+++ b/test/function/target/tcp4.cpp
@@ -206,7 +206,7 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
   }
 
-  TEST( NetworkTargetSetDestination, OpenTarget ) {
+  TEST( NetworkTargetSetDestination, OpenTcp4Target ) {
     struct stumpless_target *target;
     struct stumpless_target *target_result;
     struct stumpless_entry *entry;
@@ -278,7 +278,7 @@ namespace {
     }
   }
 
-  TEST( NetworkTargetSetDestination, PausedTarget ) {
+  TEST( NetworkTargetSetDestination, PausedTcp4Target ) {
     struct stumpless_target *target;
     struct stumpless_target *target_result;
     struct stumpless_entry *entry;
@@ -319,11 +319,7 @@ namespace {
 
       EXPECT_TRUE( stumpless_target_is_open( target ) );
 
-      entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                   STUMPLESS_SEVERITY_INFO,
-                                   "stumpless-unit-test",
-                                   "basic-entry",
-                                   "basic test message" );
+      entry = create_entry(  );
       EXPECT_NOT_NULL( entry );
 
       add_result = stumpless_add_entry( target, entry );
@@ -341,7 +337,7 @@ namespace {
     close_server_socket( port_handle );
   }
 
-  TEST( NetworkTargetSetTransportPort, OpenTarget ) {
+  TEST( NetworkTargetSetTransportPort, OpenTcp4Target ) {
     struct stumpless_target *target;
     struct stumpless_target *result;
     struct stumpless_entry *entry;
@@ -361,11 +357,7 @@ namespace {
       target = stumpless_open_tcp4_target( "target-to-self", "127.0.0.1" );
       ASSERT_NOT_NULL( target );
 
-      entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                   STUMPLESS_SEVERITY_INFO,
-                                   "stumpless-unit-test",
-                                   "basic-entry",
-                                   "basic test message" );
+      entry = create_entry(  );
       ASSERT_NOT_NULL( entry );
 
       add_result = stumpless_add_entry( target, entry );
@@ -406,7 +398,7 @@ namespace {
     close_server_socket( new_port_handle );
   }
 
-  TEST( NetworkTargetSetTransportPort, PausedTarget ) {
+  TEST( NetworkTargetSetTransportPort, PausedTcp4Target ) {
     struct stumpless_target *target;
     struct stumpless_target *result;
     struct stumpless_entry *entry;
@@ -451,11 +443,7 @@ namespace {
       EXPECT_EQ( result, target );
       EXPECT_TRUE( stumpless_target_is_open( target ) );
 
-      entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                   STUMPLESS_SEVERITY_INFO,
-                                   "stumpless-unit-test",
-                                   "basic-entry",
-                                   "basic test message" );
+      entry = create_entry(  );
       ASSERT_NOT_NULL( entry );
 
       add_result = stumpless_add_entry( target, entry );
@@ -469,7 +457,6 @@ namespace {
       stumpless_destroy_entry_and_contents( entry );
       close_server_socket( accepted );
       stumpless_close_network_target( target );
-
     }
 
     close_server_socket( default_port_handle );

--- a/test/function/target/tcp6.cpp
+++ b/test/function/target/tcp6.cpp
@@ -26,6 +26,7 @@
 #include <gtest/gtest.h>
 #include "test/function/rfc5424.hpp"
 #include "test/helper/assert.hpp"
+#include "test/helper/fixture.hpp"
 #include "test/helper/resolve.hpp"
 
 #ifndef _WIN32
@@ -47,9 +48,6 @@ namespace {
 
     virtual void
     SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
       // setting up to receive the sent messages
       handle = open_tcp6_server_socket( "::1", port );
       if( handle == BAD_HANDLE ) {
@@ -61,18 +59,7 @@ namespace {
 
       stumpless_set_target_default_app_name( target, "network-target-test" );
       stumpless_set_target_default_msgid( target, "default-message" );
-
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_INFO,
-                                         "stumpless-unit-test",
-                                         "basic-entry",
-                                         "basic test message" );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
+      basic_entry = create_entry(  );
     }
 
     virtual void

--- a/test/function/target/tcp6.cpp
+++ b/test/function/target/tcp6.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2019-2020 Joel E. Anderson
+ * Copyright 2019-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/function/target/udp.cpp
+++ b/test/function/target/udp.cpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2021 Joel E. Anderson
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <stumpless.h>
+#include "test/helper/assert.hpp"
+#include "test/function/target/udp.hpp"
+
+void TestTruncatedMessage( struct stumpless_target *target ) {
+  size_t max_msg_size;
+  size_t my_msg_size;
+  char *message;
+  int result;
+  const struct stumpless_error *error;
+
+  ASSERT_NOT_NULL( target );
+  ASSERT_TRUE( stumpless_target_is_open( target ) );
+
+  max_msg_size = stumpless_get_udp_max_message_size( target );
+  ASSERT_NE( max_msg_size, 0 );
+
+  my_msg_size = max_msg_size + 10;
+  message = ( char * ) malloc( my_msg_size );
+  ASSERT_NOT_NULL( message );
+  memset( message, 'a', max_msg_size );
+  memcpy( message, "begin", 5 );
+  memcpy( message + max_msg_size, "truncated", 9 );
+  message[my_msg_size-1] = '\0';
+
+  result = stumpless_add_message( target, message );
+  EXPECT_GE( result, 0 );
+  EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
+
+  free( message );
+}

--- a/test/function/target/udp4.cpp
+++ b/test/function/target/udp4.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 #include <gtest/gtest.h>
 #include "test/function/rfc5424.hpp"
 #include "test/helper/assert.hpp"
+#include "test/helper/fixture.hpp"
 #include "test/helper/resolve.hpp"
 
 #ifndef _WIN32
@@ -51,9 +52,6 @@ namespace {
 
     virtual void
     SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
       // setting up to receive the sent messages
       handle = open_udp4_server_socket( "127.0.0.1", port );
       if( handle == BAD_HANDLE ) {
@@ -67,17 +65,7 @@ namespace {
       stumpless_set_target_default_msgid( target, "default-message" );
       stumpless_set_udp_max_message_size( target, 500 );
 
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_INFO,
-                                         "stumpless-unit-test",
-                                         "basic-entry",
-                                         "basic test message" );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
+      basic_entry = create_entry(  );
     }
 
     virtual void
@@ -230,7 +218,7 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
   }
 
-  TEST( NetworkTargetSetDestination, OpenTarget ) {
+  TEST( NetworkTargetSetDestination, OpenUdp4Target ) {
     struct stumpless_target *target;
     struct stumpless_target *target_result;
     struct stumpless_entry *entry;
@@ -250,31 +238,27 @@ namespace {
 
       target = stumpless_open_udp4_target( "target-to-self",
                                            original_destination );
-      ASSERT_TRUE( target != NULL );
+      ASSERT_NOT_NULL( target );
       EXPECT_NO_ERROR;
 
       destination_result = stumpless_get_destination( target );
-      EXPECT_TRUE( destination_result != NULL );
+      EXPECT_NOT_NULL( destination_result );
       EXPECT_STREQ( destination_result, original_destination );
 
       EXPECT_TRUE( stumpless_target_is_open( target ) );
       target_result = stumpless_set_destination( target, new_destination );
-      EXPECT_TRUE( target_result != NULL );
+      EXPECT_NOT_NULL( target_result );
       EXPECT_NO_ERROR;
 
       EXPECT_TRUE( stumpless_target_is_open( target ) );
 
       destination_result = stumpless_get_destination( target );
-      EXPECT_TRUE( destination_result != NULL );
+      EXPECT_NOT_NULL( destination_result );
       EXPECT_STREQ( destination_result, new_destination );
 
       if( handle != BAD_HANDLE ) {
-        entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                     STUMPLESS_SEVERITY_INFO,
-                                     "stumpless-unit-test",
-                                     "basic-entry",
-                                     "basic test message" );
-        EXPECT_TRUE( entry != NULL );
+        entry = create_entry(  );
+        EXPECT_NOT_NULL( entry );
 
         add_result = stumpless_add_entry( target, entry );
         EXPECT_GE( add_result, 0 );
@@ -291,7 +275,7 @@ namespace {
     }
   }
 
-  TEST( NetworkTargetSetDestination, PausedTarget ) {
+  TEST( NetworkTargetSetDestination, PausedUdp4Target ) {
     struct stumpless_target *target;
     struct stumpless_target *target_result;
     struct stumpless_entry *entry;
@@ -304,38 +288,34 @@ namespace {
     handle = open_udp4_server_socket( destination, "514" );
 
     target = stumpless_new_udp4_target( "target-to-self" );
-    ASSERT_TRUE( target != NULL );
+    ASSERT_NOT_NULL( target );
     EXPECT_NO_ERROR;
 
     destination_result = stumpless_get_destination( target );
-    EXPECT_TRUE( destination_result == NULL );
+    EXPECT_NULL( destination_result );
 
     EXPECT_FALSE( stumpless_target_is_open( target ) );
     target_result = stumpless_set_destination( target, destination );
-    EXPECT_TRUE( target_result != NULL );
+    EXPECT_NOT_NULL( target_result );
     EXPECT_NO_ERROR;
 
     EXPECT_FALSE( stumpless_target_is_open( target ) );
 
     destination_result = stumpless_get_destination( target );
-    EXPECT_TRUE( destination_result != NULL );
+    EXPECT_NOT_NULL( destination_result );
     EXPECT_STREQ( destination_result, destination );
     free( ( void * ) destination_result );
 
     target_result = stumpless_open_target( target );
-    ASSERT_TRUE( target_result != NULL );
+    ASSERT_NOT_NULL( target_result );
     EXPECT_TRUE( target_result == target );
     EXPECT_NO_ERROR;
 
     EXPECT_TRUE( stumpless_target_is_open( target ) );
 
     if( handle != BAD_HANDLE ) {
-      entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                   STUMPLESS_SEVERITY_INFO,
-                                   "stumpless-unit-test",
-                                   "basic-entry",
-                                   "basic test message" );
-      EXPECT_TRUE( entry != NULL );
+      entry = create_entry(  );
+      EXPECT_NOT_NULL( entry );
 
       add_result = stumpless_add_entry( target, entry );
       EXPECT_GE( add_result, 0 );
@@ -351,7 +331,7 @@ namespace {
     stumpless_close_network_target( target );
   }
 
-  TEST( NetworkTargetSetTransportPort, OpenTarget ) {
+  TEST( NetworkTargetSetTransportPort, OpenUdp4Target ) {
     struct stumpless_target *target;
     struct stumpless_target *result;
     struct stumpless_entry *entry;
@@ -365,33 +345,29 @@ namespace {
 
     target = stumpless_open_udp4_target( "target-to-self",
                                          "127.0.0.1" );
-    ASSERT_TRUE( target != NULL );
+    ASSERT_NOT_NULL( target );
 
     default_port = stumpless_get_transport_port( target );
-    EXPECT_TRUE( default_port != NULL );
+    EXPECT_NOT_NULL( default_port );
     ASSERT_STRNE( default_port, new_port );
 
     EXPECT_TRUE( stumpless_target_is_open( target ) );
     result = stumpless_set_transport_port( target, new_port );
-    EXPECT_TRUE( result != NULL );
+    EXPECT_NOT_NULL( result );
     EXPECT_NO_ERROR;
 
     EXPECT_TRUE( stumpless_target_is_open( target ) );
 
     current_port = stumpless_get_transport_port( target );
-    EXPECT_TRUE( current_port != NULL );
+    EXPECT_NOT_NULL( current_port );
     EXPECT_TRUE( current_port != new_port );
     EXPECT_STREQ( new_port, current_port );
     EXPECT_NO_ERROR;
 
     if( handle != BAD_HANDLE ) {
-      entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                   STUMPLESS_SEVERITY_INFO,
-                                   "stumpless-unit-test",
-                                   "basic-entry",
-                                   "basic test message" );
+      entry = create_entry(  );
       stumpless_add_entry( target, entry );
-      EXPECT_TRUE( result != NULL );
+      EXPECT_NOT_NULL( result );
 
       recv_from_handle( handle, buffer, 1024 );
       EXPECT_TRUE( buffer[0] != '\0' );
@@ -404,7 +380,7 @@ namespace {
     stumpless_close_network_target( target );
   }
 
-  TEST( NetworkTargetSetTransportPort, PausedTarget ) {
+  TEST( NetworkTargetSetTransportPort, PausedUdp4Target ) {
     struct stumpless_target *target;
     struct stumpless_target *target_result;
     struct stumpless_entry *entry;
@@ -419,42 +395,38 @@ namespace {
     handle = open_udp4_server_socket( destination, new_port );
 
     target = stumpless_new_udp4_target( "target-to-self" );
-    ASSERT_TRUE( target != NULL );
+    ASSERT_NOT_NULL( target );
     EXPECT_NO_ERROR;
 
     default_port = stumpless_get_transport_port( target );
-    EXPECT_TRUE( default_port != NULL );
+    EXPECT_NOT_NULL( default_port );
     ASSERT_STRNE( default_port, new_port );
 
     EXPECT_FALSE( stumpless_target_is_open( target ) );
     target_result = stumpless_set_transport_port( target, new_port );
-    EXPECT_TRUE( target_result != NULL );
+    EXPECT_NOT_NULL( target_result );
     EXPECT_NO_ERROR;
 
     EXPECT_FALSE( stumpless_target_is_open( target ) );
 
     current_port = stumpless_get_transport_port( target );
-    EXPECT_TRUE( current_port != NULL );
+    EXPECT_NOT_NULL( current_port );
     EXPECT_TRUE( current_port != new_port );
     EXPECT_STREQ( new_port, current_port );
     EXPECT_NO_ERROR;
 
     target_result = stumpless_set_destination( target, destination );
-    EXPECT_TRUE( target_result != NULL );
+    EXPECT_NOT_NULL( target_result );
 
     target_result = stumpless_open_target( target );
-    ASSERT_TRUE( target_result != NULL );
+    ASSERT_NOT_NULL( target_result );
     EXPECT_TRUE( target_result == target );
     EXPECT_NO_ERROR;
 
     EXPECT_TRUE( stumpless_target_is_open( target ) );
 
     if( handle != BAD_HANDLE ) {
-      entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                   STUMPLESS_SEVERITY_INFO,
-                                   "stumpless-unit-test",
-                                   "basic-entry",
-                                   "basic test message" );
+      entry = create_entry(  );
       add_result = stumpless_add_entry( target, entry );
       EXPECT_GT( add_result, 0 );
       EXPECT_NO_ERROR;

--- a/test/function/target/udp4.cpp
+++ b/test/function/target/udp4.cpp
@@ -118,7 +118,6 @@ namespace {
 
   TEST_F( Udp4TargetTest, TruncatedMessage ) {
     int result;
-    struct stumpless_entry *long_entry;
     const struct stumpless_error *error;
     char *message;
     size_t max_msg_size;
@@ -128,7 +127,7 @@ namespace {
       SUCCEED(  ) << BINDING_DISABLED_WARNING;
 
     } else {
-      ASSERT_TRUE( target != NULL );
+      ASSERT_NOT_NULL( target );
       ASSERT_TRUE( stumpless_target_is_open( target ) );
 
       max_msg_size = stumpless_get_udp_max_message_size( target );
@@ -136,23 +135,13 @@ namespace {
 
       my_msg_size = max_msg_size + 10;
       message = ( char * ) malloc( my_msg_size );
-      ASSERT_TRUE( message != NULL );
+      ASSERT_NOT_NULL( message );
       memset( message, 'a', max_msg_size );
-      strncpy( message, "present", 7 );
-      message[7] = 'a';
-      strncpy( message + max_msg_size, "truncated", 10 );
+      memcpy( message, "present", 7 );
+      memcpy( message + max_msg_size, "truncated", 9 );
       message[my_msg_size-1] = '\0';
 
-      // due to the message header more than just the word 'truncated' will be
-      // taken from the message - this is just a basic test
-      long_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                        STUMPLESS_SEVERITY_INFO,
-                                        "stumpless-unit-test",
-                                        "basic-entry",
-                                        message );
-      ASSERT_TRUE( long_entry != NULL );
-
-      result = stumpless_add_entry( target, long_entry );
+      result = stumpless_add_message( target, message );
       EXPECT_GE( result, 0 );
       EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
 

--- a/test/function/target/udp4.cpp
+++ b/test/function/target/udp4.cpp
@@ -137,7 +137,7 @@ namespace {
       message = ( char * ) malloc( my_msg_size );
       ASSERT_NOT_NULL( message );
       memset( message, 'a', max_msg_size );
-      memcpy( message, "present", 7 );
+      memcpy( message, "present-in-udp4", 15 );
       memcpy( message + max_msg_size, "truncated", 9 );
       message[my_msg_size-1] = '\0';
 
@@ -148,7 +148,7 @@ namespace {
       GetNextMessage(  );
       TestRFC5424Compliance( buffer );
       EXPECT_THAT( buffer, Not( EndsWith( "truncated" ) ) );
-      EXPECT_THAT( buffer, HasSubstr( "present" ) );
+      EXPECT_THAT( buffer, HasSubstr( "present-in-udp4" ) );
 
       free( message );
     }
@@ -156,7 +156,7 @@ namespace {
 
   /* non-fixture tests */
 
-  TEST( NetworkTargetNewTest, Basic ) {
+  TEST( NetworkTargetNewTest, BasicUdp4 ) {
     struct stumpless_target *target;
 
     target = stumpless_new_udp4_target( "my-udp4-target" );

--- a/test/function/target/udp6.cpp
+++ b/test/function/target/udp6.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2019-2020 Joel E. Anderson
+ * Copyright 2019-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 #include <gtest/gtest.h>
 #include "test/function/rfc5424.hpp"
 #include "test/helper/assert.hpp"
+#include "test/helper/fixture.hpp"
 #include "test/helper/resolve.hpp"
 
 #ifndef _WIN32
@@ -51,9 +52,6 @@ namespace {
 
     virtual void
     SetUp( void ) {
-      struct stumpless_element *element;
-      struct stumpless_param *param;
-
       // setting up to receive the sent messages
       handle = open_udp6_server_socket( "::1", port );
       if( handle == BAD_HANDLE ) {
@@ -67,17 +65,7 @@ namespace {
       stumpless_set_target_default_msgid( target, "default-message" );
       stumpless_set_udp_max_message_size( target, 500 );
 
-      basic_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                         STUMPLESS_SEVERITY_INFO,
-                                         "stumpless-unit-test",
-                                         "basic-entry",
-                                         "basic test message" );
-
-      element = stumpless_new_element( "basic-element" );
-      stumpless_add_element( basic_entry, element );
-
-      param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-      stumpless_add_param( element, param );
+      basic_entry = create_entry(  );
     }
 
     virtual void

--- a/test/function/target/udp6.cpp
+++ b/test/function/target/udp6.cpp
@@ -142,7 +142,7 @@ namespace {
       message = ( char * ) malloc( my_msg_size );
       ASSERT_NOT_NULL( message );
       memset( message, 'a', max_msg_size );
-      memcpy( message, "present", 7 );
+      memcpy( message, "present-in-udp6", 15 );
       memcpy( message + max_msg_size, "truncated", 9 );
       message[my_msg_size-1] = '\0';
 
@@ -153,7 +153,7 @@ namespace {
       GetNextMessage(  );
       TestRFC5424Compliance( buffer );
       EXPECT_THAT( buffer, Not( EndsWith( "truncated" ) ) );
-      EXPECT_THAT( buffer, HasSubstr( "present" ) );
+      EXPECT_THAT( buffer, HasSubstr( "present-in-udp6" ) );
 
       free( message );
     }
@@ -161,7 +161,7 @@ namespace {
 
   /* non-fixture tests */
 
-  TEST( NetworkTargetNewTest, Basic ) {
+  TEST( NetworkTargetNewTest, BasicUdp6 ) {
     struct stumpless_target *target;
 
     target = stumpless_new_udp6_target( "my-udp6-target" );

--- a/test/function/target/udp6.cpp
+++ b/test/function/target/udp6.cpp
@@ -18,14 +18,13 @@
 
 #include "test/helper/server.hpp"
 
-#include <cstdlib>
 #include <stddef.h>
 #include <stdio.h>
-#include <string.h>
 #include <stumpless.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "test/function/rfc5424.hpp"
+#include "test/function/target/udp.hpp"
 #include "test/helper/assert.hpp"
 #include "test/helper/fixture.hpp"
 #include "test/helper/resolve.hpp"
@@ -122,40 +121,15 @@ namespace {
   }
 
   TEST_F( Udp6TargetTest, TruncatedMessage ) {
-    int result;
-    const struct stumpless_error *error;
-    char *message;
-    size_t max_msg_size;
-    size_t my_msg_size;
-
     if( !udp_fixtures_enabled ) {
       SUCCEED(  ) << BINDING_DISABLED_WARNING;
 
     } else {
-      ASSERT_NOT_NULL( target );
-      ASSERT_TRUE( stumpless_target_is_open( target ) );
-
-      max_msg_size = stumpless_get_udp_max_message_size( target );
-      ASSERT_NE( max_msg_size, 0 );
-
-      my_msg_size = max_msg_size + 10;
-      message = ( char * ) malloc( my_msg_size );
-      ASSERT_NOT_NULL( message );
-      memset( message, 'a', max_msg_size );
-      memcpy( message, "present-in-udp6", 15 );
-      memcpy( message + max_msg_size, "truncated", 9 );
-      message[my_msg_size-1] = '\0';
-
-      result = stumpless_add_message( target, message );
-      EXPECT_GE( result, 0 );
-      EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
-
+      TestTruncatedMessage( target );
       GetNextMessage(  );
       TestRFC5424Compliance( buffer );
       EXPECT_THAT( buffer, Not( EndsWith( "truncated" ) ) );
-      EXPECT_THAT( buffer, HasSubstr( "present-in-udp6" ) );
-
-      free( message );
+      EXPECT_THAT( buffer, HasSubstr( "begin" ) );
     }
   }
 

--- a/test/function/target/udp6.cpp
+++ b/test/function/target/udp6.cpp
@@ -123,7 +123,6 @@ namespace {
 
   TEST_F( Udp6TargetTest, TruncatedMessage ) {
     int result;
-    struct stumpless_entry *long_entry;
     const struct stumpless_error *error;
     char *message;
     size_t max_msg_size;
@@ -133,7 +132,7 @@ namespace {
       SUCCEED(  ) << BINDING_DISABLED_WARNING;
 
     } else {
-      ASSERT_TRUE( target != NULL );
+      ASSERT_NOT_NULL( target );
       ASSERT_TRUE( stumpless_target_is_open( target ) );
 
       max_msg_size = stumpless_get_udp_max_message_size( target );
@@ -141,30 +140,15 @@ namespace {
 
       my_msg_size = max_msg_size + 10;
       message = ( char * ) malloc( my_msg_size );
-      ASSERT_TRUE( message != NULL );
+      ASSERT_NOT_NULL( message );
       memset( message, 'a', max_msg_size );
-      strncpy( message, "present", 7 );
-      message[7] = 'a';
-      strncpy( message + max_msg_size, "truncated", 10 );
+      memcpy( message, "present", 7 );
+      memcpy( message + max_msg_size, "truncated", 9 );
       message[my_msg_size-1] = '\0';
 
-      // due to the message header more than just the word 'truncated' will be
-      // taken from the message - this is just a basic test
-      long_entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                        STUMPLESS_SEVERITY_INFO,
-                                        "stumpless-unit-test",
-                                        "basic-entry",
-                                        message );
-      ASSERT_TRUE( long_entry != NULL );
-
-      result = stumpless_add_entry( target, long_entry );
+      result = stumpless_add_message( target, message );
       EXPECT_GE( result, 0 );
-
-      error = stumpless_get_error( );
-      EXPECT_TRUE( error != NULL );
-      if( error ) {
-        EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
-      }
+      EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
 
       GetNextMessage(  );
       TestRFC5424Compliance( buffer );

--- a/test/helper/fixture.cpp
+++ b/test/helper/fixture.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,15 +21,11 @@
 
 struct stumpless_entry *
 create_empty_entry( void ) {
-  struct stumpless_entry *entry;
-
-  entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                               STUMPLESS_SEVERITY_INFO,
-                               "fixture-app-name",
-                               "fixture-msgid",
-                               "fixture message" );
-
-  return entry;
+  return stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                              STUMPLESS_SEVERITY_INFO,
+                              "fixture-app-name",
+                              "fixture-msgid",
+                              "fixture message" );
 }
 
 struct stumpless_entry *

--- a/tools/check_headers/standard_library.yml
+++ b/tools/check_headers/standard_library.yml
@@ -91,8 +91,12 @@
 "malloc":
   - "cstdlib"
   - "stdlib.h"
-"memcpy": "string.h"
-"memset": "string.h"
+"memcpy":
+  - "cstring"
+  - "string.h"
+"memset":
+  - "cstring"
+  - "string.h"
 "mkstemp": "stdlib.h"
 "NULL":
   - "cstddef"

--- a/tools/check_headers/stumpless_private.yml
+++ b/tools/check_headers/stumpless_private.yml
@@ -55,6 +55,7 @@
 "target_free_global": "private/target.h"
 "target_free_thread": "private/target.h"
 "TARGET_MUTEX": "private/target.h"
+"TestTruncatedMessage": "test/function/target/udp.hpp"
 "unlock_element": "private/element.h"
 "unlock_entry": "private/entry.h"
 "unlock_network_target": "private/target/network.h"

--- a/tools/check_headers/stumpless_private.yml
+++ b/tools/check_headers/stumpless_private.yml
@@ -1,5 +1,6 @@
 "add_messages": "test/helper/usage.hpp"
 "BINDING_DISABLED_WARNING": "test/helper/server.hpp"
+"BUFFER_TARGET_FIXTURE_CLASS": "test/helper/fixture.hpp"
 "config_atomic_ptr_t": "private/config/wrapper/thread_safety.h"
 "config_compare_exchange_ptr": "private/config/wrapper/thread_safety.h"
 "config_destroy_mutex": "private/config/wrapper/thread_safety.h"

--- a/tools/cmake/test.cmake
+++ b/tools/cmake/test.cmake
@@ -181,6 +181,8 @@ set_target_properties(test_function_target_udp
   COMPILE_FLAGS "${function_test_compile_flags}"
 )
 
+add_dependencies(test_function_target_udp libgtest)
+
 target_include_directories(test_function_target_udp
     PRIVATE
     ${PROJECT_SOURCE_DIR}/include
@@ -196,6 +198,8 @@ set_target_properties(test_helper_fixture
   PROPERTIES
   COMPILE_FLAGS "${function_test_compile_flags}"
 )
+
+add_dependencies(test_helper_fixture libgtest)
 
 target_include_directories(test_helper_fixture
     PRIVATE

--- a/tools/cmake/test.cmake
+++ b/tools/cmake/test.cmake
@@ -171,6 +171,22 @@ target_include_directories(rfc5424_checker
 )
 
 # helper libraries
+add_library(test_function_target_udp
+  EXCLUDE_FROM_ALL
+  OBJECT ${PROJECT_SOURCE_DIR}/test/function/target/udp.cpp
+)
+
+set_target_properties(test_function_target_udp
+  PROPERTIES
+  COMPILE_FLAGS "${function_test_compile_flags}"
+)
+
+target_include_directories(test_function_target_udp
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${CMAKE_BINARY_DIR}/include
+)
+
 add_library(test_helper_fixture
   EXCLUDE_FROM_ALL
   OBJECT ${PROJECT_SOURCE_DIR}/test/helper/fixture.cpp
@@ -186,6 +202,7 @@ target_include_directories(test_helper_fixture
     ${PROJECT_SOURCE_DIR}/include
     ${CMAKE_BINARY_DIR}/include
 )
+
 add_library(test_helper_resolve
   EXCLUDE_FROM_ALL
   OBJECT ${PROJECT_SOURCE_DIR}/test/helper/resolve.cpp


### PR DESCRIPTION
Upon adding code review of all test suite code several violations were noted, which are addressed here.

Some issues with function targets are also addressed, including updated documentation and missing functionality in the `stumpless_close_target` function.