### PR TITLE
 length checking of param names

### DIFF
--- a/include/private/validate.h
+++ b/include/private/validate.h
@@ -73,6 +73,17 @@ bool validate_app_name_length( const char* app_name);
 bool validate_param_name( const char* str);
 
 /**
+ * Checks that the passed in param name is of valid length.
+ *
+ * @param the param name(string).
+ *
+ * @return True if the param name is less than allowed length 
+ * (32 characters not including NULL terminating), otherwise
+ * it will return false and raise STUMPLESS_ARGUMENT_TOO_BIG error.
+ */
+bool validate_param_name_length( const char* str );
+
+/**
  * Checks that the passed in element name contains only ASCII characters and
  * also does not contain any of the following characters: '=',']','"'.
  *

--- a/include/stumpless/entry.h
+++ b/include/stumpless/entry.h
@@ -42,6 +42,9 @@
 /** The maximum length of an element name, as specified by RFC 5424. */
 #  define STUMPLESS_MAX_ELEMENT_NAME_LENGTH 32
 
+/** The maximum length of a parameter name, as specified by RFC 5424. */
+#  define STUMPLESS_MAX_PARAM_NAME_LENGTH 32
+
 #  ifdef __cplusplus
 extern "C" {
 #  endif

--- a/src/param.c
+++ b/src/param.c
@@ -97,7 +97,8 @@ stumpless_new_param( const char *name, const char *value ) {
   VALIDATE_ARG_NOT_NULL( name );
   VALIDATE_ARG_NOT_NULL( value );
 
-  if ( !validate_param_name( name ) ) {
+  if ( !validate_param_name( name ) ||
+       !validate_param_name_length( name )) {
     goto fail;
   }
 

--- a/src/param.c
+++ b/src/param.c
@@ -149,7 +149,8 @@ stumpless_set_param_name( struct stumpless_param *param, const char *name ) {
   VALIDATE_ARG_NOT_NULL( param );
   VALIDATE_ARG_NOT_NULL( name );
 
-  if ( !validate_param_name( name ) ) {
+  if ( !validate_param_name( name ) ||
+       !validate_param_name_length( name )) {
     goto fail;
   }
 

--- a/src/param.c
+++ b/src/param.c
@@ -97,7 +97,8 @@ stumpless_new_param( const char *name, const char *value ) {
   VALIDATE_ARG_NOT_NULL( name );
   VALIDATE_ARG_NOT_NULL( value );
 
-  if ( !validate_param_name( name ) ) {
+  if ( !validate_param_name( name ) ||
+       !validate_param_name_length( name )) {
     goto fail;
   }
 
@@ -148,7 +149,8 @@ stumpless_set_param_name( struct stumpless_param *param, const char *name ) {
   VALIDATE_ARG_NOT_NULL( param );
   VALIDATE_ARG_NOT_NULL( name );
 
-  if ( !validate_param_name( name ) ) {
+  if ( !validate_param_name( name ) ||
+       !validate_param_name_length( name )) {
     goto fail;
   }
 

--- a/src/validate.c
+++ b/src/validate.c
@@ -23,7 +23,8 @@
 #include "private/error.h"
 #include "private/config/locale/wrapper.h"
 
-bool validate_string_length( const char* str, size_t max_length ) {
+/* Helper function that can be used in other length validation routines */
+static bool validate_string_length( const char* str, size_t max_length ) {
   size_t length = strlen( str );
   bool validation_status = true;
 

--- a/src/validate.c
+++ b/src/validate.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <stumpless/entry.h>
 #include "private/error.h"
+#include "private/validate.h"
 #include "private/config/locale/wrapper.h"
 
 /* Helper function that can be used in other length validation routines */

--- a/src/validate.c
+++ b/src/validate.c
@@ -23,6 +23,20 @@
 #include "private/error.h"
 #include "private/config/locale/wrapper.h"
 
+bool validate_string_length( const char* str, size_t max_length ) {
+  size_t length = strlen( str );
+  bool validation_status = true;
+
+  if( length > max_length ) {
+    raise_argument_too_big( L10N_STRING_TOO_LONG_ERROR_MESSAGE,
+			    length,
+			    L10N_STRING_LENGTH_ERROR_CODE_TYPE );
+    validation_status = false;
+  }
+
+  return validation_status;
+}
+
 bool validate_msgid_length(const char* msgid ) {
   size_t msgid_char_length = strlen( msgid );
   bool validation_status = true;
@@ -79,6 +93,10 @@ bool validate_param_name( const char* str) {
   }
 
   return true;
+}
+
+bool validate_param_name_length( const char* name ) {
+  return validate_string_length( name, STUMPLESS_MAX_PARAM_NAME_LENGTH );
 }
 
 bool validate_element_name( const char* str) {

--- a/test/function/element.cpp
+++ b/test/function/element.cpp
@@ -1089,4 +1089,22 @@ namespace {
     EXPECT_NULL( result );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
   }
+
+  TEST( AddParamTest, ParamNameTooLong ) {
+    struct stumpless_element *element;
+    struct stumpless_element *result;
+    const struct stumpless_error *error;
+
+    element = stumpless_new_element( "element" );
+
+    result = stumpless_add_new_param( element,
+				      "very-long-name-abcdefghijklmnopqrstuvwxyz",
+				      "test-value" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
+
+    stumpless_destroy_element_and_contents( element );
+    stumpless_free_all(  );
+  }
+
 }

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -2041,4 +2041,30 @@ namespace {
 
     stumpless_free_all(  );
   }
+
+  TEST( AddParamTest, ParamNameTooLong ){
+    struct stumpless_entry *entry;
+    struct stumpless_entry *result;
+    const struct stumpless_error *error;
+    const char *app_name = "test-app-name";
+    const char *msgid = "test-msgid";
+    const char *message = "test-message";
+
+    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                                 STUMPLESS_SEVERITY_INFO,
+                                 app_name,
+                                 msgid,
+                                 message );
+
+    result = stumpless_add_new_param_to_entry( entry,
+					       "new-element-name",
+					       "very-long-name-abcdefghijklmnopqrstuvwxyz",
+					       "test-value" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
+
+    stumpless_destroy_entry_and_contents( entry );
+    stumpless_free_all(  );
+  }
+
 }

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -423,6 +423,21 @@ namespace {
     stumpless_free_all(  );
   }
 
+  TEST( SetName, InvalidNameLength ) {
+    struct stumpless_param *param;
+    struct stumpless_param *result;
+    const struct stumpless_error *error;
+
+    param = stumpless_new_param( "param", "test-value" );
+
+    result = stumpless_set_param_name( param, "very-long-name-abcdefghijklmnopqrstuvwxyz" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
+
+    stumpless_destroy_param( param );
+    stumpless_free_all(  );
+  }
+
   TEST( SetValue, Basic ) {
     struct stumpless_param *param;
     const char *original_value = "first-value";

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -340,6 +340,17 @@ namespace {
     stumpless_free_all(  );
   }
 
+  TEST( NewParamTest, InvalidNameLength ) {
+    struct stumpless_param *param;
+    const struct stumpless_error *error;
+
+    param = stumpless_new_param( "very-long-name-abcdefghijklmnopqrstuvwxyz", "test-value" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
+
+    stumpless_free_all(  );
+  }
+
   TEST( NewParamTest, NullValue ) {
     struct stumpless_param *param;
     const struct stumpless_error *error;

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -340,6 +340,17 @@ namespace {
     stumpless_free_all(  );
   }
 
+  TEST( NewParamTest, InvalidNameLength ) {
+    struct stumpless_param *param;
+    const struct stumpless_error *error;
+
+    param = stumpless_new_param( "very-long-name-abcdefghijklmnopqrstuvwxyz", "test-value" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
+
+    stumpless_free_all(  );
+  }
+
   TEST( NewParamTest, NullValue ) {
     struct stumpless_param *param;
     const struct stumpless_error *error;
@@ -408,6 +419,21 @@ namespace {
     EXPECT_NULL( result );
     EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
     
+    stumpless_destroy_param( param );
+    stumpless_free_all(  );
+  }
+
+  TEST( SetName, InvalidNameLength ) {
+    struct stumpless_param *param;
+    struct stumpless_param *result;
+    const struct stumpless_error *error;
+
+    param = stumpless_new_param( "param", "test-value" );
+
+    result = stumpless_set_param_name( param, "very-long-name-abcdefghijklmnopqrstuvwxyz" );
+    EXPECT_NULL( result );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
+
     stumpless_destroy_param( param );
     stumpless_free_all(  );
   }

--- a/tools/check_headers/stumpless_private.yml
+++ b/tools/check_headers/stumpless_private.yml
@@ -120,5 +120,4 @@
 "windows_init_mutex": "private/config/have_windows.h"
 "windows_lock_mutex": "private/config/have_windows.h"
 "windows_unlock_mutex": "private/config/have_windows.h"
-"validate_string_length": "private/validate.h"
 "validate_param_name_length": "private/validate.h"

--- a/tools/check_headers/stumpless_private.yml
+++ b/tools/check_headers/stumpless_private.yml
@@ -120,3 +120,5 @@
 "windows_init_mutex": "private/config/have_windows.h"
 "windows_lock_mutex": "private/config/have_windows.h"
 "windows_unlock_mutex": "private/config/have_windows.h"
+"validate_string_length": "private/validate.h"
+"validate_param_name_length": "private/validate.h"


### PR DESCRIPTION
Do not allow parameter names to exceed the maximum length of 32, as per RFC5424.
Issue #147 
