### PR TITLE
correct perror multithreading issue

### DIFF
--- a/include/private/error.h
+++ b/include/private/error.h
@@ -166,4 +166,33 @@ COLD_FUNCTION
 void
 raise_invalid_encoding( const char *message );
 
+/**
+ * Writes a message to the error stream. This is ignored if the error stream
+ * is NULL.
+ *
+ * This function does not update or modify the per-thread error code. Failures
+ * are silently ignored.
+ *
+ * **Thread Safety: MT-Safe race:prefix**
+ * This function is thread safe. A lock is used to coordinate writes to the
+ * error stream.
+ *
+ * **Async Signal Safety: AS-Unsafe lock**
+ * This function is not safe to call from signal handlers, as it uses a
+ * non-reentrant lock to synchronize access to the error stream.
+ *
+ * **Async Cancel Safety: AC-Unsafe lock**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, as the lock used to control access to the error stream may not
+ * be released after a cancellation.
+ *
+ * @since v2.1.0.
+ *
+ * @param msg The message to be written to the error stream.
+ *
+ * @param msg_size The size of the message to be written in bytes.
+ */
+void
+write_to_error_stream( const char *msg, size_t msg_size );
+
 #endif /* __STUMPLESS_PRIVATE_ERROR_H */

--- a/include/private/target.h
+++ b/include/private/target.h
@@ -56,33 +56,4 @@ unlock_target( const struct stumpless_target *target );
 int
 unsupported_target_is_open( const struct stumpless_target *target );
 
-/**
- * Writes a message to the error stream. This is ignored if the error stream
- * is NULL.
- *
- * This function does not update or modify the per-thread error code. Failures
- * are silently ignored.
- * 
- * **Thread Safety: MT-Safe race:prefix**
- * This function is thread safe. A lock is used to coordinate writes to the
- * error stream.
-*
- * **Async Signal Safety: AS-Unsafe lock**
- * This function is not safe to call from signal handlers, as it uses a
- * non-reentrant lock to synchronize access to the error stream.
- *
- * **Async Cancel Safety: AC-Unsafe lock**
- * This function is not safe to call from threads that may be asynchronously
- * cancelled, as the lock used to control access to the error stream may not
- * be released after a cancellation.
- *
- * @since v2.1.0.
- *
- * @param msg The message to be written to the error stream.
- *
- * @param msg_size The size of the message to be written in bytes.
- */
-void
-write_to_error_stream( const char *msg, size_t msg_size );
-
 #endif /* __STUMPLESS_PRIVATE_TARGET_H */

--- a/include/private/target.h
+++ b/include/private/target.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2021 Joel E. Anderson
+ * Copyright 2018-2022 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,5 +55,34 @@ unlock_target( const struct stumpless_target *target );
 
 int
 unsupported_target_is_open( const struct stumpless_target *target );
+
+/**
+ * Writes a message to the error stream. This is ignored if the error stream
+ * is NULL.
+ *
+ * This function does not update or modify the per-thread error code. Failures
+ * are silently ignored.
+ * 
+ * **Thread Safety: MT-Safe race:prefix**
+ * This function is thread safe. A lock is used to coordinate writes to the
+ * error stream.
+*
+ * **Async Signal Safety: AS-Unsafe lock**
+ * This function is not safe to call from signal handlers, as it uses a
+ * non-reentrant lock to synchronize access to the error stream.
+ *
+ * **Async Cancel Safety: AC-Unsafe lock**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, as the lock used to control access to the error stream may not
+ * be released after a cancellation.
+ *
+ * @since v2.1.0.
+ *
+ * @param msg The message to be written to the error stream.
+ *
+ * @param msg_size The size of the message to be written in bytes.
+ */
+void
+write_to_error_stream( const char *msg, size_t msg_size );
 
 #endif /* __STUMPLESS_PRIVATE_TARGET_H */

--- a/include/stumpless/error.h
+++ b/include/stumpless/error.h
@@ -158,6 +158,9 @@ struct stumpless_error {
  *
  * If the code_type is NULL, then the code is not valid and should be ignored.
  *
+ * This function does _not_ clear or update the per-thread error code for
+ * stumpless, as it is involved in the error handling process itself.
+ *
  * **Thread Safety: MT-Safe**
  * This function is thread safe. No synchronization primitives are used as the
  * returned pointer is specific to the thread of execution. As a result, the

--- a/src/error.c
+++ b/src/error.c
@@ -339,3 +339,23 @@ void
 raise_invalid_encoding( const char *message ) {
   raise_error( STUMPLESS_INVALID_ENCODING, message, 0, NULL );
 }
+
+void
+write_to_error_stream( const char *msg, size_t msg_size ) {
+  FILE *error_stream;
+  size_t write_result;
+  bool locked;
+
+  error_stream = stumpless_get_error_stream(  );
+  if( !error_stream ) {
+    return;
+  }
+
+  do{
+    locked = config_compare_exchange_bool( &error_stream_free, true, false );
+  } while( !locked );
+
+  fwrite( msg, sizeof( *msg ), msg_size, error_stream );
+
+  config_write_bool( &error_stream_free, true );
+}

--- a/src/error.c
+++ b/src/error.c
@@ -342,12 +342,11 @@ raise_invalid_encoding( const char *message ) {
 
 void
 write_to_error_stream( const char *msg, size_t msg_size ) {
-  FILE *error_stream;
-  size_t write_result;
+  FILE *stream;
   bool locked;
 
-  error_stream = stumpless_get_error_stream(  );
-  if( !error_stream ) {
+  stream = stumpless_get_error_stream(  );
+  if( !stream ) {
     return;
   }
 
@@ -355,7 +354,7 @@ write_to_error_stream( const char *msg, size_t msg_size ) {
     locked = config_compare_exchange_bool( &error_stream_free, true, false );
   } while( !locked );
 
-  fwrite( msg, sizeof( *msg ), msg_size, error_stream );
+  fwrite( msg, sizeof( *msg ), msg_size, stream );
 
   config_write_bool( &error_stream_free, true );
 }

--- a/src/target.c
+++ b/src/target.c
@@ -83,7 +83,6 @@ stumpless_add_entry( struct stumpless_target *target,
   size_t builder_length;
   const char *buffer = NULL;
   int result;
-  FILE *error_stream;
 
   VALIDATE_ARG_NOT_NULL_INT_RETURN( target );
   VALIDATE_ARG_NOT_NULL_INT_RETURN( entry );

--- a/tools/check_headers/stumpless_private.yml
+++ b/tools/check_headers/stumpless_private.yml
@@ -134,4 +134,5 @@
 "windows_init_mutex": "private/config/have_windows.h"
 "windows_lock_mutex": "private/config/have_windows.h"
 "windows_unlock_mutex": "private/config/have_windows.h"
+"write_to_error_stream": "private/error.h"
 "validate_param_name_length": "private/validate.h"


### PR DESCRIPTION
Protects writes to the error stream by the `STUMPLESS_OPTION_PERROR` target option using the error stream lock, so that they are no longer unsafe.

This resolves #207, which can be referenced for more details.