### PR TITLE
Set get for entry hostname

### DIFF
--- a/include/private/validate.h
+++ b/include/private/validate.h
@@ -68,17 +68,27 @@ if( unlikely( ARG_NAME == NULL ) ) {                                           \
  * Checks the char length of procid.
  *
  * @param the procid.
- * 
+ *
  * @return True if the procid is at or below the maximum allowed length, otherwise
  * it will return false and raise the appropriate error.
  */
 bool validate_procid_length( const char* procid );
 
 /**
+ * Checks the char length of a hostname.
+ *
+ * @param the hostname.
+ *
+ * @return True if the hostname is at or below the maximum allowed length, otherwise
+ * it will return false and raise the appropriate error.
+ */
+bool validate_hostname_length( const char* hostname );
+
+/**
  * Checks the char length of msgid.
  *
  * @param the msgid.
- * 
+ *
  * @return True if the msgid is at or below the maximum allowed length, otherwise
  * it will return false and raise the appropriate error.
  */
@@ -99,7 +109,7 @@ bool validate_printable_ascii( const char* str );
  *
  * @param the app name
  *
- * @return True if the app name is less than allowed length 
+ * @return True if the app name is less than allowed length
  * (48 characters not including NULL terminating),otherwise
  * it will return false and raise STUMPLESS_ARGUMENT_TOO_BIG error.
  */
@@ -121,7 +131,7 @@ bool validate_param_name( const char* str);
  *
  * @param the param name(string).
  *
- * @return True if the param name is less than allowed length 
+ * @return True if the param name is less than allowed length
  * (32 characters not including NULL terminating), otherwise
  * it will return false and raise STUMPLESS_ARGUMENT_TOO_BIG error.
  */
@@ -143,7 +153,7 @@ bool validate_element_name( const char* str);
  *
  * @param the element name(string).
  *
- * @return True if the element name is less than allowed length 
+ * @return True if the element name is less than allowed length
  * (32 characters not including NULL terminating),otherwise
  * it will return false and raise STUMPLESS_ARGUMENT_TOO_BIG error.
  */

--- a/include/stumpless/entry.h
+++ b/include/stumpless/entry.h
@@ -1552,7 +1552,8 @@ stumpless_set_entry_procid( struct stumpless_entry *entry, const char *procid );
  * appropriately.
  */
 STUMPLESS_PUBLIC_FUNCTION
-const char *stumpless_get_entry_hostname( const struct stumpless_entry *entry );
+const char *
+stumpless_get_entry_hostname( const struct stumpless_entry *entry );
 
 /**
  * Sets the hostname of a given entry. If hostname is NULL it will set hostname to
@@ -1572,7 +1573,7 @@ const char *stumpless_get_entry_hostname( const struct stumpless_entry *entry );
  *
  * @param entry The entry to modify.
  *
- * @param procid The new hostname to set on the entry.
+ * @param hostname The new hostname to set on the entry.
  *
  * @return The modified entry if no error is encountered. If an error is
  * encountered, then NULL is returned and an error code is set appropriately.

--- a/include/stumpless/entry.h
+++ b/include/stumpless/entry.h
@@ -34,6 +34,7 @@
 #  include <stumpless/severity.h>
 
 #define STUMPLESS_MAX_PROCID_LENGTH 128
+#define STUMPLESS_MAX_HOSTNAME_LENGTH 255
 
 /** The maximum length of an app name, as specified by RFC 5424. */
 #  define STUMPLESS_MAX_APP_NAME_LENGTH 48
@@ -63,6 +64,10 @@ struct stumpless_entry {
   char procid[STUMPLESS_MAX_PROCID_LENGTH + 1];
 /** A bool specifying whether or not procid has been overriden. */
   bool procid_override;
+/** The hostname of this entry, as a NULL-terminated string. */
+  char hostname[STUMPLESS_MAX_HOSTNAME_LENGTH + 1];
+/** A bool specifying whether or not hostname has been overriden. */
+  bool hostname_override;
 /**
  * The prival of this entry. This is a combination of the facility and severity
  * of the event, combined using a bitwise or.
@@ -190,9 +195,9 @@ stumpless_add_new_element( struct stumpless_entry *entry,
  * @param entry The entry to add the new param to.
  *
  * @param element_name The name of the element to add the param to. If an
- * element with this name is not found, it will be created. Valid name should 
- * have printable ASCII charecters expect '=', ']' , '"' and should be 32 
- * charecters long 
+ * element with this name is not found, it will be created. Valid name should
+ * have printable ASCII charecters expect '=', ']' , '"' and should be 32
+ * charecters long
  *
  * @param param_name The name of the new param to add.
  *
@@ -1050,9 +1055,9 @@ stumpless_set_entry_facility( struct stumpless_entry *entry,
  *
  * @param msgid A NULL-terminated string holding the new msgid for the entry.
  * The string must be in the ASCII printable range 33 <= character <= 126 as
- * specified in RFC5424. This will be copied in to the entry, and therefore 
- * may be modified or freed after this call without affecting the entry. If 
- * this is NULL, then a single '-' character will be used, as specified as 
+ * specified in RFC5424. This will be copied in to the entry, and therefore
+ * may be modified or freed after this call without affecting the entry. If
+ * this is NULL, then a single '-' character will be used, as specified as
  * the NILVALUE in RFC 5424.
  *
  * @return The modified entry if no error is encountered. If an error is
@@ -1402,7 +1407,7 @@ stumpless_set_entry_severity( struct stumpless_entry *entry,
  * to be 48 characters or less.
  *
  * @param msgid The message id of the entry. If this is NULL, then it will be
- * blank in the entry (a single '-' character). The string must be in the 
+ * blank in the entry (a single '-' character). The string must be in the
  * ASCII printable range 33 <= character <= 126 as specified in RFC5424.
  *
  * @param message The message in the entry. This message may contain any format
@@ -1469,9 +1474,9 @@ vstumpless_set_entry_message( struct stumpless_entry *entry,
 
 /**
  * Returns the procid of a given entry. If procid is not set it will return the
- * ProcessID. The result character buffer must be freed by the caller when it is 
+ * ProcessID. The result character buffer must be freed by the caller when it is
  * no longer needed to avoid memory leaks.
- * 
+ *
  * **Thread Safety: MT-Safe**
  * This function is thread safe. A mutex is used to coordinate changes to the
  * entry while it is being modified.
@@ -1484,11 +1489,11 @@ vstumpless_set_entry_message( struct stumpless_entry *entry,
  * This function is not safe to call from threads that may be asynchronously
  * cancelled, due to the use of a lock that could be left locked as well as
  * memory management functions.
- * 
+ *
  * @param entry The entry to get the procid of.
- * 
+ *
  * @return The procid of the entry if no error is encountered. If an error
- * was encountered, then NULL is returned and an error code is set 
+ * was encountered, then NULL is returned and an error code is set
  * appropriately.
  */
 STUMPLESS_PUBLIC_FUNCTION
@@ -1498,7 +1503,7 @@ stumpless_get_entry_procid( const struct stumpless_entry *entry );
 /**
  * Sets the procid of a given entry. If procid is NULL it will set procid to
  * be the ProcessID.
- * 
+ *
  * **Thread Safety: MT-Safe**
  * This function is thread safe. A mutex is used to coordinate changes to the
  * entry while it is being modified.
@@ -1510,17 +1515,71 @@ stumpless_get_entry_procid( const struct stumpless_entry *entry );
  * **Async Cancel Safety: AC-Unsafe lock heap**
  * This function is not safe to call from threads that may be asynchronously
  * cancelled, due to the use of a lock that could be left locked.
- * 
+ *
  * @param entry The entry to modify.
- * 
+ *
  * @param procid The new procid to set on the entry.
- * 
+ *
  * @return The modified entry if no error is encountered. If an error is
  * encountered, then NULL is returned and an error code is set appropriately.
  */
 STUMPLESS_PUBLIC_FUNCTION
 struct stumpless_entry *
 stumpless_set_entry_procid( struct stumpless_entry *entry, const char *procid );
+
+/**
+ * Returns the hostname of a given entry. If hostname is not set it will return the
+ * Machine hostname. The result character buffer must be freed by the caller when it is
+ * no longer needed to avoid memory leaks.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe. A mutex is used to coordinate changes to the
+ * entry while it is being modified.
+ *
+ * **Async Signal Safety: AS-Unsafe lock heap**
+ * This function is not safe to call from signal handlers due to the use of a
+ * non-reentrant lock to coordinate changes.
+ *
+ * **Async Cancel Safety: AC-Unsafe lock heap**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, due to the use of a lock that could be left locked as well as
+ * memory management functions.
+ *
+ * @param entry The entry to get the hostname of.
+ *
+ * @return The hostname of the entry if no error is encountered. If an error
+ * was encountered, then NULL is returned and an error code is set
+ * appropriately.
+ */
+STUMPLESS_PUBLIC_FUNCTION
+const char *stumpless_get_entry_hostname( const struct stumpless_entry *entry );
+
+/**
+ * Sets the hostname of a given entry. If hostname is NULL it will set hostname to
+ * be the Machine hostname.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe. A mutex is used to coordinate changes to the
+ * entry while it is being modified.
+ *
+ * **Async Signal Safety: AS-Unsafe lock heap**
+ * This function is not safe to call from signal handlers due to the use of a
+ * non-reentrant lock to coordinate changes.
+ *
+ * **Async Cancel Safety: AC-Unsafe lock heap**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, due to the use of a lock that could be left locked.
+ *
+ * @param entry The entry to modify.
+ *
+ * @param procid The new hostname to set on the entry.
+ *
+ * @return The modified entry if no error is encountered. If an error is
+ * encountered, then NULL is returned and an error code is set appropriately.
+ */
+STUMPLESS_PUBLIC_FUNCTION
+struct stumpless_entry *
+stumpless_set_entry_hostname( struct stumpless_entry *entry, const char *hostname );
 
 #  ifdef __cplusplus
 }                               /* extern "C" */

--- a/src/entry.c
+++ b/src/entry.c
@@ -982,11 +982,11 @@ const char *
 stumpless_get_entry_procid( const struct stumpless_entry *entry ) {
   struct strbuilder *procid_builder;
   char *procid;
-  
+
   VALIDATE_ARG_NOT_NULL( entry );
 
   lock_entry( entry );
-  
+
   procid_builder = strbuilder_new();
 
   if( entry->procid_override == false ) {
@@ -1017,6 +1017,53 @@ stumpless_set_entry_procid( struct stumpless_entry *entry, const char *procid ) 
     if( !validate_printable_ascii( procid ) || !validate_procid_length( procid ) ) return NULL;
     strncpy( entry->procid, procid, STUMPLESS_MAX_PROCID_LENGTH + 1 );
     entry->procid_override = true;
+  }
+
+  unlock_entry(entry);
+  return entry;
+}
+
+const char *
+stumpless_get_entry_hostname( const struct stumpless_entry *entry ) {
+  struct strbuilder *hostname_builder;
+  char *hostname;
+
+  VALIDATE_ARG_NOT_NULL( entry );
+
+  lock_entry( entry );
+
+  hostname_builder = strbuilder_new();
+
+  if( entry->hostname_override == false ) {
+    strbuilder_append_hostname( hostname_builder );
+  }
+  else {
+    strbuilder_append_string( hostname_builder, entry->hostname );
+  }
+
+  hostname = strbuilder_to_string( hostname_builder );
+
+  strbuilder_destroy( hostname_builder );
+  unlock_entry( entry );
+
+  return hostname;
+}
+
+struct stumpless_entry *
+stumpless_set_entry_hostname( struct stumpless_entry *entry, const char *hostname ) {
+  VALIDATE_ARG_NOT_NULL( entry );
+
+  lock_entry( entry );
+
+  if( hostname == NULL ) {
+    // setting the hostname to a NULL pointer should effectively restore default behavior.
+    entry->hostname_override = false;
+  }
+  else {
+    // the setter should return the modified entry in the case of success, and NULL if not.
+    if( !validate_printable_ascii( hostname ) || !validate_hostname_length( hostname ) ) return NULL;
+    strncpy( entry->hostname, hostname, STUMPLESS_MAX_HOSTNAME_LENGTH + 1 );
+    entry->hostname_override = true;
   }
 
   unlock_entry(entry);

--- a/src/entry.c
+++ b/src/entry.c
@@ -1205,6 +1205,7 @@ new_entry( enum stumpless_facility facility,
   }
 
   entry->procid_override = false;
+  entry->hostname_override = false;
   entry->message = message;
   entry->message_length = message_length;
   entry->prival = get_prival( facility, severity );

--- a/src/validate.c
+++ b/src/validate.c
@@ -53,6 +53,20 @@ bool validate_procid_length(const char* procid ) {
   return validation_status;
 }
 
+bool validate_hostname_length( const char* hostname ) {
+  size_t length = strlen( hostname );
+  bool validation_status = true;
+
+  if( length > STUMPLESS_MAX_HOSTNAME_LENGTH ) {
+    raise_argument_too_big( L10N_STRING_TOO_LONG_ERROR_MESSAGE,
+                            length,
+                            L10N_STRING_LENGTH_ERROR_CODE_TYPE );
+    validation_status = false;
+  }
+
+  return validation_status;
+}
+
 bool validate_msgid_length(const char* msgid ) {
   size_t msgid_char_length = strlen( msgid );
   bool validation_status = true;

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -208,3 +208,5 @@ EXPORTS
   stumpless_get_target_type_string              @193
   stumpless_get_entry_procid                    @194
   stumpless_set_entry_procid                    @195
+  stumpless_get_entry_hostname                  @196
+  stumpless_set_entry_hostname                  @197

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -2436,7 +2436,6 @@ namespace {
     hostname = stumpless_get_entry_hostname( entry );
     EXPECT_NOT_NULL( hostname );
 
-    free( (void *) hostname );
     stumpless_destroy_entry_and_contents( entry );
     stumpless_free_all(  );
   }

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -2413,8 +2413,10 @@ namespace {
     ASSERT_NOT_NULL( entry );
 
     stumpless_set_entry_hostname( entry, hostname );
-    EXPECT_THAT( stumpless_get_entry_hostname( entry ), HasSubstr( hostname ) );
+    const char *result = stumpless_get_entry_hostname( entry );
+    EXPECT_THAT( result, HasSubstr( hostname ) );
 
+    free( (void *) result );
     stumpless_destroy_entry_and_contents( entry );
     stumpless_free_all(  );
   }
@@ -2436,6 +2438,7 @@ namespace {
     hostname = stumpless_get_entry_hostname( entry );
     EXPECT_NOT_NULL( hostname );
 
+    free( (void *) hostname );
     stumpless_destroy_entry_and_contents( entry );
     stumpless_free_all(  );
   }
@@ -2467,8 +2470,10 @@ namespace {
     EXPECT_NO_ERROR;
     EXPECT_NOT_NULL( result );
     EXPECT_EQ( result, entry );
-    EXPECT_THAT( stumpless_get_entry_hostname( entry ), HasSubstr( hostname ) );
+    const char *result_hostname = stumpless_get_entry_hostname( entry );
+    EXPECT_THAT( result_hostname, HasSubstr( hostname ) );
 
+    free( (void *) result_hostname );
     stumpless_destroy_entry_and_contents( entry );
     stumpless_free_all(  );
   }

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -168,7 +168,7 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
     EXPECT_NULL( result );
   }
-  
+
   TEST_F( EntryTest, InvalidNameLength ) {
     const struct stumpless_entry *result;
     const struct stumpless_error *error;
@@ -599,7 +599,7 @@ namespace {
     EXPECT_NULL( result );
     EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
   }
-  
+
   TEST_F( EntryTest, GetParamValueByIndex ) {
     const char *result;
 
@@ -698,7 +698,7 @@ namespace {
     EXPECT_NULL( result );
     EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
   }
-  
+
   TEST_F( EntryTest, HasElement ) {
     bool result;
 
@@ -740,7 +740,7 @@ namespace {
     EXPECT_FALSE( result );
     EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
   }
-  
+
   TEST_F( EntryTest, GetElementInvalidName ) {
     bool result;
     const struct stumpless_error *error;
@@ -757,7 +757,7 @@ namespace {
     EXPECT_FALSE( result );
     EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
   }
-  
+
   TEST_F( EntryTest, GetElementIdxInvalidName ) {
     bool result;
     const struct stumpless_error *error;
@@ -2289,7 +2289,7 @@ namespace {
     const char *msgid = "test-msgid";
     const char *message = "test-message";
     char *procid[129];
-    
+
     entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
                                  STUMPLESS_SEVERITY_INFO,
                                  app_name,
@@ -2329,7 +2329,7 @@ namespace {
                          "-abcdefghijklmnopqrstuvwxy"
                          "-abcdefghijklmnopqrstuvwxy"
                          "-abcdefghijklmn";
-    
+
     entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
                                  STUMPLESS_SEVERITY_INFO,
                                  app_name,
@@ -2353,7 +2353,7 @@ namespace {
     const char *msgid = "test-msgid";
     const char *message = "test-message";
     const char *procid = "\n";
-    
+
     entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
                                  STUMPLESS_SEVERITY_INFO,
                                  app_name,
@@ -2378,7 +2378,7 @@ namespace {
     const char *msgid = "test-msgid";
     const char *message = "test-message";
     const char *procid = "test-procid";
-    
+
     target = stumpless_open_buffer_target("output buffer", buffer, 8096);
     stumpless_set_option( target, STUMPLESS_OPTION_PID);
     ASSERT_NOT_NULL( target );
@@ -2393,6 +2393,174 @@ namespace {
     stumpless_set_entry_procid( entry, procid );
     stumpless_add_entry( target, entry );
     EXPECT_THAT( buffer, HasSubstr( "test-procid" ) );
+
+    stumpless_destroy_entry_and_contents( entry );
+    stumpless_free_all(  );
+  }
+
+  TEST( GetHostName, HostNameSet ) {
+    struct stumpless_entry *entry;
+    const char *app_name = "test-app-name";
+    const char *msgid = "test-msgid";
+    const char *message = "test-message";
+    const char *hostname = "test-hostname";
+
+    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                                 STUMPLESS_SEVERITY_INFO,
+                                 app_name,
+                                 msgid,
+                                 message );
+    ASSERT_NOT_NULL( entry );
+
+    stumpless_set_entry_hostname( entry, hostname );
+    EXPECT_THAT( stumpless_get_entry_hostname( entry ), HasSubstr( hostname ) );
+
+    stumpless_destroy_entry_and_contents( entry );
+    stumpless_free_all(  );
+  }
+
+  TEST( GetHostName, HostNameNotSet ) {
+    struct stumpless_entry *entry;
+    const char *app_name = "test-app-name";
+    const char *msgid = "test-msgid";
+    const char *message = "test-message";
+    const char *hostname;
+
+    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                                 STUMPLESS_SEVERITY_INFO,
+                                 app_name,
+                                 msgid,
+                                 message );
+    ASSERT_NOT_NULL( entry );
+
+    hostname = stumpless_get_entry_hostname( entry );
+    EXPECT_NOT_NULL( hostname );
+
+    free( (void *) hostname );
+    stumpless_destroy_entry_and_contents( entry );
+    stumpless_free_all(  );
+  }
+
+  TEST( GetHostName, NullEntry ) {
+    const char *hostname;
+
+    hostname = stumpless_get_entry_hostname( NULL );
+
+    EXPECT_NULL( hostname );
+  }
+
+  TEST( SetHostName, SetValue ) {
+    struct stumpless_entry *entry;
+    struct stumpless_entry *result;
+    const char *app_name = "test-app-name";
+    const char *msgid = "test-msgid";
+    const char *message = "test-message";
+    const char *hostname = "test-hostname";
+
+    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                                 STUMPLESS_SEVERITY_INFO,
+                                 app_name,
+                                 msgid,
+                                 message );
+    ASSERT_NOT_NULL( entry );
+
+    result = stumpless_set_entry_hostname( entry, hostname );
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( result );
+    EXPECT_EQ( result, entry );
+    EXPECT_THAT( stumpless_get_entry_hostname( entry ), HasSubstr( hostname ) );
+
+    stumpless_destroy_entry_and_contents( entry );
+    stumpless_free_all(  );
+  }
+
+  TEST( SetHostName, ResetValue ) {
+    struct stumpless_entry *entry;
+    struct stumpless_entry *result;
+    const struct stumpless_error *error;
+    const char *app_name = "test-app-name";
+    const char *msgid = "test-msgid";
+    const char *message = "test-message";
+
+    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                                 STUMPLESS_SEVERITY_INFO,
+                                 app_name,
+                                 msgid,
+                                 message );
+
+    result = stumpless_set_entry_hostname( entry, NULL );
+
+    EXPECT_NOT_NULL( result );
+
+    stumpless_destroy_entry_and_contents( entry );
+    stumpless_free_all(  );
+  }
+
+  TEST( SetHostName, NullEntry ) {
+    struct stumpless_entry *result;
+    const struct stumpless_error *error;
+
+    result = stumpless_set_entry_hostname( NULL, NULL );
+
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+    EXPECT_NULL( result );
+
+    stumpless_free_all(  );
+  }
+
+  TEST( SetHostName, HostNameTooLong ) {
+    struct stumpless_entry *entry;
+    struct stumpless_entry *result;
+    const struct stumpless_error *error;
+    const char *app_name = "test-app-name";
+    const char *msgid = "test-msgid";
+    const char *message = "test-message";
+    const char *hostname = "test-procid-"
+                         "abcdefghijklmnopqrstuvwxy"
+                         "-abcdefghijklmnopqrstuvwxy"
+                         "-abcdefghijklmnopqrstuvwxy"
+                         "-abcdefghijklmnopqrstuvwxy"
+                         "-abcdefghijklmnopqrstuvwxy"
+                         "-abcdefghijklmnopqrstuvwxy"
+                         "-abcdefghijklmnopqrstuvwxy"
+                         "-abcdefghijklmnopqrstuvwxy"
+                         "-abcdefghijklmnopqrstuvwxy"
+                         "-abcdefghijklmnopqrstuvwxy";
+
+    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                                 STUMPLESS_SEVERITY_INFO,
+                                 app_name,
+                                 msgid,
+                                 message );
+
+    result = stumpless_set_entry_hostname( entry, hostname );
+
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_BIG );
+    EXPECT_NULL( result );
+
+    stumpless_destroy_entry_and_contents( entry );
+    stumpless_free_all(  );
+  }
+
+  TEST( SetHostName, HostNameNotPrintable ) {
+    struct stumpless_entry *entry;
+    struct stumpless_entry *result;
+    const struct stumpless_error *error;
+    const char *app_name = "test-app-name";
+    const char *msgid = "test-msgid";
+    const char *message = "test-message";
+    const char *hostname = "test-procid-\x01";
+
+    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                                 STUMPLESS_SEVERITY_INFO,
+                                 app_name,
+                                 msgid,
+                                 message );
+
+    result = stumpless_set_entry_hostname( entry, hostname );
+
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_ENCODING );
+    EXPECT_NULL( result );
 
     stumpless_destroy_entry_and_contents( entry );
     stumpless_free_all(  );


### PR DESCRIPTION
This Pull Request is a response to the issue: #294
The hostname field is a 255 printable ASCII field in RFC 5424, and users may want to set this to something more meaningful to them. This task implements a pair of functions to set and retrieve the hostname of an entry, which is used if it is set during entry formatting.

Make sure that your pull request follows the guidelines specified in the
[Guidelines for Contributing](../docs/CONTRIBUTING.md). 
