### PR TITLE
optimize strbuilder int hander

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1040,6 +1040,10 @@ add_performance_test(target
   SOURCES test/performance/target.cpp
 )
 
+add_performance_test(version
+  SOURCES test/performance/version.cpp
+)
+
 add_custom_target(bench
   DEPENDS ${STUMPLESS_PERFORMANCE_TEST_RUNNERS}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1027,7 +1027,9 @@ add_performance_test(element
 )
 
 add_performance_test(entry
-  SOURCES test/performance/entry.cpp
+  SOURCES
+    ${PROJECT_SOURCE_DIR}/test/performance/entry.cpp
+    $<TARGET_OBJECTS:test_helper_fixture>
 )
 
 add_performance_test(function
@@ -1041,7 +1043,7 @@ add_performance_test(target
 )
 
 add_performance_test(version
-  SOURCES test/performance/version.cpp
+  SOURCES ${PROJECT_SOURCE_DIR}/test/performance/version.cpp
 )
 
 add_custom_target(bench

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -7,8 +7,14 @@ measure execution time and other efficiency characteristics.
 
 Performance tests are named `performance-test-<item>` for various pieces of the
 library. You can use the `bench` target to build and execute all performance
-tests at once, or just the name of the executable if you only want to measure
-a single module.
+tests at once, or the name of the executable prefixed with `run-` if you only
+want to run a single module. These targets write their results to both the
+standard output as well as a json file in the `performance-output` directory of
+the build location, which you can use with the `compare.py` tool from the
+benchmark library. There is an example of using this tool in the walkthrough
+below. Of course, you can also directly execute the test executable itself if
+you want to set the parameters yourself. This is also demonstrated in the
+walkthrough.
 
 Performance tests are NOT intended to be an absolute measurement of the
 performance of a function or the library as a whole. They are only useful for
@@ -17,9 +23,9 @@ machine in the same environment. This is why you will not see performance
 test results posted in any documentation. The results are only useful when
 compared to one another, typically during development of some change.
 
-Benchmarks are run for Release CI builds, but should not be used as indicators
-of performance for this exact reason. They are only included in the CI process
-to make sure that they are not broken.
+Benchmarks are run during Release CI builds, but should not be used as
+indicators of performance for this exact reason. They are only included in the
+CI process to make sure that they are not broken.
 
 ## Walkthrough: Improving `stumpless_copy_element`
 

--- a/include/private/strbuilder.h
+++ b/include/private/strbuilder.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2020 Joel E. Anderson
+ * Copyright 2018-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,31 @@ strbuilder_append_buffer( struct strbuilder *builder,
 struct strbuilder *
 strbuilder_append_char( struct strbuilder *builder, char c );
 
+/**
+ * Appends an int value. The value is assumed to be greater than or equal to
+ * zero. If it is negative, a negative sign is NOT included in the sequence of
+ * appended characters.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is not thread safe.
+ *
+ * **Async Signal Safety: AS-Unsafe heap**
+ * This function is not safe to call from signal handlers due to the potential
+ * use of memory management functions.
+ *
+ * **Async Cancel Safety: AC-Unsafe heap**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, due to the potential use of memory management functions.
+ *
+ * @param builder The strbuilder to append the characters to.
+ *
+ * @param i The zero or positive value to append.
+ *
+ * @return The modified builder if no error is encountered. If an error is
+ * encountered, then NULL is returned and an error code is set appropriately.
+ */
 struct strbuilder *
-strbuilder_append_int( struct strbuilder *builder, int i );
+strbuilder_append_positive_int( struct strbuilder *builder, int i );
 
 struct strbuilder *
 strbuilder_append_string( struct strbuilder *builder,

--- a/src/entry.c
+++ b/src/entry.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2020 Joel E. Anderson
+ * Copyright 2018-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/entry.c
+++ b/src/entry.c
@@ -1076,7 +1076,7 @@ strbuilder_append_message( struct strbuilder *builder,
 
 struct strbuilder *
 strbuilder_append_procid( struct strbuilder *builder ) {
-  return strbuilder_append_int( builder, config_getpid(  ) );
+  return strbuilder_append_positive_int( builder, config_getpid(  ) );
 }
 
 struct strbuilder *

--- a/src/formatter.c
+++ b/src/formatter.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2020 Joel E. Anderson
+ * Copyright 2018-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,6 @@ format_entry( const struct stumpless_entry *entry,
   builder = strbuilder_new(  );
   builder = strbuilder_append_char( builder, '<' );
 
-  //builder = strbuilder_append_int( builder, entry->prival );
   if( entry->prival >= 100 ) {
     builder = strbuilder_append_char( builder, ( entry->prival / 100 ) + 48 );
   }

--- a/src/formatter.c
+++ b/src/formatter.c
@@ -39,15 +39,7 @@ format_entry( const struct stumpless_entry *entry,
 
   builder = strbuilder_new(  );
   builder = strbuilder_append_char( builder, '<' );
-
-  if( entry->prival >= 100 ) {
-    builder = strbuilder_append_char( builder, ( entry->prival / 100 ) + 48 );
-  }
-  if( entry->prival >= 10 ) {
-    builder = strbuilder_append_char( builder, ( entry->prival / 10 ) + 48 );
-  }
-  builder = strbuilder_append_char( builder, ( entry->prival % 10 ) + 48 );
-
+  builder = strbuilder_append_positive_int( builder, entry->prival );
   builder = strbuilder_append_string( builder, ">1 " );
   builder = strbuilder_append_buffer( builder, timestamp, timestamp_size );
   builder = strbuilder_append_char( builder, ' ' );

--- a/src/formatter.c
+++ b/src/formatter.c
@@ -39,7 +39,16 @@ format_entry( const struct stumpless_entry *entry,
 
   builder = strbuilder_new(  );
   builder = strbuilder_append_char( builder, '<' );
-  builder = strbuilder_append_int( builder, entry->prival );
+
+  //builder = strbuilder_append_int( builder, entry->prival );
+  if( entry->prival >= 100 ) {
+    builder = strbuilder_append_char( builder, ( entry->prival / 100 ) + 48 );
+  }
+  if( entry->prival >= 10 ) {
+    builder = strbuilder_append_char( builder, ( entry->prival / 10 ) + 48 );
+  }
+  builder = strbuilder_append_char( builder, ( entry->prival % 10 ) + 48 );
+
   builder = strbuilder_append_string( builder, ">1 " );
   builder = strbuilder_append_buffer( builder, timestamp, timestamp_size );
   builder = strbuilder_append_char( builder, ' ' );

--- a/src/strbuilder.c
+++ b/src/strbuilder.c
@@ -110,24 +110,19 @@ strbuilder_append_char( struct strbuilder *builder, char c ) {
 }
 
 struct strbuilder *
-strbuilder_append_int( struct strbuilder *builder, int i ) {
+strbuilder_append_positive_int( struct strbuilder *builder, int i ) {
   struct strbuilder *result = builder;
-  int running_val = i;
   char buffer[MAX_INT_SIZE];
   size_t digit_count = 0;
 
   if( i == 0 ) {
-    return strbuilder_append_char( result, '0' );
+    return strbuilder_append_char( builder, '0' );
   }
 
-  if( i < 0 ) {
-    result = strbuilder_append_char( result, '-' );
-  }
-
-  while( running_val != 0 ) {
-    buffer[digit_count] = ( running_val % 10 ) + 48;
+  while( i != 0 ) {
+    buffer[digit_count] = ( i % 10 ) + 48;
+    i /= 10;
     digit_count++;
-    running_val /= 10;
   }
 
   while( digit_count > 0 ) {

--- a/src/strbuilder.c
+++ b/src/strbuilder.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2020 Joel E. Anderson
+ * Copyright 2018-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
  */
 
 #include <stddef.h>
-#include <stdio.h>
 #include <string.h>
 #include "private/cache.h"
 #include "private/config/wrapper.h"
@@ -112,14 +111,31 @@ strbuilder_append_char( struct strbuilder *builder, char c ) {
 
 struct strbuilder *
 strbuilder_append_int( struct strbuilder *builder, int i ) {
+  struct strbuilder *result = builder;
+  int running_val = i;
   char buffer[MAX_INT_SIZE];
+  size_t digit_count = 0;
 
-  if( !builder ) {
-    return NULL;
+  if( i == 0 ) {
+    return strbuilder_append_char( result, '0' );
   }
 
-  snprintf( buffer, MAX_INT_SIZE, "%d", i );
-  return strbuilder_append_string( builder, buffer );
+  if( i < 0 ) {
+    result = strbuilder_append_char( result, '-' );
+  }
+
+  while( running_val != 0 ) {
+    buffer[digit_count] = ( running_val % 10 ) + 48;
+    digit_count++;
+    running_val /= 10;
+  }
+
+  while( digit_count > 0 ) {
+    digit_count--;
+    result = strbuilder_append_char( result, buffer[digit_count] );
+  }
+
+  return result;
 }
 
 struct strbuilder *

--- a/src/version.c
+++ b/src/version.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
+ * Copyright 2018-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,11 +88,11 @@ stumpless_version_to_string( const struct stumpless_version *version ) {
 
   builder = strbuilder_new(  );
 
-  aggregate = strbuilder_append_int( builder, version->major );
+  aggregate = strbuilder_append_positive_int( builder, version->major );
   aggregate = strbuilder_append_char( aggregate, '.' );
-  aggregate = strbuilder_append_int( aggregate, version->minor );
+  aggregate = strbuilder_append_positive_int( aggregate, version->minor );
   aggregate = strbuilder_append_char( aggregate, '.' );
-  aggregate = strbuilder_append_int( aggregate, version->patch );
+  aggregate = strbuilder_append_positive_int( aggregate, version->patch );
 
   version_string = strbuilder_to_string( aggregate );
 

--- a/test/performance/version.cpp
+++ b/test/performance/version.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2021 Joel E. Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <benchmark/benchmark.h>
+#include <stumpless.h>
+#include "test/helper/memory_counter.hpp"
+
+NEW_MEMORY_COUNTER( version_to_string )
+
+static void VersionToString(benchmark::State& state){
+  const struct stumpless_version *current_version;
+  char *result;
+
+  INIT_MEMORY_COUNTER( version_to_string );
+  current_version = stumpless_get_version(  );
+
+  for(auto _ : state){
+    result = stumpless_version_to_string( current_version );
+    if( !result ) {
+      state.SkipWithError( "could not get the version as a string" );
+    } else {
+      version_to_string_memory_counter_free( ( void * ) result );
+    }
+  }
+
+  version_to_string_memory_counter_free( ( void * ) current_version );
+  SET_STATE_COUNTERS( state, version_to_string );
+}
+
+BENCHMARK( VersionToString );

--- a/tools/check_headers/stumpless_private.yml
+++ b/tools/check_headers/stumpless_private.yml
@@ -52,6 +52,7 @@
 "stdatomic_read_ptr": "private/config/have_stdatomic.h"
 "stdatomic_write_flag": "private/config/have_stdatomic.h"
 "stdatomic_write_ptr": "private/config/have_stdatomic.h"
+"strbuilder_append_positive_int": "private/strbuilder.h"
 "target_free_global": "private/target.h"
 "target_free_thread": "private/target.h"
 "TARGET_MUTEX": "private/target.h"

--- a/tools/cmake/test.cmake
+++ b/tools/cmake/test.cmake
@@ -98,6 +98,9 @@ macro(add_thread_safety_test name)
   private_add_thread_safety_test(NAME ${name} ${ARGN})
 endmacro(add_thread_safety_test name)
 
+set(PERFORMANCE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/performance-output")
+file(MAKE_DIRECTORY ${PERFORMANCE_OUTPUT_DIR})
+
 function(private_add_performance_test)
   set(single_val_args NAME)
   set(multi_val_args SOURCES LIBRARIES)
@@ -139,7 +142,7 @@ function(private_add_performance_test)
   )
 
   add_custom_target(run-performance-test-${FUNCTION_PERF_ARG_NAME}
-    COMMAND "performance-test-${FUNCTION_PERF_ARG_NAME}"
+    COMMAND ${CMAKE_BINARY_DIR}/performance-test-${FUNCTION_PERF_ARG_NAME} --benchmark_out=${PERFORMANCE_OUTPUT_DIR}/${FUNCTION_PERF_ARG_NAME}.json --benchmark_out_format=json
     DEPENDS performance-test-${FUNCTION_PERF_ARG_NAME}
   )
 


### PR DESCRIPTION
Use custom code instead of `snprintf` to append positive values to strbuilders. This improves performance for code paths using this feature, including all logging functions.