### PR TITLE
add cmake policy CMP0135

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.2.3)
 
-cmake_policy(SET CMP0135 NEW)
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
 
 project(stumpless VERSION 2.1.0)
 set(CMAKE_PROJECT_HOMEPAGE_URL "https://goatshriek.github.io/stumpless/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.2.3)
 
+cmake_policy(SET CMP0135 NEW)
+
 project(stumpless VERSION 2.1.0)
 set(CMAKE_PROJECT_HOMEPAGE_URL "https://goatshriek.github.io/stumpless/")
 


### PR DESCRIPTION
Newer versions of cmake change the behavior of `ExternalProject_Add` to make file timestamps match the time of extraction by default. Older versions of cmake do not provide an option regarding this behavior, so this change sets the policy to use the new behavior when available.