### PR TITLE
fix test usage of stack-based target structs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,7 +547,9 @@ elseif(NOT HAVE_SYS_SOCKET_H)
   set(STUMPLESS_SOCKET_TARGETS_SUPPORTED FALSE)
 
   add_function_test(socket_unsupported
-    SOURCES ${PROJECT_SOURCE_DIR}/test/function/config/socket_unsupported.cpp
+    SOURCES
+      ${PROJECT_SOURCE_DIR}/test/function/config/socket_unsupported.cpp
+      $<TARGET_OBJECTS:test_helper_fixture>
   )
 
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,7 +536,10 @@ if(NOT ENABLE_SOCKET_TARGETS)
   set(STUMPLESS_SOCKET_TARGETS_SUPPORTED FALSE)
 
   add_function_test(socket_unsupported
-    SOURCES ${PROJECT_SOURCE_DIR}/test/function/config/socket_unsupported.cpp
+    SOURCES
+      ${PROJECT_SOURCE_DIR}/test/function/config/socket_unsupported.cpp
+      $<TARGET_OBJECTS:test_helper_fixture>
+    LIBRARIES ${network_libraries}
   )
 
 elseif(NOT HAVE_SYS_SOCKET_H)
@@ -564,6 +567,7 @@ else()
     SOURCES
       test/function/target/socket.cpp
       $<TARGET_OBJECTS:rfc5424_checker>
+      $<TARGET_OBJECTS:test_helper_fixture>
   )
 
   add_function_test(socket_add_malloc_failure
@@ -599,7 +603,9 @@ if(NOT STUMPLESS_WINDOWS_EVENT_LOG_TARGETS_SUPPORTED)
   list(INSERT WRAPTURE_SPECS 0 ${PROJECT_SOURCE_DIR}/tools/wrapture/no_wel_templates.yml)
 
   add_function_test(wel_unsupported
-    SOURCES ${PROJECT_SOURCE_DIR}/test/function/config/wel_unsupported.cpp
+    SOURCES
+      ${PROJECT_SOURCE_DIR}/test/function/config/wel_unsupported.cpp
+      $<TARGET_OBJECTS:test_helper_fixture>
   )
 else()
   list(APPEND STUMPLESS_SOURCES ${PROJECT_SOURCE_DIR}/src/target/wel.c)

--- a/test/function/config/journald_unsupported.cpp
+++ b/test/function/config/journald_unsupported.cpp
@@ -38,13 +38,20 @@ namespace {
   }
 
   TEST( JournaldTargetTest, GenericClose ) {
-    struct stumpless_target target;
+    struct stumpless_target *target;
     const struct stumpless_error *error;
 
-    target.type = STUMPLESS_JOURNALD_TARGET;
+    target = stumpless_open_stdout_target( "fake-journald-target" );
+    ASSERT_NOT_NULL( target );
 
-    stumpless_close_target( &target );
+    target->type = STUMPLESS_JOURNALD_TARGET;
+
+    stumpless_close_target( target );
     EXPECT_ERROR_ID_EQ( STUMPLESS_TARGET_UNSUPPORTED );
+
+    target->type = STUMPLESS_STREAM_TARGET;
+    stumpless_close_stream_target( target );
+    stumpless_free_all(  );
   }
 
   TEST( JournaldTargetTest, Unsupported ) {
@@ -57,6 +64,8 @@ namespace {
     ASSERT_NOT_NULL( entry );
 
     target = stumpless_open_stdout_target( "fake-journald-target" );
+    ASSERT_NOT_NULL( target );
+
     target->type = STUMPLESS_JOURNALD_TARGET;
 
     result = stumpless_add_entry( target, entry );
@@ -67,5 +76,6 @@ namespace {
     stumpless_close_stream_target( target );
 
     stumpless_destroy_entry_and_contents( entry );
+    stumpless_free_all(  );
   }
 }

--- a/test/function/config/journald_unsupported.cpp
+++ b/test/function/config/journald_unsupported.cpp
@@ -48,19 +48,23 @@ namespace {
   }
 
   TEST( JournaldTargetTest, Unsupported ) {
-    struct stumpless_target target;
     struct stumpless_entry *entry;
+    struct stumpless_target *target;
     const struct stumpless_error *error;
     int result;
 
     entry = create_entry(  );
+    ASSERT_NOT_NULL( entry );
 
-    target.type = STUMPLESS_JOURNALD_TARGET;
-    target.id = &target;
+    target = stumpless_open_stdout_target( "fake-journald-target" );
+    target->type = STUMPLESS_JOURNALD_TARGET;
 
-    result = stumpless_add_entry( &target, entry );
+    result = stumpless_add_entry( target, entry );
     EXPECT_LT( result, 0 );
     EXPECT_ERROR_ID_EQ( STUMPLESS_TARGET_UNSUPPORTED );
+
+    target->type = STUMPLESS_STREAM_TARGET;
+    stumpless_close_stream_target( target );
 
     stumpless_destroy_entry_and_contents( entry );
   }

--- a/test/function/config/socket_unsupported.cpp
+++ b/test/function/config/socket_unsupported.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2019 Joel E. Anderson
+ * Copyright 2018-2021 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #include <stddef.h>
 #include <stumpless.h>
 #include "test/helper/assert.hpp"
+#include "test/helper/fixture.hpp"
 
 namespace {
 
@@ -37,36 +38,44 @@ namespace {
   }
 
   TEST( SocketTargetTest, GenericClose ) {
-    struct stumpless_target target;
+    struct stumpless_target *target;
     const struct stumpless_error *error;
 
-    target.type = STUMPLESS_SOCKET_TARGET;
+    target = stumpless_open_stdout_target( "fake-socket-target" );
+    ASSERT_NOT_NULL( target );
 
-    stumpless_close_target( &target );
+    target->type = STUMPLESS_SOCKET_TARGET;
 
+    stumpless_close_target( target );
     EXPECT_ERROR_ID_EQ( STUMPLESS_TARGET_UNSUPPORTED );
+
+    target->type = STUMPLESS_STREAM_TARGET;
+    stumpless_close_stream_target( target );
+    stumpless_free_all(  );
   }
 
   TEST( SocketTargetTest, Unsupported ) {
-    struct stumpless_target target;
+    struct stumpless_target *target;
     struct stumpless_entry *entry;
     const struct stumpless_error *error;
     int result;
 
-    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                 STUMPLESS_SEVERITY_INFO,
-                                "stumpless-unit-test",
-                                "basic-entry",
-                                "basic test message" );
+    entry = create_entry(  );
+    ASSERT_NOT_NULL( entry );
 
-    target.type = STUMPLESS_SOCKET_TARGET;
-    target.id = &target;
+    target = stumpless_open_stdout_target( "fake-socket-target" );
+    ASSERT_NOT_NULL( target );
 
-    result = stumpless_add_entry( &target, entry );
+    target->type = STUMPLESS_SOCKET_TARGET;
+
+    result = stumpless_add_entry( target, entry );
     EXPECT_LT( result, 0 );
-
     EXPECT_ERROR_ID_EQ( STUMPLESS_TARGET_UNSUPPORTED );
 
+    target->type = STUMPLESS_STREAM_TARGET;
+    stumpless_close_stream_target( target );
+
     stumpless_destroy_entry_and_contents( entry );
+    stumpless_free_all(  );
   }
 }


### PR DESCRIPTION
Some tests used a target struct allocated on the stack, which can cause subtle issues if this is used after not being fully initialized properly. This change refactors tests that do this to either use a heap-based struct instead, or to make sure that the stack-based usage is appropriate.

This is intended to resolve the CI issues in #202.