### PR TITLE
avoid SIGPIPE termination

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -85,6 +85,7 @@ fixes, check out the
     * Object cache leak in some allocation failure scenarios
     * Creating network target with unsupported protocols
  - `close` syscall is no longer called on invalid socket handles
+ - TCP network targets do not hang when the session is closed by the receiver.
 
 ## [2.0.0] - 2020-12-27
 ### Added

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,6 +10,12 @@ or want to make a suggestion, please submit an issue on the project's
    as to a local file as well as a network server. Target chains will allow this
    stream to be defined as a logging target, and a logging call only made to
    this instead of manually logging to each target.
+ * [ADD] **Improved network target error detection**
+   Network targets do not currently detect errors that they would be able to in
+   some cases, such as with `select` or `poll`. This may lead to a connection
+   being left open for longer than necessary if the error is already detected.
+   This change will improve error detection in network targets to reduce the
+   time needed to pass these errors on to callers.
 
 
 ## 3.0.0 (next major release)

--- a/src/config/have_sys_socket.c
+++ b/src/config/have_sys_socket.c
@@ -243,7 +243,7 @@ sys_socket_sendto_target( struct network_target *target,
   result = send( target->handle,
                  msg,
                  msg_length,
-                 0 );
+                 MSG_NOSIGNAL );
   unlock_network_target( target );
 
   if( result == -1 ){

--- a/test/function/target/tcp6.cpp
+++ b/test/function/target/tcp6.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2019-2021 Joel E. Anderson
+ * Copyright 2019-2022 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -506,5 +506,43 @@ namespace {
 
     close_server_socket( default_port_handle );
     close_server_socket( new_port_handle );
+  }
+
+  TEST( Tcp6AddEntryTest, ClosedSession ) {
+    struct stumpless_target *target;
+    const char *destination = "::1";
+    int add_result;
+    socket_handle_t accepted;
+    socket_handle_t port_handle;
+
+    port_handle = open_tcp6_server_socket( destination, "514" );
+
+    if( port_handle == BAD_HANDLE ) {
+      printf( "WARNING: " BINDING_DISABLED_WARNING "\n" );
+      SUCCEED(  ) <<  BINDING_DISABLED_WARNING;
+
+    } else {
+      target = stumpless_open_tcp6_target( "close-test", destination );
+      EXPECT_NO_ERROR;
+      ASSERT_NOT_NULL( target );
+
+      EXPECT_TRUE( stumpless_target_is_open( target ) );
+
+      add_result = stumpless_add_message( target, "first message" );
+      EXPECT_GE( add_result, 0 );
+
+      // accept and then close the connection early
+      accepted = accept_tcp_connection( port_handle );
+      close_server_socket( accepted );
+      close_server_socket( port_handle );
+
+      // we want an error, not program termination
+      while( add_result >= 0 ) {
+        add_result = stumpless_add_message( target, "testing a closed session" );
+      }
+
+      stumpless_close_network_target( target );
+
+    }
   }
 }

--- a/tools/check_headers/standard_library.yml
+++ b/tools/check_headers/standard_library.yml
@@ -102,6 +102,7 @@
   - "cstring"
   - "string.h"
 "mkstemp": "stdlib.h"
+"MSG_NOSIGNAL": "sys/socket.h"
 "NULL":
   - "cstddef"
   - "stddef.h"


### PR DESCRIPTION
Adds a `MSG_NOSIGNAL` flag to POSIX network send calls to avoid program termination via a `SIGPIPE` signal. While this was not an issue on Windows builds, Linux systems at a minimum were affected.

A roadmap item has been added for the next minor release to improve error handling so that a closed session is detected faster than a failed call to `send`, which may take longer than necessary in some cases.

This is intended to resolve #231 reported by @matthew-macgregor.