### PR TITLE
Several typo corrections made on docs

### DIFF
--- a/docs/portability.md
+++ b/docs/portability.md
@@ -153,7 +153,7 @@ the platform independent library code to implement its own fallback code.
 
 A good example of this convention can be found in the call to get the memory
 page size of the system, which is used to make the slab caches used for some of
-the internal data structures more efficient. This call is defined in the wrapper
+the internal data structures that are more efficient. This call is defined in the wrapper
 header as described above, like this:
 
 ```c

--- a/docs/style.md
+++ b/docs/style.md
@@ -14,7 +14,7 @@ the git history.
 Here are a few other style points to follow in the code base:
 
  * **No `#ifdef` directives are allowed in source (`.c`) files.**
-   Source code with preprocesor directives that add, alter, or remove
+   Source code with preprocessor directives that add, alter, or remove
    functionality are easy to add, but scatter configuration-specific behavior
    and build environment dependencies across source files, and make it harder to
    understand program flow. These snippets should instead be factored into
@@ -67,6 +67,6 @@ in your own additions.
    that are standard for arguments. These functions are provided to ease use in
    Windows environments, where wide strings may be the standard instead of
    multibyte. The suffix is similar to the 'A' vs. 'W' suffixes applied to
-   Windows functions to deliniate ASCII vs. wide string arguments. Keep in mind
+   Windows functions to delineate ASCII vs. wide string arguments. Keep in mind
    that this is different though; stumpless uses multibyte strings otherwise,
    not just ASCII!

--- a/docs/test.md
+++ b/docs/test.md
@@ -52,7 +52,7 @@ As with any development project, the need to write code that can be used across
 many tests will arise. The helper test modules exist for this purpose and are
 found in the `test/helper` directory of the project, with headers in the
 `include/test/helper` directory. There are already a number of utilities in
-these folders for tasks like adding customr assertions, tracking memory
+these folders for tasks like adding custom assertions, tracking memory
 allocations and deallocations for leak testing, running network services, and
 so on. If you find yourself writing something for your tests that would be
 useful for more than just one test suite, consider putting it here for reuse.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -4,7 +4,7 @@ This is a lofty goal. The current standard practice is to keep logging at a high
 level and only turn on debug when needed, and even then only for troublesome
 components. And this is for good reason. Consider the pitfall of issuing the
 `debug all` command to a network device, only to have the processor overwhelmed
-and the box crash under the deluge of messages. Administrators may even go so
+and the box crashes under the deluge of messages. Administrators may even go so
 far as to specifically blacklist the command to prevent junior admins from
 unintentionally wreaking havoc.
 


### PR DESCRIPTION
I made several corrections as regards to the typo error found in four (4) different documents.
Though I don't know if It still counts because of the instructions found in the contribution guidelines but there's need to do that.
 Corrections are found in 

- vision.md
- style.md
- test.md
- portability.md
