### PR TITLE
fix mingw build and docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,14 +70,33 @@ branches, or make any changes yourself.
 
 ## Prepping your System
 Since there are so many possible ways to set up an environment, stumpless does
-not provide any single way to do this. However, here are some one-liners that
+not provide any single way to do this. However, here are some snippets that
 can get everything installed for you in some common environments.
+
+Note that some depenencies for developing Stumpless are left out of these
+snippets, most notably Ruby and Valgrind. For a full list of dependencies check
+the [dependency documentation](./docs/dependencies.md), which lists all of the
+tools you might need. The snippets below allow you to build and test the
+library, as well as build the documentation for it.
+
+Similarly, if you only want to build the library, you may not need all of these.
+A C++ compiler is only needed to build the test suites, and doxygen is only
+needed if you build the documentation. If you only want to build the library and
+immediately install/use it, you can get away with just cmake and a C toolchain.
 
 For Linux systems with a package manager like `apt`, you can install the needed
 tools (for a GNU toolchain) with something like the following:
 
 ```sh
+# for distributions using apt, such as Ubuntu or Debian:
 sudo apt-get install git cmake make gcc g++ doxygen
+
+# for MinGW, you can use the following pacman invocation
+# be sure that you are in a MinGW shell (for example, MSYS2 has several
+# terminals, only some of which are MinGW)
+pacman -S $MINGW_PACKAGE_PREFIX-cmake \
+          $MINGW_PACKAGE_PREFIX-make \
+          $MINGW_PACKAGE_PREFIX-gcc
 ```
 
 Cygwin lacks a package manager in the environment itself, requiring packages to
@@ -115,17 +134,20 @@ Visual Studio provides a CMake menu in the IDE that will display all available
 targets.
 
 If you're unsure of the build commands for the toolchain on your system, then
-cmake can run these commands for you if you invoke it in build mode.
+cmake can run these commands for you if you invoke it in build mode. This is
+especially handy in environments like Visual Studio or MinGW, where the build
+toolchain might require prefixes and/or options to work properly.
 
 ```sh
-# build the `all` target using whatever toolchain cmake detected during the
-# configuration stage
+# build the default target ("all") using whatever toolchain cmake detected
+# during the configuration stage
 # the argument to the `--build` parameter is the root of the folder where we
 # ran the original cmake configuration command
-cmake --build . --target all
+cmake --build .
 
-# build and run the test suite the same way
-cmake --build . --target all
+# we can build and run any other target with the `--target` option
+# for example, this invocation builds and runs the test suite
+cmake --build . --target check
 ```
 
 The type of build can be changed at configuration time by defining the

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@
 ## Key Features
 Stumpless offers a robust set of features to make logging in C faster and
 easier:
- * structured and unstructured logging to suit your needs
  * easy logging to [lots of things](#what-can-it-log-to) like Splunk, rsyslog,
    journald, the Windows Event Log, and more!
+ * structured and unstructured logging to suit your needs
  * interoperable with common log daemons and libraries
- * cross-platform builds on Linux, Windows, Mac, Cygwin, and more
+ * builds for Linux, Windows, Mac, MinGW, MSYS2, Cygwin, and more
  * completely thread safe
  * can be adjusted or removed during compilation for zero runtime impact
  * localized for multiple languages :brazil: :bulgaria: :cn: :czech_republic:

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -43,12 +43,10 @@ the public header files. Documentation can also be generated using `doxygen`.
 This is done using the `docs` build target, which will only be available if
 doxygen is detected on the build system.
 
-You can avoid downloading the repo and building the documentation by visiting
-the project Github Pages website, (code is in the `gh-pages` branch of the
-repository). This contains several of the documents in the `docs` folder of the
-repository in a prettier format, and also uses `m.css` to generate a more
-appealing and mobile-friendly doxygen page. More information on `m.css` can be
-found on the [m.css project page](https://mcss.mosra.cz/).
+If you only want to see the docs, you can avoid downloading the repo and
+building it by visiting the project
+[website](https://goatshriek.github.io/stumpless/), which has documentation for
+C and C++ for the latest release.
 
 ## Development
 If you wish to develop within the stumpless project itself, you will need a few

--- a/src/config/wel_supported.c
+++ b/src/config/wel_supported.c
@@ -1192,15 +1192,15 @@ stumpless_add_wel_event_source( LPCSTR subkey_name,
                                 LPCSTR param_file,
                                 DWORD types_supported ) {
   DWORD result = ERROR_SUCCESS;
-  DWORD subkey_name_length = 0;
+  int subkey_name_length = 0;
   LPCWSTR subkey_name_w;
-  DWORD source_name_length = 0;
+  int source_name_length = 0;
   LPWSTR source_name_w;
-  DWORD category_file_length = 0;
+  int category_file_length = 0;
   LPCWSTR category_file_w = NULL;
-  DWORD event_file_length = 0;
+  int event_file_length = 0;
   LPCWSTR event_file_w = NULL;
-  DWORD param_file_length = 0;
+  int param_file_length = 0;
   LPCWSTR param_file_w = NULL;
 
   VALIDATE_ARG_NOT_NULL_WINDOWS_RETURN( subkey_name );
@@ -1209,14 +1209,14 @@ stumpless_add_wel_event_source( LPCSTR subkey_name,
   clear_error(  );
 
   subkey_name_w = windows_copy_cstring_to_lpwstr( subkey_name,
-                                                   &subkey_name_length );
+                                                  &subkey_name_length );
   if( !subkey_name_w ) {
     result = get_windows_error_code(  );
     goto finish;
   }
 
   source_name_w = windows_copy_cstring_to_lpwstr( source_name,
-                                                   &source_name_length );
+                                                  &source_name_length );
   if( !source_name_w ) {
     result = get_windows_error_code(  );
     goto cleanup_subkey;
@@ -1224,7 +1224,7 @@ stumpless_add_wel_event_source( LPCSTR subkey_name,
 
   if( category_file ) {
     category_file_w = windows_copy_cstring_to_lpwstr( category_file,
-                                                       &category_file_length );
+                                                      &category_file_length );
     if( !category_file_w ) {
       result = get_windows_error_code(  );
       goto cleanup_source;
@@ -1233,7 +1233,7 @@ stumpless_add_wel_event_source( LPCSTR subkey_name,
 
   if( event_file ) {
     event_file_w = windows_copy_cstring_to_lpwstr( event_file,
-                                                    &event_file_length );
+                                                   &event_file_length );
     if( !event_file_w ) {
       result = get_windows_error_code(  );
       goto cleanup_category;
@@ -1242,7 +1242,7 @@ stumpless_add_wel_event_source( LPCSTR subkey_name,
 
   if( param_file ) {
     param_file_w = windows_copy_cstring_to_lpwstr( param_file,
-                                                    &param_file_length );
+                                                   &param_file_length );
     if( !param_file_w ) {
       result = get_windows_error_code(  );
       goto cleanup_event;


### PR DESCRIPTION
Fixes warnings encountered during MinGW builds due to type mismatches. Also updates the build documentation to include more specific instructions for MinGW platforms.

This partially resolves #318, which can be referenced for more details. It does not fix the build on older versions of MinGW, which will be handled in a separate change if needed.