### PR TITLE
Implement stumpless_element_to_string function

### DIFF
--- a/include/stumpless/element.h
+++ b/include/stumpless/element.h
@@ -762,6 +762,35 @@ stumpless_set_param_value_by_name( struct stumpless_element *element,
                                    const char *name,
                                    const char *value );
 
+/**
+ * Returns name and params from element as a formatted string.
+ * The character buffer should be freed when no longer is needed by the caller.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe. A mutex is used to coordinate the read of the
+ * element with other accesses and modifications.
+ *
+ * **Async Signal Safety: AS-Unsafe lock heap**
+ * This function is not safe to call from signal handlers due to the use of a
+ * non-reentrant lock to coordinate access and the use of memory management
+ * functions to create the result.
+ *
+ * **Async Cancel Safety: AC-Unsafe lock heap**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, due to the use of a lock that could be left locked as well as
+ * memory management functions.
+ *
+ * @since release v2.1.0
+ *
+ * @param element The element to get the name and params from.  
+ *
+ * @return The formatted string of <name> or <name>:[param1,...] if no error is encountered.
+ * If an error is  encountered, then NULL is returned and an error code is set appropriately.
+ */
+const char *
+stumpless_element_to_string( const struct stumpless_element *element );
+
+
 #  ifdef __cplusplus
 }                               /* extern "C" */
 #  endif

--- a/src/element.c
+++ b/src/element.c
@@ -522,7 +522,7 @@ stumpless_element_to_string( const struct stumpless_element *element ) {
     // acc total format size
     format_len = name_len;
 
-    const char *params_format[param_count];
+    const char **params_format = alloc_mem(sizeof(char*) * param_count);
     for( size_t i = 0; i < param_count; i++ ) {
       params_format[i] = stumpless_param_to_string(params[i]);
       // does not count '\0' on purpose
@@ -555,6 +555,7 @@ stumpless_element_to_string( const struct stumpless_element *element ) {
       }
       free_mem(params_format[i]);
     }
+    free_mem(params_format);
 
     unlock_element( element );
 
@@ -576,7 +577,6 @@ stumpless_element_to_string( const struct stumpless_element *element ) {
 
     clear_error( );
     return format;
-
 fail:
     unlock_element( element );
     return NULL;

--- a/src/element.c
+++ b/src/element.c
@@ -553,6 +553,7 @@ stumpless_element_to_string( const struct stumpless_element *element ) {
       if( i < param_count - 1 ) {
         format[pos_offset++] = ',';
       }
+      free_mem(params_format[i]);
     }
 
     unlock_element( element );

--- a/src/element.c
+++ b/src/element.c
@@ -501,6 +501,86 @@ stumpless_set_param_value_by_name( struct stumpless_element *element,
   return element;
 }
 
+const char *
+stumpless_element_to_string( const struct stumpless_element *element ) {
+    char *format;
+    const char *name;
+    size_t name_len;
+    size_t format_len;
+    size_t param_count;
+    struct stumpless_param **params;
+
+    VALIDATE_ARG_NOT_NULL( element );
+
+    lock_element( element );
+
+    name = element->name;
+    name_len = element->name_length;
+    params = element->params; 
+    param_count = element->param_count;
+
+    // acc total format size
+    format_len = name_len;
+
+    const char *params_format[param_count];
+    for( size_t i = 0; i < param_count; i++ ) {
+      params_format[i] = stumpless_param_to_string(params[i]);
+      // does not count '\0' on purpose
+      format_len += strlen(params_format[i]);
+    }
+
+    if( param_count != 0 ) {
+      // extra param list chars and commas
+      format_len += 6 + param_count - 1;
+    } else {
+      // no params, just name
+      format_len += 3;
+    }
+
+    format = alloc_mem( format_len );
+    if( !format ) {
+      goto fail;
+    }
+
+    memcpy( format + 1, name, name_len );
+
+    // build params list "param_1_to_string,param_2_to_string, ..."
+    size_t pos_offset = name_len + 4;
+    for( size_t i = 0; i < param_count; i++) {
+      // replace '\0' with ',' at the end of each string
+      memcpy( format + pos_offset, params_format[i], strlen(params_format[i]));
+      pos_offset += strlen(params_format[i]);
+      if( i < param_count - 1 ) {
+        format[pos_offset++] = ',';
+      }
+    }
+
+    unlock_element( element );
+
+    format[0] = '<';
+    format[name_len + 1] = '>';
+
+    if (param_count != 0 ) {
+      // <name>:[param_1_to_string,param_2_to_string,etc.] (with params)
+      format[name_len + 2] = ':';
+      format[name_len + 3] = '[';
+      format[pos_offset] = ']';
+    } else {
+      // <name> (no params)
+      // pos_offset is name_len + 4 here 
+      pos_offset -= 3;
+    }
+
+    format[pos_offset + 1] = '\0';
+
+    clear_error( );
+    return format;
+
+fail:
+    unlock_element( element );
+    return NULL;
+}
+
 /* private functions */
 
 void

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -157,3 +157,5 @@ EXPORTS
 ; added in v2.1.0
   stumpless_close_function_target               @143
   stumpless_open_function_target                @144
+  stumpless_element_to_string                   @145
+

--- a/test/function/element.cpp
+++ b/test/function/element.cpp
@@ -709,13 +709,23 @@ namespace {
     EXPECT_NULL( result );
   }
 
-  TEST_F( ElementTest, GetElementToString) {
+  TEST_F( ElementTest, GetElementToStringWithParams) {
     const char *format;
 
     format = stumpless_element_to_string( element_with_params );
     ASSERT_NOT_NULL( format );
 
     EXPECT_STREQ( format, "<element-with-params>:[<param-1>:<value-1>,<param-2>:<value-2>]" );
+    EXPECT_NO_ERROR;
+  }
+
+  TEST_F( ElementTest, GetElementToStringWithoutParams) {
+    const char *format;
+
+    format = stumpless_element_to_string( basic_element );
+    ASSERT_NOT_NULL( format );
+
+    EXPECT_STREQ( format, "<basic-element>" );
     EXPECT_NO_ERROR;
   }
 

--- a/test/function/element.cpp
+++ b/test/function/element.cpp
@@ -719,6 +719,25 @@ namespace {
     EXPECT_NO_ERROR;
   }
 
+  TEST_F( ElementTest, ElementToStringMemoryFailure ) {
+    void * (*set_malloc_result)(size_t);
+    const struct stumpless_error *error;
+    const char *result;
+
+    // create the internal error struct
+    stumpless_get_element_name( NULL );
+
+    set_malloc_result = stumpless_set_malloc( [](size_t size)->void *{ return NULL; } );
+    ASSERT_NOT_NULL( set_malloc_result );
+
+    result = stumpless_element_to_string( basic_element);
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
+
+    set_malloc_result = stumpless_set_malloc( malloc );
+    EXPECT_TRUE( set_malloc_result == malloc );
+  }
+
   /* non-fixture tests */
 
   TEST( AddParamTest, NullElement ) {
@@ -893,4 +912,12 @@ namespace {
     stumpless_free_all(  );
   }
 
+  TEST( ElemenToStringTest, NullElement ) {
+    const char *result;
+    const struct stumpless_error *error;
+
+    result = stumpless_element_to_string( NULL );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+  }
 }

--- a/test/function/element.cpp
+++ b/test/function/element.cpp
@@ -709,6 +709,16 @@ namespace {
     EXPECT_NULL( result );
   }
 
+  TEST_F( ElementTest, GetElementToString) {
+    const char *format;
+
+    format = stumpless_element_to_string( element_with_params );
+    ASSERT_NOT_NULL( format );
+
+    EXPECT_STREQ( format, "<element-with-params>:[<param-1>:<value-1>,<param-2>:<value-2>]" );
+    EXPECT_NO_ERROR;
+  }
+
   /* non-fixture tests */
 
   TEST( AddParamTest, NullElement ) {


### PR DESCRIPTION
This addresses #146 

- [x] add declaration to `element.h`
- [x] implement `stumpless_element_to_string` in element.c
- [x] add tests