### PR TITLE
make msgids and app names fixed buffers

### DIFF
--- a/include/stumpless/entry.h
+++ b/include/stumpless/entry.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2020 Joel E. Anderson
+ * Copyright 2018-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,12 @@
 #  include <stumpless/param.h>
 #  include <stumpless/severity.h>
 
+/** The maximum length of an app name, as specified by RFC 5424. */
+#  define STUMPLESS_MAX_APP_NAME_LENGTH 48
+
+/** The maximum length of a msgid, as specified by RFC 5424. */
+#  define STUMPLESS_MAX_MSGID_LENGTH 32
+
 #  ifdef __cplusplus
 extern "C" {
 #  endif
@@ -53,7 +59,7 @@ struct stumpless_entry {
  */
   int prival;
 /** The app name of this entry, as a NULL-terminated string. */
-  char *app_name;
+  char app_name[STUMPLESS_MAX_APP_NAME_LENGTH + 1];
 /** The length of the app name, without the NULL terminator. */
   size_t app_name_length;
 /** The message of this entry, as a NULL-terminated string. */
@@ -61,7 +67,7 @@ struct stumpless_entry {
 /** The length of the message, without the NULL terminator. */
   size_t message_length;
 /** The message id of this entry, as a NULL-terminated string. */
-  char *msgid;
+  char msgid[STUMPLESS_MAX_MSGID_LENGTH + 1];
 /** The length of the message id, without the NULL terminator. */
   size_t msgid_length;
 /** An array holding the elements of this entry. */

--- a/src/validate.c
+++ b/src/validate.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2020 Joel E. Anderson
+ * Copyright 2018-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,15 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <string.h>
+#include <stumpless/entry.h>
 #include "private/error.h"
 #include "private/config/locale/wrapper.h"
 
 bool validate_msgid_length(const char* msgid ) {
-  size_t max_msgid_length = 32;
   size_t msgid_char_length = strlen( msgid );
   bool validation_status = true;
 
-  if( msgid_char_length > max_msgid_length ) {
+  if( msgid_char_length > STUMPLESS_MAX_MSGID_LENGTH ) {
     raise_argument_too_big( L10N_STRING_TOO_LONG_ERROR_MESSAGE,
                             msgid_char_length,
                             L10N_STRING_LENGTH_ERROR_CODE_TYPE );
@@ -53,16 +53,15 @@ bool validate_printable_ascii( const char* str ) {
 
 
 bool validate_app_name_length( const char* app_name ) {
-    size_t max_app_name_length = 48;
     size_t app_name_char_length = strlen( app_name );
     bool validation_status = true;
 
-    if ( app_name_char_length > max_app_name_length ) {
-        raise_argument_too_big( L10N_STRING_TOO_LONG_ERROR_MESSAGE,
-                app_name_char_length,
-                L10N_STRING_LENGTH_ERROR_CODE_TYPE );
+    if ( app_name_char_length > STUMPLESS_MAX_APP_NAME_LENGTH ) {
+      raise_argument_too_big( L10N_STRING_TOO_LONG_ERROR_MESSAGE,
+                              app_name_char_length,
+                              L10N_STRING_LENGTH_ERROR_CODE_TYPE );
 
-        validation_status = false;
+      validation_status = false;
     }
 
     return validation_status;

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2020 Joel E. Anderson
+ * Copyright 2018-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -659,14 +659,13 @@ namespace {
   TEST_F( EntryTest, SetAppNameMemoryFailure ) {
     void *(*set_malloc_result)(size_t);
     const struct stumpless_entry *result;
-    const struct stumpless_error *error;
 
     set_malloc_result = stumpless_set_malloc( MALLOC_FAIL );
     ASSERT_NOT_NULL( set_malloc_result );
 
-    result = stumpless_set_entry_app_name( basic_entry, "gonna-fail" );
-    EXPECT_ERROR_ID_EQ( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
-    EXPECT_NULL( result );
+    result = stumpless_set_entry_app_name( basic_entry, "no-memory-required" );
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( result );
 
     set_malloc_result = stumpless_set_malloc( malloc );
     ASSERT_TRUE( set_malloc_result == malloc );
@@ -681,7 +680,6 @@ namespace {
     entry = stumpless_set_entry_app_name( basic_entry, NULL );
     EXPECT_NO_ERROR;
     EXPECT_EQ( entry, basic_entry );
-    EXPECT_NE( basic_entry->app_name, previous_app_name );
 
     EXPECT_EQ( basic_entry->app_name_length, 1 );
     EXPECT_EQ( 0, strcmp( basic_entry->app_name, "-" ) );
@@ -803,14 +801,13 @@ namespace {
   TEST_F( EntryTest, SetMsgidMemoryFailure ) {
     void *(*set_malloc_result)(size_t);
     const struct stumpless_entry *result;
-    const struct stumpless_error *error;
 
     set_malloc_result = stumpless_set_malloc( MALLOC_FAIL );
     ASSERT_NOT_NULL( set_malloc_result );
 
-    result = stumpless_set_entry_msgid( basic_entry, "gonna-fail" );
-    EXPECT_ERROR_ID_EQ( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
-    EXPECT_NULL( result );
+    result = stumpless_set_entry_msgid( basic_entry, "no-memory-required" );
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( result );
 
     set_malloc_result = stumpless_set_malloc( malloc );
     ASSERT_TRUE( set_malloc_result == malloc );
@@ -825,7 +822,6 @@ namespace {
     entry = stumpless_set_entry_msgid( basic_entry, NULL );
     EXPECT_NO_ERROR;
     EXPECT_EQ( entry, basic_entry );
-    EXPECT_NE( basic_entry->msgid, previous_msgid );
 
     EXPECT_EQ( basic_entry->msgid_length, 1 );
     EXPECT_EQ( 0, strcmp( basic_entry->msgid, "-" ) );
@@ -1497,7 +1493,6 @@ namespace {
     const char *msgid = "test-msgid-of-unique-length";
     const char *message = "test-message";
     struct stumpless_entry *result;
-    const struct stumpless_error *error;
 
     set_malloc_result = stumpless_set_malloc( MALLOC_FAIL_ON_SIZE( 28 ) );
     ASSERT_NOT_NULL( set_malloc_result );
@@ -1507,38 +1502,39 @@ namespace {
                                   app_name,
                                   msgid,
                                   message );
-
-    EXPECT_ERROR_ID_EQ( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
-    EXPECT_NULL( result );
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( result );
 
     set_malloc_result = stumpless_set_malloc( malloc );
     EXPECT_TRUE( set_malloc_result == malloc );
 
+    stumpless_destroy_entry_and_contents( result );
     stumpless_free_all(  );
   }
 
   TEST( NewEntryTest, MallocFailureOnAppName ) {
-      void *(*set_malloc_result)(size_t);
-      const char *app_name = "test-app-name-of-unique-length";
-      const char *msgid = "test-msgid";
-      const char *message = "test-message";
-      struct stumpless_entry *result;
-      const struct stumpless_error *error;
+    void *(*set_malloc_result)(size_t);
+    const char *app_name = "test-app-name-of-unique-length";
+    const char *msgid = "test-msgid";
+    const char *message = "test-message";
+    struct stumpless_entry *result;
 
-      set_malloc_result = stumpless_set_malloc( MALLOC_FAIL_ON_SIZE( 31 ) );
-      ASSERT_NOT_NULL( set_malloc_result );
+    set_malloc_result = stumpless_set_malloc( MALLOC_FAIL_ON_SIZE( 31 ) );
+    ASSERT_NOT_NULL( set_malloc_result );
 
-      result = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-              STUMPLESS_SEVERITY_INFO,
-              app_name,
-              msgid,
-              message );
+    result = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+            STUMPLESS_SEVERITY_INFO,
+            app_name,
+            msgid,
+            message );
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( result );
 
-      EXPECT_ERROR_ID_EQ( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
-      EXPECT_NULL( result );
+    set_malloc_result = stumpless_set_malloc( malloc );
+    EXPECT_TRUE( set_malloc_result == malloc );
 
-      set_malloc_result = stumpless_set_malloc( malloc );
-      EXPECT_TRUE( set_malloc_result == malloc );
+    stumpless_destroy_entry_and_contents( result );
+    stumpless_free_all(  );
   }
 
   TEST( NewEntryTest, MallocFailureOnSecond ) {

--- a/tools/check_headers/stumpless.yml
+++ b/tools/check_headers/stumpless.yml
@@ -281,6 +281,8 @@
 "STUMPLESS_LANGUAGE": "stumpless/config.h"
 "stumpless_log_func_t": "stumpless/target/function.h"
 "STUMPLESS_MAJOR_VERSION": "stumpless/config.h"
+"STUMPLESS_MAX_APP_NAME_LENGTH": "stumpless/entry.h"
+"STUMPLESS_MAX_MSGID_LENGTH": "stumpless/entry.h"
 "STUMPLESS_MINOR_VERSION": "stumpless/config.h"
 "stumpless_network_protocol": "stumpless/target/network.h"
 "STUMPLESS_NETWORK_PROTOCOL_UNSUPPORTED": "stumpless/error.h"


### PR DESCRIPTION
Since msgid and app name lengths are enforced to not go past the RFC 5424 limits, they have been converted to use fixed length buffers in the entry struct instead of memory allocated from the heap. This improves performance in logging functions that modify an underlying entry each time, such as `stumpless_add_message`.