### PR TITLE
refactor enum to string helpers

### DIFF
--- a/include/private/error.h
+++ b/include/private/error.h
@@ -19,9 +19,6 @@
 #ifndef __STUMPLESS_PRIVATE_ERROR_H
 #  define __STUMPLESS_PRIVATE_ERROR_H
 
-// Generate error enum strings array in src/error.c
-#define STUMPLESS_GENERATE_STRING(STRING, INDEX) #STRING,
-
 #  include <stddef.h>
 #  include <stumpless/error.h>
 

--- a/include/private/strhelper.h
+++ b/include/private/strhelper.h
@@ -1,14 +1,14 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2020 Joel E. Anderson
- * 
+ * Copyright 2018-2021 Joel E. Anderson
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,13 @@
 #  define __STUMPLESS_PRIVATE_STRHELPER_H
 
 #  include <stddef.h>
+
+/**
+ * Stringifies the first argument and adds a comma afterwards, and ignores the
+ * second argument. Useful in FOREACH macros used to define enumerations,
+ * particularly for conversion to string functionality.
+ */
+#  define GENERATE_STRING( STRING, INDEX ) #STRING,
 
 char *
 copy_cstring( const char *str );

--- a/src/error.c
+++ b/src/error.c
@@ -31,7 +31,7 @@ static config_atomic_ptr_t error_stream = config_atomic_ptr_initializer;
 static config_atomic_bool_t error_stream_free = config_atomic_bool_true;
 static config_atomic_bool_t error_stream_valid = config_atomic_bool_false;
 
-static const char *stumpless_error_enum_to_string[] = {
+static const char *error_enum_to_string[] = {
   STUMPLESS_FOREACH_ERROR( GENERATE_STRING )
 };
 
@@ -54,10 +54,9 @@ stumpless_get_error_id( const struct stumpless_error *err ) {
 
 const char *
 stumpless_get_error_id_string( enum stumpless_error_id id) {
-  int error_id_upper_bound = sizeof( stumpless_error_enum_to_string ) /
-                             sizeof( char * );
+  int error_id_upper_bound = sizeof( error_enum_to_string ) / sizeof( char * );
   if ( id >= 0 && id < error_id_upper_bound ) {
-    return stumpless_error_enum_to_string[id];
+    return error_enum_to_string[id];
   }
 
   return "NO_SUCH_ERROR_ID";

--- a/src/error.c
+++ b/src/error.c
@@ -24,6 +24,7 @@
 #include "private/config/wrapper/thread_safety.h"
 #include "private/error.h"
 #include "private/inthelper.h"
+#include "private/strhelper.h"
 
 /* global static variables */
 static config_atomic_ptr_t error_stream = config_atomic_ptr_initializer;
@@ -31,7 +32,7 @@ static config_atomic_bool_t error_stream_free = config_atomic_bool_true;
 static config_atomic_bool_t error_stream_valid = config_atomic_bool_false;
 
 static const char *stumpless_error_enum_to_string[] = {
-  STUMPLESS_FOREACH_ERROR(STUMPLESS_GENERATE_STRING)
+  STUMPLESS_FOREACH_ERROR( GENERATE_STRING )
 };
 
 /* per-thread static variables */

--- a/test/function/error.cpp
+++ b/test/function/error.cpp
@@ -282,20 +282,17 @@ namespace {
   }
 
   TEST( GetErrorId, NoSuchErrorId ) {
-    #define STUMPLESS_GENERATE_STRING( STRING, ENUM ) #STRING,
-    static const char *stumpless_error_enum_to_string[] = {
-      STUMPLESS_FOREACH_ERROR(STUMPLESS_GENERATE_STRING)
-    };
+    int error_count = 0;
+    const char *result;
 
-    int wrong_id_int = 
-	    sizeof( stumpless_error_enum_to_string ) / sizeof( char * ) + 1;
+    #define COUNT_ERRORS( STRING, ENUM ) error_count++;
+    STUMPLESS_FOREACH_ERROR( COUNT_ERRORS )
+
     stumpless_error_id wrong_id = 
-	    static_cast<stumpless_error_id>(wrong_id_int);
+	    static_cast<stumpless_error_id>(error_count + 1);
     
-    std::string result( stumpless_get_error_id_string( wrong_id ) );
-    
-    EXPECT_TRUE( result == "NO_SUCH_ERROR_ID" );
+    result = stumpless_get_error_id_string( wrong_id );
+    EXPECT_STREQ( result, "NO_SUCH_ERROR_ID" );
   }
-
 
 }

--- a/tools/check_headers/stumpless_private.yml
+++ b/tools/check_headers/stumpless_private.yml
@@ -25,6 +25,7 @@
 "config_write_ptr": "private/config/wrapper/thread_safety.h"
 "create_empty_entry": "test/helper/fixture.hpp"
 "FOR_EACH_PARAM_WITH_NAME": "private/element.h"
+"GENERATE_STRING": "private/strhelper.h"
 "get_journald_field_name": "private/target/journald.h"
 "HAVE_PTHREAD_H": "private/config.h"
 "init_fields": "private/target/journald.h"


### PR DESCRIPTION
Refactor some underlying code in `stumpless_get_error_id_string` to support similar functionality for other enumerations.