### PR TITLE
document naming conventions

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -75,7 +75,8 @@ A few other documents may be helpful for newcomers to glance through:
  * [docs/acronyms.md](acronyms.md) lists acronyms and initialisms used in the
    source of stumpless.
  * [docs/style.md](style.md) has a basic set of style guidelines to follow when
-   working on the source code itself.
+   working on the source code itself, including formatting and naming
+   conventions the project follows.
  * [docs/test.md](test.md) describes the testing framework used in stumpless to
    write and run unit tests. This is important to understand if you're
    implementing any new functionality, which will need tests to confirm it works

--- a/docs/style.md
+++ b/docs/style.md
@@ -31,3 +31,16 @@ Here are a few other style points to follow in the code base:
    less clear than some other order, and in those cases it's of course fine to
    use the clearer order instead. But always default to inserting things in
    alphabetical order unless there is some reason to do otherwise.
+
+
+## Naming Conventions
+There are a few standard prefixes, suffixes, and other naming standards that
+are followed in the functions and variables in the source code. Understanding
+these will help you follow the logic of code and understand how to choose names
+in your own additions.
+
+ * **`config_` prefix** Functions that start with `config_` are dependent on the
+   build configuration of the project. They may resolve to a different function
+   when built on different platforms or with different flags, but will always
+   have the same semantics. See the [portability guide](portability.md) for more
+   information on how portability is handled in function and header names.

--- a/docs/style.md
+++ b/docs/style.md
@@ -44,3 +44,16 @@ in your own additions.
    when built on different platforms or with different flags, but will always
    have the same semantics. See the [portability guide](portability.md) for more
    information on how portability is handled in function and header names.
+ * **`locked_` prefix** Functions that start with `locked_` make the assumption
+   that some or all of their parameters are protected by holding a mutex before
+   they are called. They are not thread safe on their own, so it is up to the
+   caller to lock the resources. These are useful when you need to perform an
+   operation, but using a thread-safe version would cause deadlock by trying to
+   get a mutex that is already held. Often, the version of the function without
+   the locked prefix simply acquires the locks, and then calls the `locked_`
+   version.
+ * **`unchecked_` prefix** Some functions start with `unsafe_` to mark that they
+   do not perform any checking on their arguments. These allow callers to avoid
+   NULL checks and other checks that would be redundant because the checks have
+   already been performed elsewhere. Of course, the caller needs to make sure
+   that they do any necessary checks before calling these.

--- a/docs/style.md
+++ b/docs/style.md
@@ -57,9 +57,9 @@ in your own additions.
    get a mutex that is already held. Often, the version of the function without
    the locked prefix simply acquires the locks, and then calls the `locked_`
    version.
- * **`unchecked_` prefix** Some functions start with `unsafe_` to mark that they
-   do not perform any checking on their arguments. These allow callers to avoid
-   NULL checks and other checks that would be redundant because the checks have
+ * **`unchecked_` prefix** Some functions start with `unchecked_` to mark that
+   they do not perform any checks on their arguments. These allow callers to
+   avoid NULL checks and other checks that would be redundant because they have
    already been performed elsewhere. Of course, the caller needs to make sure
    that they do any necessary checks before calling these.
  * **`_w` suffix** Functions that end with `_w` have arguments that are wide

--- a/docs/style.md
+++ b/docs/style.md
@@ -39,6 +39,11 @@ are followed in the functions and variables in the source code. Understanding
 these will help you follow the logic of code and understand how to choose names
 in your own additions.
 
+ * **`stumpless_` prefix** Functions and types that are provided by the library
+   almost all begin with `stumpless_` to minimize namespace conflicts with users
+   of the library. There are a few exceptions to this rule (like `stump` and
+   `stumplog`), but in general if you are creating a new public-facing function
+   then it should start with this prefix.
  * **`config_` prefix** Functions that start with `config_` are dependent on the
    build configuration of the project. They may resolve to a different function
    when built on different platforms or with different flags, but will always
@@ -57,3 +62,11 @@ in your own additions.
    NULL checks and other checks that would be redundant because the checks have
    already been performed elsewhere. Of course, the caller needs to make sure
    that they do any necessary checks before calling these.
+ * **`_w` suffix** Functions that end with `_w` have arguments that are wide
+   character strings in UTF-16 encoding, instead of the UTF-8 multibyte strings
+   that are standard for arguments. These functions are provided to ease use in
+   Windows environments, where wide strings may be the standard instead of
+   multibyte. The suffix is similar to the 'A' vs. 'W' suffixes applied to
+   Windows functions to deliniate ASCII vs. wide string arguments. Keep in mind
+   that this is different though; stumpless uses multibyte strings otherwise,
+   not just ASCII!


### PR DESCRIPTION
Some conventions followed within the source code have specific meaning, but are not documented as a standard practice. This change adds documentation on these conventions, what they mean, and how to use them appropriately.