### PR TITLE
Documented NOWAIT

### DIFF
--- a/include/stumpless/option.h
+++ b/include/stumpless/option.h
@@ -58,7 +58,13 @@
 #    define STUMPLESS_OPTION_ODELAY (1<<3)
 #  endif
 
-/** Not currently supported. */
+/** No need to wait for the child processes that may have 
+ *  been created while logging the messages.
+ *  (Stumpless does not spawn child processes because it 
+ *  slows down the process of logging, so essentially
+ *  this option is always set)
+ */
+
 #  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
 #    define STUMPLESS_OPTION_NOWAIT LOG_NOWAIT
 #  else


### PR DESCRIPTION

Documented the use of NOWAIT option in stumpless. Since no child processes are spun the NOWAIT option is essentially on and no implementation is needed of the same. Documentation is at line 61 of `include/stumpless/option.h`