### PR TITLE
Factor config_getpid out of wrapper.h

### DIFF
--- a/include/private/config/wrapper.h
+++ b/include/private/config/wrapper.h
@@ -101,17 +101,4 @@
 #  endif
 
 
-/* definition of config_getpid */
-#  ifdef HAVE_UNISTD_H
-#    include "private/config/have_unistd.h"
-#    define config_getpid unistd_getpid
-#  elif HAVE_WINDOWS_H
-#    include "private/config/have_windows.h"
-#    define config_getpid windows_getpid
-#  else
-#    include "private/config/fallback.h"
-#    define config_getpid fallback_getpid
-#  endif
-
-
 #endif /* __STUMPLESS_PRIVATE_CONFIG_WRAPPER_H */

--- a/include/private/config/wrapper/getpid.h
+++ b/include/private/config/wrapper/getpid.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Copyright 2022 Joel E. Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef __STUMPLESS_PRIVATE_CONFIG_WRAPPER_GETPID_H
+#  define __STUMPLESS_PRIVATE_CONFIG_WRAPPER_GETPID_H
+
+#  include "private/config.h"
+
+/* definition of config_getpid */
+#  ifdef HAVE_UNISTD_H
+#    include "private/config/have_unistd.h"
+#    define config_getpid unistd_getpid
+#  elif HAVE_WINDOWS_H
+#    include "private/config/have_windows.h"
+#    define config_getpid windows_getpid
+#  else
+#    include "private/config/fallback.h"
+#    define config_getpid fallback_getpid
+#  endif
+
+#endif /* __STUMPLESS_PRIVATE_CONFIG_WRAPPER_GETPID_H */

--- a/src/entry.c
+++ b/src/entry.c
@@ -28,6 +28,7 @@
 #include "private/cache.h"
 #include "private/config/locale/wrapper.h"
 #include "private/config/wrapper.h"
+#include "private/config/wrapper/getpid.h"
 #include "private/config/wrapper/wel.h"
 #include "private/config/wrapper/thread_safety.h"
 #include "private/deprecate.h"

--- a/src/target/journald.c
+++ b/src/target/journald.c
@@ -30,6 +30,7 @@
 #include <systemd/sd-journal.h>
 #include "private/config/locale/wrapper.h"
 #include "private/config/wrapper.h"
+#include "private/config/wrapper/getpid.h"
 #include "private/config/wrapper/thread_safety.h"
 #include "private/element.h"
 #include "private/entry.h"

--- a/tools/check_headers/stumpless_private.yml
+++ b/tools/check_headers/stumpless_private.yml
@@ -13,6 +13,7 @@
 "config_copy_wstring_to_cstring": "private/config/wrapper/wstring.h"
 "config_destroy_cached_mutex": "private/config/wrapper/thread_safety.h"
 "config_destroy_mutex": "private/config/wrapper/thread_safety.h"
+"config_getpid": "private/config/wrapper/getpid.h"
 "config_get_local_socket_name": "private/config/wrapper/socket.h"
 "config_init_journald_element": "private/config/wrapper/journald.h"
 "config_init_journald_param": "private/config/wrapper/journald.h"


### PR DESCRIPTION
This PR is to move definition of config_getpid to its own header file. The details are discussed in issue https://github.com/goatshriek/stumpless/issues/271
