### PR TITLE
add format checking of param values (#322)

### DIFF
--- a/include/private/config/locale/bg-bg.h
+++ b/include/private/config/locale/bg-bg.h
@@ -123,6 +123,10 @@
 " стойности между 0 и 7 включително"
 
 // todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
+// todo translate
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "target type is incompatible with this operation"
 

--- a/include/private/config/locale/bn-in.h
+++ b/include/private/config/locale/bn-in.h
@@ -122,6 +122,10 @@
 "সংজ্ঞায়িত করা উচিত: 0 এর মধ্যে মান" \
 " এবং 7 সহ"
 
+// todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "টার্গেট টাইপ এই অপারেশনের সাথে বেমানান"
 

--- a/include/private/config/locale/cz-cz.h
+++ b/include/private/config/locale/cz-cz.h
@@ -119,6 +119,10 @@
 " 7 včetně"
 
 // todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
+// todo translate
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "target type is incompatible with this operation"
 

--- a/include/private/config/locale/de-de.h
+++ b/include/private/config/locale/de-de.h
@@ -130,6 +130,10 @@
 "Werte zwischen 0 und einschließlich 7"
 
 // todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
+// todo translate
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "target type is incompatible with this operation"
 

--- a/include/private/config/locale/el-gr.h
+++ b/include/private/config/locale/el-gr.h
@@ -120,6 +120,10 @@
 "οι κωδικοί σοβαρότητας πρέπει να είναι καθορισμένοι με βάση το RFC 5424" \
 " και οι τιμές να είναι στο εύρος 0 έως 7"
 
+// todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
 # define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "ΣΦΑΛΜΑ: ΜΗ ΕΓΚΥΡΟΣ ΤΥΠΟΣ ΣΤΟΧΟΥ"
 

--- a/include/private/config/locale/en-us.h
+++ b/include/private/config/locale/en-us.h
@@ -115,6 +115,9 @@
 "severity codes must be defined in accordance with RFC 5424: values between 0" \
 " and 7 inclusive"
 
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "target type is incompatible with this operation"
 

--- a/include/private/config/locale/es-es.h
+++ b/include/private/config/locale/es-es.h
@@ -119,6 +119,10 @@
 "los códigos de gravedad deben ser definidos de acuerdo al RFC 5424:" \
 " valores entre 0 y 7 inclusive"
 
+// todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "mensaje de error por tipo de objetivo no válido"
 

--- a/include/private/config/locale/fr-fr.h
+++ b/include/private/config/locale/fr-fr.h
@@ -114,6 +114,10 @@
 "les codes de sévérité doivent être définis conformément au RFC 5424:" \
 " valeurs entre 0 et 7 inclus"
 
+// todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "le type de la cible est incompatible avec cette opération"
 

--- a/include/private/config/locale/hi-in.h
+++ b/include/private/config/locale/hi-in.h
@@ -116,6 +116,10 @@
 "गंभीरता कोड को RFC 5424 के अनुसार परिभाषित किया जाना चाहिए: 0 . " \
 "के बीच के मान और 7 समावेशी"
 
+// todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "लक्ष्य प्रकार इस ऑपरेशन के साथ असंगत है"
 

--- a/include/private/config/locale/it-it.h
+++ b/include/private/config/locale/it-it.h
@@ -115,6 +115,10 @@
 "i codici gravità devono essere definiti in osservanza del RFC 5424: tra 0" \
 " e 7, compreso"
 
+// todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "il tipo di target è incompatibile con questa operazione"
 

--- a/include/private/config/locale/pl-pl.h
+++ b/include/private/config/locale/pl-pl.h
@@ -121,6 +121,10 @@
 " wartości pomiędzy 0 a 7 łącznie z"
 
 // todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
+// todo translate
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "target type is incompatible with this operation"
 

--- a/include/private/config/locale/pt-br.h
+++ b/include/private/config/locale/pt-br.h
@@ -115,6 +115,10 @@
 "códigos de gravidade devem ser definidos de acordo com a RFC 5424:" \
 " valores entre 0 e 7, incluso"
 
+// todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "tipo de objetivo é incompatível com esta operação"
 

--- a/include/private/config/locale/sk-sk.h
+++ b/include/private/config/locale/sk-sk.h
@@ -129,6 +129,10 @@
 " 0 a 7 vrátane"
 
 // todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
+// todo translate
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "target type is incompatible with this operation"
 

--- a/include/private/config/locale/sv-se.h
+++ b/include/private/config/locale/sv-se.h
@@ -130,6 +130,10 @@
 "mellan 0 till och med 7"
 
 // todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
+// todo translate
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "target type is incompatible with this operation"
 

--- a/include/private/config/locale/zh-cn.h
+++ b/include/private/config/locale/zh-cn.h
@@ -118,6 +118,10 @@
 #  define L10N_INVALID_SEVERITY_ERROR_MESSAGE \
 "severity代码必须根据RFC 5424定义：值在0~7之间"
 
+// todo translate
+#  define L10N_INVALID_STATE_DURING_UTF8_PARSING \
+"invalid state reached during UTF-8 string parsing"
+
 #  define L10N_INVALID_TARGET_TYPE_ERROR_MESSAGE \
 "目标类型与此操作不兼容"
 

--- a/include/private/validate.h
+++ b/include/private/validate.h
@@ -226,6 +226,19 @@ bool
 validate_param_name_length( const char *str, size_t *length );
 
 /**
+ * Checks that the passed in param value is valid UTF-8 string.
+ *
+ * @param str The param value(string).
+ *
+ * @param length The length of the string to validate.
+ *
+ * @return True if the param name is valid UTF-8 string, otherwise
+ * it will return false and raise STUMPLESS_INVALID_ENCODING error.
+ */
+bool
+validate_param_value( const char *str, size_t length );
+
+/**
  * Checks that the passed in string contains only ASCII characters
  * (33 <= char <= 126).
  *

--- a/include/stumpless/param.h
+++ b/include/stumpless/param.h
@@ -319,7 +319,7 @@ stumpless_load_param( struct stumpless_param *param,
  * @param name The name of the new param. Restricted to printable ASCII
  * characters different from '=', ']' and '"'.
  *
- * @param value The value of the new param.
+ * @param value The value of the new param. The value must be UTF-8 string.
  *
  * @return The created param, if no error is encountered. If an error is
  * encountered, then NULL is returned and an error code set appropriately.
@@ -379,7 +379,7 @@ stumpless_set_param_name( struct stumpless_param *param, const char *name );
  *
  * @param param The param to set the value of.
  *
- * @param value The new name of param.
+ * @param value The new name of param. The value must be UTF-8 string.
  *
  * @return The modified param, if no error is encountered. If an error is
  * encountered, then NULL is returned and an error code is set appropriately.

--- a/src/param.c
+++ b/src/param.c
@@ -123,6 +123,10 @@ stumpless_new_param( const char *name, const char *value ) {
     return NULL;
   }
 
+  if( unlikely( !validate_param_value( value, strlen(value) ) ) ) {
+    return NULL;
+  }
+
   clear_error(  );
 
   param = alloc_mem( sizeof( *param ) );
@@ -170,6 +174,10 @@ stumpless_set_param_value( struct stumpless_param *param, const char *value ) {
 
   VALIDATE_ARG_NOT_NULL( param );
   VALIDATE_ARG_NOT_NULL( value );
+
+  if( unlikely( !validate_param_value( value, strlen(value) ) ) ) {
+    goto fail;
+  }
 
   new_value = copy_cstring_with_length( value, &new_size );
   if( !new_value ) {

--- a/src/validate.c
+++ b/src/validate.c
@@ -134,6 +134,156 @@ validate_param_name_length( const char *name, size_t *length ) {
                                  length );
 }
 
+/**
+ * Validates that a provided string is UTF-8 compliance.
+ *
+ * @param str The string to validate.
+ *
+ * @param length The length of the string.
+ * 
+ * @return True if the string is valid UTF-8 string, otherwise
+ * it will return false and raise STUMPLESS_INVALID_ENCODING error.
+ * 
+ * @note This implementation is ported from the function
+ * TestUTF8Compliance in test/helper/utf8.cpp.
+ */
+static
+bool
+validate_utf8_compliance( const char *str, size_t length ) {
+  enum utf8_state {
+    LEAD_CHAR,
+    TWO_CHAR,
+    THREE_CHAR,
+    FOUR_CHAR,
+    FIVE_CHAR,
+    SIX_CHAR
+  };
+
+  enum utf8_state current_state = LEAD_CHAR;
+  size_t i;
+  size_t char_count;
+  char bytes[6];
+
+  // strip off the BOM if it exists
+  if( length >= 3 && str[0] == '\xef' && str[1] == '\xbb' && str[2] == '\xbf' ) {
+    str += 3;
+    length -= 3;
+  }
+
+  for( i = 0; i < length; i++ ) {
+    #define VALIDATE_CONTINUATION_BYTE( continuation_byte ) \
+      if( ( ( continuation_byte ) & '\xc0' ) != '\x80' ) { \
+        raise_invalid_encoding( L10N_FORMAT_ERROR_MESSAGE( "UTF-8 continuation byte" ) ); \
+        return false; \
+      }
+
+    #define VALIDATE_SHORTEST_FORM( surplus_most_significant_bits ) \
+      if( ( surplus_most_significant_bits ) == 0 ) { \
+        raise_invalid_encoding( L10N_FORMAT_ERROR_MESSAGE( "UTF-8 shortest form" ) ); \
+        return false; \
+      }
+
+    const char c = str[i];
+    switch( current_state ) {
+      case LEAD_CHAR:
+        if( ( c & '\xe0' ) == '\xc0' ) {
+          current_state = TWO_CHAR;
+          bytes[0] = c & '\x1f';
+          break;
+        }
+        if( ( c & '\xf0' ) == '\xe0' ) {
+          current_state = THREE_CHAR;
+          bytes[0] = c & '\x0f';
+          char_count = 1;
+          break;
+        }
+        if( ( c & '\xf8' ) == '\xf0' ) {
+          current_state = FOUR_CHAR;
+          bytes[0] = c & '\x07';
+          char_count = 1;
+          break;
+        }
+        if( ( c & '\xfc' ) == '\xf8' ) {
+          current_state = FIVE_CHAR;
+          bytes[0] = c & '\x03';
+          char_count = 1;
+          break;
+        }
+        if( ( c & '\xfe' ) == '\xfc' ) {
+          current_state = SIX_CHAR;
+          bytes[0] = c & '\x01';
+          char_count = 1;
+          break;
+        }
+        if( ( c & '\x80' ) != 0 ) {
+          raise_invalid_encoding( L10N_FORMAT_ERROR_MESSAGE( "UTF-8 lead byte" ) );
+          return false;
+        }
+        break;
+
+      case TWO_CHAR:
+        VALIDATE_CONTINUATION_BYTE( c );
+        VALIDATE_SHORTEST_FORM( bytes[0] & '\x1e' )
+        current_state = LEAD_CHAR;
+        break;
+
+      case THREE_CHAR:
+        VALIDATE_CONTINUATION_BYTE( c );
+        bytes[char_count] = c & '\x3f';
+        char_count++;
+        if( char_count == 3 ) {
+          VALIDATE_SHORTEST_FORM( bytes[0] | ( bytes[1] & '\x20' ) );
+          current_state = LEAD_CHAR;
+        }
+        break;
+
+      case FOUR_CHAR:
+        VALIDATE_CONTINUATION_BYTE( c );
+        bytes[char_count] = c & '\x3f';
+        char_count++;
+        if( char_count == 4 ) {
+          VALIDATE_SHORTEST_FORM( bytes[0] | ( bytes[1] & '\x30' ) );
+          current_state = LEAD_CHAR;
+        }
+        break;
+
+      case FIVE_CHAR:
+        VALIDATE_CONTINUATION_BYTE( c );
+        bytes[char_count] = c & '\x3f';
+        char_count++;
+        if( char_count == 5 ) {
+          VALIDATE_SHORTEST_FORM( bytes[0] | ( bytes[1] & '\x38' ) );
+          current_state = LEAD_CHAR;
+        }
+        break;
+
+      case SIX_CHAR:
+        VALIDATE_CONTINUATION_BYTE ( c );
+        bytes[char_count] = c & '\x3f';
+        char_count++;
+        if( char_count == 6 ) {
+          VALIDATE_SHORTEST_FORM( bytes[0] | ( bytes[1] & '\x3c' ) );
+          current_state = LEAD_CHAR;
+        }
+        break;
+
+      default:
+        raise_invalid_encoding( L10N_INVALID_STATE_DURING_UTF8_PARSING );
+        return false;
+    }
+
+    #undef VALIDATE_SHORTEST_FORM
+    #undef VALIDATE_CONTINUATION_BYTE
+  }
+
+  return true;
+}
+
+bool
+validate_param_value( const char *str, size_t length ) {
+  return validate_utf8_compliance( str, length );
+}
+
 bool
 validate_printable_ascii( const char *str, size_t length ) {
   size_t i;

--- a/src/validate.c
+++ b/src/validate.c
@@ -155,8 +155,6 @@ validate_utf8_compliance( const char *str, size_t length ) {
     TWO_CHAR,
     THREE_CHAR,
     FOUR_CHAR,
-    FIVE_CHAR,
-    SIX_CHAR
   };
 
   enum utf8_state current_state = LEAD_CHAR;
@@ -203,18 +201,6 @@ validate_utf8_compliance( const char *str, size_t length ) {
           char_count = 1;
           break;
         }
-        if( ( c & '\xfc' ) == '\xf8' ) {
-          current_state = FIVE_CHAR;
-          bytes[0] = c & '\x03';
-          char_count = 1;
-          break;
-        }
-        if( ( c & '\xfe' ) == '\xfc' ) {
-          current_state = SIX_CHAR;
-          bytes[0] = c & '\x01';
-          char_count = 1;
-          break;
-        }
         if( ( c & '\x80' ) != 0 ) {
           raise_invalid_encoding( L10N_FORMAT_ERROR_MESSAGE( "UTF-8 lead byte" ) );
           return false;
@@ -243,26 +229,6 @@ validate_utf8_compliance( const char *str, size_t length ) {
         char_count++;
         if( char_count == 4 ) {
           VALIDATE_SHORTEST_FORM( bytes[0] | ( bytes[1] & '\x30' ) );
-          current_state = LEAD_CHAR;
-        }
-        break;
-
-      case FIVE_CHAR:
-        VALIDATE_CONTINUATION_BYTE( c );
-        bytes[char_count] = c & '\x3f';
-        char_count++;
-        if( char_count == 5 ) {
-          VALIDATE_SHORTEST_FORM( bytes[0] | ( bytes[1] & '\x38' ) );
-          current_state = LEAD_CHAR;
-        }
-        break;
-
-      case SIX_CHAR:
-        VALIDATE_CONTINUATION_BYTE ( c );
-        bytes[char_count] = c & '\x3f';
-        char_count++;
-        if( char_count == 6 ) {
-          VALIDATE_SHORTEST_FORM( bytes[0] | ( bytes[1] & '\x3c' ) );
           current_state = LEAD_CHAR;
         }
         break;

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -556,8 +556,8 @@ namespace {
     // U+2162 U+2264 U+0035(<Roman Numeral Three><Less-Than or Equal To>5)
     const char *original_value = "\xe2\x85\xa2\xe2\x89\xa4\x35";
     const char *retrieved_value;
-    // U+0033 U+002e U+0035 U+33A0(3.5<Square Cm Squared>)
-    const char *new_value = "\x33\x2e\x35\xe3\x8e\xa0";
+    // BOM U+0041 U+0391 U+1d2c U+10ffff(<BOM>A<Alpha><Modifier Letter A><noncharacter>)
+    const char *new_value = "\xef\xbb\xbf\x41\xce\x91\xe1\xb4\xac\xf4\x8f\xbf\xbf";
     const struct stumpless_param *result;
 
     param = stumpless_new_param( "my-name", original_value );


### PR DESCRIPTION
Resolves #322

Adds the validation of param values so that they follow the syslog RFC.
The RFC requires param values to be a valid UTF-8 string.

The UTF-8 validation function is `validate_utf8_compliance` in src/validate.c. It is called by
`stumpless_new_param` and `stumpless_set_param_value` in src/param.c.