### PR TITLE
Implement format checking of param names

### DIFF
--- a/include/private/validate.h
+++ b/include/private/validate.h
@@ -61,4 +61,15 @@ bool validate_printable_ascii( const char* str );
  */
 bool validate_app_name_length( const char* app_name);
 
+/**
+ * Checks that the passed in param name contains only ASCII characters and
+ * also does not contain any of the following characters: '=',']','"'.
+ *
+ * @param the param name.
+ *
+ * @return True if the param name has the correct format, otherwise
+ * it will return false and raise STUMPLESS_INVALID_ENCODING error.
+ */
+bool validate_param_name( const char* str);
+
 #endif /* __STUMPLESS_PRIVATE_VALIDATE_H */

--- a/include/stumpless/param.h
+++ b/include/stumpless/param.h
@@ -207,7 +207,7 @@ stumpless_get_param_value( const struct stumpless_param *param );
  * This function is not safe to call from threads that may be asynchronously
  * cancelled, due to the use of memory management functions.
  *
- * @param name The name of the new param.
+ * @param name The name of the new param. Restricted to printable ASCII characters different from '=', ']' and '"'.
  *
  * @param value The value of the new param.
  *
@@ -238,7 +238,7 @@ stumpless_new_param( const char *name, const char *value );
  *
  * @param param The param to set the name of.
  *
- * @param name The new name of param.
+ * @param name The new name of param. Restricted to printable ASCII characters different from '=', ']' and '"'. 
  *
  * @return The modified param, if no error is encountered. If an error is
  * encountered, then NULL is returned and an error code is set appropriately.

--- a/src/element.c
+++ b/src/element.c
@@ -370,6 +370,10 @@ stumpless_get_param_value_by_name( const struct stumpless_element *element,
                                    const char *name ) {
   const struct stumpless_param *param;
 
+  if (name && !validate_param_name(name)) {
+    return NULL;
+  }
+
   param = stumpless_get_param_by_name( element, name );
   if( !param ) {
     return NULL;

--- a/src/element.c
+++ b/src/element.c
@@ -289,6 +289,10 @@ stumpless_get_param_index( const struct stumpless_element *element,
     return 0;
   }
 
+  if  ( !validate_param_name(name) ) {
+    return 0;
+  }
+
   lock_element( element );
   FOR_EACH_PARAM_WITH_NAME( element, name )
     clear_error(  );

--- a/src/element.c
+++ b/src/element.c
@@ -172,7 +172,7 @@ stumpless_element_has_param( const struct stumpless_element *element,
   }
 
   if ( !validate_param_name( name ) ) {
-    return false; 
+    return false;
   }
 
   clear_error(  );

--- a/src/element.c
+++ b/src/element.c
@@ -338,6 +338,10 @@ stumpless_get_param_name_count( const struct stumpless_element *element,
     return 0;
   }
 
+  if (!validate_param_name(name)) {
+    return 0;
+  }
+
   lock_element( element );
   FOR_EACH_PARAM_WITH_NAME( element, name )
     count++;

--- a/src/element.c
+++ b/src/element.c
@@ -171,6 +171,10 @@ stumpless_element_has_param( const struct stumpless_element *element,
     return false;
   }
 
+  if ( !validate_param_name( name ) ) {
+    return false; 
+  }
+
   clear_error(  );
   lock_element( element );
   FOR_EACH_PARAM_WITH_NAME( element, name )

--- a/src/element.c
+++ b/src/element.c
@@ -237,6 +237,10 @@ stumpless_get_param_by_name( const struct stumpless_element *element,
   VALIDATE_ARG_NOT_NULL( element );
   VALIDATE_ARG_NOT_NULL( name );
 
+  if ( !validate_param_name( name ) ) {
+    return NULL; 
+  }
+
   lock_element( element );
   FOR_EACH_PARAM_WITH_NAME( element, name )
     clear_error(  );

--- a/src/entry.c
+++ b/src/entry.c
@@ -447,6 +447,10 @@ stumpless_get_entry_param_by_name( const struct stumpless_entry *entry,
   VALIDATE_ARG_NOT_NULL( element_name );
   VALIDATE_ARG_NOT_NULL( param_name );
 
+  if ( !validate_param_name( param_name ) ) {
+    return NULL;
+  }
+
   lock_entry( entry );
   element = locked_get_element_by_name( entry, element_name );
   unlock_entry( entry );
@@ -486,6 +490,10 @@ stumpless_get_entry_param_value_by_name( const struct stumpless_entry *entry,
   VALIDATE_ARG_NOT_NULL( entry );
   VALIDATE_ARG_NOT_NULL( element_name );
   VALIDATE_ARG_NOT_NULL( param_name );
+
+  if (!validate_param_name(param_name)) {
+      return NULL;
+  }
 
   lock_entry( entry );
   element = locked_get_element_by_name( entry, element_name );

--- a/src/param.c
+++ b/src/param.c
@@ -96,6 +96,10 @@ stumpless_new_param( const char *name, const char *value ) {
   VALIDATE_ARG_NOT_NULL( name );
   VALIDATE_ARG_NOT_NULL( value );
 
+  if ( !validate_param_name( name ) ) {
+    goto fail; 
+  }
+
   param = alloc_mem( sizeof( *param ) + CONFIG_MUTEX_T_SIZE );
   if( !param ) {
     goto fail;

--- a/src/param.c
+++ b/src/param.c
@@ -139,6 +139,10 @@ stumpless_set_param_name( struct stumpless_param *param, const char *name ) {
   VALIDATE_ARG_NOT_NULL( param );
   VALIDATE_ARG_NOT_NULL( name );
 
+  if ( !validate_param_name( name ) ) {
+    goto fail;
+  }
+
   new_name = copy_cstring_with_length( name, &new_size );
   if( !new_name ) {
     goto fail;

--- a/src/validate.c
+++ b/src/validate.c
@@ -69,7 +69,7 @@ bool validate_param_name( const char* str) {
   size_t str_length = strlen( str );
   for (size_t i = 0; i < str_length; i++) {
     if (str[i] < 33 || str[i] > 126 || str[i] == '=' || str[i] == ']' || str[i] == '"') {
-      raise_invalid_encoding(L10N_FORMAT_ERROR_MESSAGE("param name"));
+      raise_invalid_encoding(L10N_FORMAT_ERROR_MESSAGE("invalid param name"));
       return false;
     }
   }

--- a/src/validate.c
+++ b/src/validate.c
@@ -37,7 +37,6 @@ bool validate_msgid_length(const char* msgid ) {
 
   return validation_status;
 }
-
 bool validate_printable_ascii( const char* str ) {
   size_t str_length = strlen( str );
 
@@ -50,7 +49,6 @@ bool validate_printable_ascii( const char* str ) {
 
   return true;
 }
-
 
 bool validate_app_name_length( const char* app_name ) {
     size_t app_name_char_length = strlen( app_name );
@@ -66,3 +64,16 @@ bool validate_app_name_length( const char* app_name ) {
 
     return validation_status;
 }
+
+bool validate_param_name( const char* str) {
+  size_t str_length = strlen( str );
+  for (size_t i = 0; i < str_length; i++) {
+    if (str[i] < 33 || str[i] > 126 || str[i] == '=' || str[i] == ']' || str[i] == '"') {
+      raise_invalid_encoding(L10N_FORMAT_ERROR_MESSAGE("param name"));
+      return false;
+    }
+  }
+
+  return true;
+}
+

--- a/test/function/element.cpp
+++ b/test/function/element.cpp
@@ -400,11 +400,11 @@ namespace {
     EXPECT_EQ( result, 0 );
     EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
 
-    result = stumpless_get_param_index( element_with_params, "par=am" );
+    result = stumpless_get_param_index( element_with_params, "par]am" );
     EXPECT_EQ( result, 0 );
     EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
 
-    result = stumpless_get_param_index( element_with_params, "par=am" );
+    result = stumpless_get_param_index( element_with_params, "par\"am" );
     EXPECT_EQ( result, 0 );
     EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
   }
@@ -437,6 +437,23 @@ namespace {
     result = stumpless_get_param_name_count( basic_element, NULL );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
     EXPECT_EQ( result, 0 );
+  }
+
+  TEST_F( ElementTest, GetParamNameCountInvalidName ) {
+    size_t result;
+    const struct stumpless_error *error;
+
+    result = stumpless_get_param_name_count( basic_element, "par=am" );
+    EXPECT_EQ( result, 0 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_get_param_name_count( basic_element, "par]am" );
+    EXPECT_EQ( result, 0 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_get_param_name_count( basic_element, "par\"am" );
+    EXPECT_EQ( result, 0 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
   }
 
   TEST_F( ElementTest, GetParamNameByIndex ) {

--- a/test/function/element.cpp
+++ b/test/function/element.cpp
@@ -326,7 +326,7 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_PARAM_NOT_FOUND );
   }
 
-  TEST_F( ElementTest, GetParamInvalidName ) {
+  TEST_F( ElementTest, GetParamByNameInvalidName ) {
     const struct stumpless_param *result;
     const struct stumpless_error *error;
 
@@ -541,6 +541,23 @@ namespace {
     value = stumpless_get_param_value_by_name( element_with_params, NULL );
     EXPECT_NULL( value );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+  }
+
+  TEST_F( ElementTest, GetParamValueByNameInvalidName ) {
+    const char *result;
+    const struct stumpless_error *error;
+
+    result = stumpless_get_param_value_by_name( element_with_params, "par=am" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_get_param_value_by_name( element_with_params, "par]am" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_get_param_value_by_name( element_with_params, "par\"am" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
   }
 
   TEST_F( ElementTest, HasParam ) {

--- a/test/function/element.cpp
+++ b/test/function/element.cpp
@@ -327,7 +327,7 @@ namespace {
   }
 
   TEST_F( ElementTest, GetParamInvalidName ) {
-    bool result;
+    const struct stumpless_param *result;
     const struct stumpless_error *error;
 
     result = stumpless_get_param_by_name( element_with_params, "par=am" );
@@ -390,6 +390,23 @@ namespace {
     result = stumpless_get_param_index( element_with_params, NULL );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
     EXPECT_EQ( result, 0 );
+  }
+
+  TEST_F( ElementTest, GetParamIndexInvalidName ) {
+    size_t result;
+    const struct stumpless_error *error;
+
+    result = stumpless_get_param_index( element_with_params, "par=am" );
+    EXPECT_EQ( result, 0 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_get_param_index( element_with_params, "par=am" );
+    EXPECT_EQ( result, 0 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_get_param_index( element_with_params, "par=am" );
+    EXPECT_EQ( result, 0 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
   }
 
   TEST_F( ElementTest, GetParamNameCount ) {

--- a/test/function/element.cpp
+++ b/test/function/element.cpp
@@ -513,6 +513,23 @@ namespace {
     EXPECT_FALSE( result );
   }
 
+  TEST_F( ElementTest, HasParamInvalidName ) {
+    bool result;
+    const struct stumpless_error *error;
+
+    result = stumpless_element_has_param( element_with_params, "par=am" );
+    EXPECT_FALSE( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_element_has_param( element_with_params, "para]m" );
+    EXPECT_FALSE( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_element_has_param( element_with_params, "pa\"ram" );
+    EXPECT_FALSE( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+  }
+
   TEST_F( ElementTest, SetNameMemoryFailure ) {
     void * (*set_malloc_result)(size_t);
     const char *new_name = "this-wont-work";

--- a/test/function/element.cpp
+++ b/test/function/element.cpp
@@ -326,6 +326,23 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_PARAM_NOT_FOUND );
   }
 
+  TEST_F( ElementTest, GetParamInvalidName ) {
+    bool result;
+    const struct stumpless_error *error;
+
+    result = stumpless_get_param_by_name( element_with_params, "par=am" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_get_param_by_name( element_with_params, "par]am" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_get_param_by_name( element_with_params, "par\"am" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+  }
+
   TEST_F( ElementTest, GetParamCount ) {
     EXPECT_EQ( stumpless_get_param_count( basic_element ), 0 );
     EXPECT_NO_ERROR;

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -549,6 +549,23 @@ namespace {
     EXPECT_NULL( result );
   }
 
+  TEST_F( EntryTest, GetParamByNameInvalidName ) {
+    const struct stumpless_param *result;
+    const struct stumpless_error *error;
+
+    result = stumpless_get_entry_param_by_name( basic_entry, "e-name", "par=am" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_get_entry_param_by_name( basic_entry, "e-name", "par]am" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_get_entry_param_by_name( basic_entry, "e-name", "par\"am" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+  }
+
   TEST_F( EntryTest, GetParamValueByIndex ) {
     const char *result;
 
@@ -612,6 +629,23 @@ namespace {
                                                       NULL );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
     EXPECT_NULL( result );
+  }
+
+  TEST_F( EntryTest, GetParamValueByNameInvalidName ) {
+    const char *result;
+    const struct stumpless_error *error;
+
+    result = stumpless_get_entry_param_value_by_name( basic_entry, "e-name", "par=am" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_get_entry_param_value_by_name( basic_entry, "e-name", "par]am" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_get_entry_param_value_by_name( basic_entry, "e-name", "par\"am" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
   }
 
   TEST_F( EntryTest, HasElement ) {

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -319,6 +319,25 @@ namespace {
     stumpless_free_all(  );
   }
 
+  TEST( NewParamTest, InvalidName ) {
+    struct stumpless_param *param;
+    const struct stumpless_error *error;
+
+    param = stumpless_new_param( "par=am", "test-value" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    param = stumpless_new_param( "param]", "test-value" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    param = stumpless_new_param( "p\"aram", "test-value" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+    
+    stumpless_free_all(  );
+  }
+
   TEST( NewParamTest, NullValue ) {
     struct stumpless_param *param;
     const struct stumpless_error *error;
@@ -413,5 +432,4 @@ namespace {
     EXPECT_NULL( result );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
   }
-
 }

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -386,6 +386,30 @@ namespace {
     stumpless_free_all(  );
   }
 
+  TEST( SetName, InvalidName) {
+    struct stumpless_param *param;
+    struct stumpless_param *result;
+    const struct stumpless_error *error;
+
+    param = stumpless_new_param( "param", "my-value" );
+    ASSERT_NOT_NULL( param );
+
+    result = stumpless_set_param_name( param, "par=am");
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_set_param_name( param, "par]m");
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+
+    result = stumpless_set_param_name( param, "param\"");
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+    
+    stumpless_destroy_param( param );
+    stumpless_free_all(  );
+  }
+
   TEST( SetValue, Basic ) {
     struct stumpless_param *param;
     const char *original_value = "first-value";


### PR DESCRIPTION
following #177

- [x] implement `validate_param_name`
- [x] add `validate_param_name` declaration to `validate`.h
- [x] update docs for `stumpless_new_param` and `stumpless_set_param_name`

validate param names in:
- [x] `stumpless_new_param` 
- [x] `stumpless_set_param_name`
- [x] `stumpless_element_has_param` 
- [x] `stumpless_get_param_by_name`
- [x] `stumpless_get_param_index`
- [x] `stumpless_get_param_name_count` 
- [x] `stumpless_get_param_value_by_name` 
- [x] `stumpless_get_entry_param_by_name`
- [x] `stumpless_get_entry_param_value_by_name`

Write tests with invalid param names for :
- [x] `stumpless_new_param` 
- [x] `stumpless_set_param_name`
- [x] `stumpless_element_has_param` 
- [x] `stumpless_get_param_by_name`
- [x] `stumpless_get_param_index`
- [x] `stumpless_get_param_name_count` 
- [x] `stumpless_get_param_value_by_name` 
- [x] `stumpless_get_entry_param_by_name`
- [x] `stumpless_get_entry_param_value_by_name`
