### PR TITLE
separate config_format_string wrapper (#297)

### DIFF
--- a/include/private/config/wrapper.h
+++ b/include/private/config/wrapper.h
@@ -50,15 +50,4 @@
 #    include <stdio.h>
 #    define config_fopen fopen
 #  endif
-
-
-/* definition of config_format_string */
-#  ifdef HAVE_VSNPRINTF_S
-#    include "private/config/have_vsnprintf_s.h"
-#    define config_format_string vsnprintf_s_format_string
-#  else
-#    include "private/config/no_vsnprintf_s.h"
-#    define config_format_string no_vsnprintf_s_format_string
-#  endif
-
 #endif /* __STUMPLESS_PRIVATE_CONFIG_WRAPPER_H */

--- a/include/private/config/wrapper/config_format_string.h
+++ b/include/private/config/wrapper/config_format_string.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+* Copyright 2018-2022 Joel E. Anderson
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+#ifndef __STUMPLESS_PRIVATE_CONFIG_FORMAT_STRING_H
+#  define __STUMPLESS_PRIVATE_CONFIG_FORMAT_STRING_H
+
+#  include "private/config.h"
+/* definition of config_format_string */
+#  ifdef HAVE_VSNPRINTF_S
+#    include "private/config/have_vsnprintf_s.h"
+#    define config_format_string vsnprintf_s_format_string
+#  else
+#    include "private/config/no_vsnprintf_s.h"
+#    define config_format_string no_vsnprintf_s_format_string
+#  endif
+#endif /* __STUMPLESS_PRIVATE_CONFIG_FORMAT_STRING_H */

--- a/src/entry.c
+++ b/src/entry.c
@@ -28,6 +28,7 @@
 #include "private/cache.h"
 #include "private/config/locale/wrapper.h"
 #include "private/config/wrapper.h"
+#include "private/config/wrapper/config_format_string.h"
 #include "private/config/wrapper/gethostname.h"
 #include "private/config/wrapper/getpid.h"
 #include "private/config/wrapper/wel.h"

--- a/src/entry.c
+++ b/src/entry.c
@@ -27,10 +27,9 @@
 #include <stumpless/severity.h>
 #include "private/cache.h"
 #include "private/config/locale/wrapper.h"
-#include "private/config/wrapper.h"
-#include "private/config/wrapper/config_format_string.h"
 #include "private/config/wrapper/gethostname.h"
 #include "private/config/wrapper/getpid.h"
+#include "private/config/wrapper/config_format_string.h"
 #include "private/config/wrapper/wel.h"
 #include "private/config/wrapper/thread_safety.h"
 #include "private/deprecate.h"

--- a/tools/check_headers/stumpless.yml
+++ b/tools/check_headers/stumpless.yml
@@ -25,7 +25,7 @@
 "config_copy_wel_fields": "private/config/wrapper.h"
 "config_destroy_insertion_params": "private/config/wrapper.h"
 "config_fopen": "private/config/wrapper.h"
-"config_format_string": "private/config/wrapper.h"
+"config_format_string": "private/config/wrapper/config_format_string.h"
 "config_gethostname": "private/config/wrapper.h"
 "config_getpagesize": "private/config/wrapper/getpagesize.h"
 "config_get_now": "private/config/wrapper/get_now.h"

--- a/tools/check_headers/stumpless_private.yml
+++ b/tools/check_headers/stumpless_private.yml
@@ -14,6 +14,7 @@
 "config_destroy_cached_mutex": "private/config/wrapper/thread_safety.h"
 "config_destroy_mutex": "private/config/wrapper/thread_safety.h"
 "config_getpid": "private/config/wrapper/getpid.h"
+"config_format_string": "private/config/wrapper/config_format_string.h"
 "config_get_local_socket_name": "private/config/wrapper/socket.h"
 "config_get_now": "private/config/wrapper/get_now.h"
 "config_init_journald_element": "private/config/wrapper/journald.h"


### PR DESCRIPTION
Continuing the elimination of include/private/config/wrapper.h
 
by moving another function into its own wrapper header.

This fixes https://github.com/goatshriek/stumpless/issues/297, which can be referenced for more details.