### PR TITLE
Closes #244: Network target protocol accessor functions

### DIFF
--- a/include/stumpless/target/network.h
+++ b/include/stumpless/target/network.h
@@ -669,6 +669,55 @@ struct stumpless_target *
 stumpless_set_udp_max_message_size( struct stumpless_target *target,
                                     size_t max_msg_size );
 
+/**
+ * Gets the network protocol of a network target.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe. A mutex is used to coordinate the read of the
+ * target with other accesses and modifications.
+ *
+ * **Async Signal Safety: AS-Unsafe lock heap**
+ * This function is not safe to call from signal handlers due to the use of a
+ * non-reentrant lock to coordinate access.
+ *
+ * **Async Cancel Safety: AC-Unsafe lock heap**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, due to the use of a lock that could be left locked.
+ *
+ * @param target The target to get the network protocol from.
+ *
+ * @return The network protocol of the network target.
+ * In the event of an error, -1 is returned and an error code is 
+ * set appropriately.
+ */
+STUMPLESS_PUBLIC_FUNCTION
+enum stumpless_network_protocol
+stumpless_get_network_protocol( const struct stumpless_target *target );
+
+/**
+ * Gets the transport protocol of a network target.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe. A mutex is used to coordinate the read of the
+ * target with other accesses and modifications.
+ *
+ * **Async Signal Safety: AS-Unsafe lock heap**
+ * This function is not safe to call from signal handlers due to the use of a
+ * non-reentrant lock to coordinate access.
+ *
+ * **Async Cancel Safety: AC-Unsafe lock heap**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, due to the use of a lock that could be left locked.
+ *
+ * @param target The target to get the transport protocol from.
+ *
+ * @return The transport protocol of the network target. In the event of 
+ * an error, -1 is returned and an error code is set appropriately.
+ */
+STUMPLESS_PUBLIC_FUNCTION
+enum stumpless_transport_protocol
+stumpless_get_transport_protocol( const struct stumpless_target *target );                     
+
 #  ifdef __cplusplus
 }                               /* extern "C" */
 #  endif

--- a/src/config/network_unsupported.c
+++ b/src/config/network_unsupported.c
@@ -144,3 +144,15 @@ stumpless_set_udp_max_message_size( struct stumpless_target *target,
   raise_target_unsupported( L10N_NETWORK_TARGETS_UNSUPPORTED );
   return NULL;
 }
+
+enum stumpless_network_protocol
+stumpless_get_network_protocol( const struct stumpless_target *target ) {
+  raise_target_unsupported( L10N_NETWORK_TARGETS_UNSUPPORTED );
+  return -1;
+}
+
+enum stumpless_transport_protocol
+stumpless_get_transport_protocol( const struct stumpless_target *target ) {
+  raise_target_unsupported( L10N_NETWORK_TARGETS_UNSUPPORTED );
+  return -1;
+}

--- a/src/target/network.c
+++ b/src/target/network.c
@@ -646,6 +646,56 @@ incompatible:
   return NULL;
 }
 
+enum stumpless_network_protocol
+stumpless_get_network_protocol( const struct stumpless_target *target ) {
+
+  struct network_target *net_target;
+  enum stumpless_network_protocol network_protocol;
+
+  VALIDATE_ARG_NOT_NULL_INT_RETURN( target );
+
+  lock_target( target );
+  if( target->type != STUMPLESS_NETWORK_TARGET ) {
+    raise_target_incompatible( L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE );
+    goto cleanup_and_fail;
+  }
+
+  net_target = target->id;
+  network_protocol = net_target->network;
+  unlock_target( target );
+
+  return network_protocol;
+
+cleanup_and_fail:
+  unlock_target( target );
+  return ( enum stumpless_network_protocol ) -1;
+}
+
+enum stumpless_transport_protocol
+stumpless_get_transport_protocol( const struct stumpless_target *target ) {
+
+  struct network_target *net_target;
+  enum stumpless_transport_protocol transport_protocol;
+
+  VALIDATE_ARG_NOT_NULL_INT_RETURN( target );
+
+  lock_target( target );
+  if( target->type != STUMPLESS_NETWORK_TARGET ) {
+    raise_target_incompatible( L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE );
+    goto cleanup_and_fail;
+  }
+
+  net_target = target->id;
+  transport_protocol = net_target->transport;
+  unlock_target( target );
+
+  return transport_protocol;
+
+cleanup_and_fail:
+  unlock_target( target );
+  return ( enum stumpless_transport_protocol ) -1;
+}
+
 /* private definitions */
 
 void

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -189,3 +189,5 @@ EXPORTS
   stumpless_get_facility_string                 @174
   stumpless_get_facility_enum                   @175
   stumpless_get_severity_enum                   @176
+  stumpless_get_network_protocol                @177
+  stumpless_get_transport_protocol              @178

--- a/test/function/target/network.cpp
+++ b/test/function/target/network.cpp
@@ -112,7 +112,7 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
   }
 
-  TEST( NetworkTargetGetTransportProtocol, BadTargetType ) {
+  TEST( NetworkTargetGetTransportPort, BadTargetType ) {
     const char *result;
     const struct stumpless_error *error;
     struct stumpless_target *target;
@@ -520,5 +520,87 @@ namespace {
     result = stumpless_set_udp_max_message_size( NULL, 1500 );
     EXPECT_TRUE( result == NULL );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+  }
+
+  TEST ( NetworkTargetGetNetworkProtocol, Generic ) {
+    enum stumpless_network_protocol result;
+    const struct stumpless_target *target;
+    const char *target_name = "get-network-protocol-test";
+
+    target = stumpless_open_udp4_target( target_name, "127.0.0.1" );
+
+    result = stumpless_get_network_protocol( target );
+    EXPECT_NO_ERROR;
+    ASSERT_TRUE( result == STUMPLESS_IPV4_NETWORK_PROTOCOL );
+
+    stumpless_close_network_target( target );
+  }
+
+  TEST ( NetworkTargetGetNetworkProtocol, NullTarget ) {
+    enum stumpless_network_protocol result;
+    const struct stumpless_error *error;
+
+    result = stumpless_get_network_protocol(NULL);
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+    EXPECT_TRUE( result == -1 );
+  }
+
+  TEST ( NetworkTargetGetNetworkProtocol, BadTargetType ) {
+    enum stumpless_network_protocol result;
+    const struct stumpless_target *target;
+    const struct stumpless_error *error;
+    char buffer[100];
+
+    target = stumpless_open_buffer_target( "not-a-udp-target",
+                                           buffer,
+                                           sizeof( buffer ) );
+    ASSERT_NOT_NULL( target );
+
+    result = stumpless_get_network_protocol( target );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_TARGET_INCOMPATIBLE );
+    EXPECT_TRUE( result == -1 );
+
+    stumpless_close_buffer_target( target );
+  }
+
+  TEST ( NetworkTargetGetTransportProtocol, Generic ) {
+    enum stumpless_transport_protocol result;
+    const struct stumpless_target *target;
+    const char *target_name = "get-network-protocol-test";
+
+    target = stumpless_open_udp4_target( target_name, "127.0.0.1" );
+
+    result = stumpless_get_transport_protocol( target );
+    EXPECT_NO_ERROR;
+    ASSERT_TRUE( result == STUMPLESS_UDP_TRANSPORT_PROTOCOL );
+
+    stumpless_close_network_target( target );
+  }
+
+  TEST ( NetworkTargetGetTransportProtocol, NullTarget ) {
+    enum stumpless_transport_protocol result;
+    const struct stumpless_error *error;
+
+    result = stumpless_get_transport_protocol(NULL);
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+    EXPECT_TRUE( result == -1 );
+  }
+
+  TEST ( NetworkTargetGetTransportProtocol, BadTargetType ) {
+    enum stumpless_transport_protocol result;
+    const struct stumpless_target *target;
+    const struct stumpless_error *error;
+    char buffer[100];
+
+    target = stumpless_open_buffer_target( "not-a-udp-target",
+                                           buffer,
+                                           sizeof( buffer ) );
+    ASSERT_NOT_NULL( target );
+
+    result = stumpless_get_transport_protocol( target );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_TARGET_INCOMPATIBLE );
+    EXPECT_TRUE( result == -1 );
+
+    stumpless_close_buffer_target( target );
   }
 }


### PR DESCRIPTION
### Overview
Implements the network target protocol accessor functions to allow retrieving of network protocol and transport protocol stored in `network_targets`.

### Details & Caveats

In order to compile without errors/warnings we cannot return `NULL` and instead have to cast `-1` to the valid return enum. A test case also has been renamed to reflect its true intent and to not clash with the new test cases being implemented.

### Testing

Add network target protocol accessor unit tests.
TODO: Testing on Windows
