### PR TITLE
exclude forks from sonarcloud

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           cmake .
       - name: Sonarcloud Analysis
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           wget -q https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
           unzip build-wrapper-linux-x86.zip

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           cmake .
       - name: Sonarcloud Analysis
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == "push" || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           wget -q https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
           unzip build-wrapper-linux-x86.zip

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           cmake .
       - name: Sonarcloud Analysis
-        if: github.event_name == "push" || github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           wget -q https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
           unzip build-wrapper-linux-x86.zip


### PR DESCRIPTION
Sonarcloud analysis should not be run for pull requests coming from
forks, since they are not granted sufficient permissions to succeed.

This resolves #228, which can be referenced for more details.