### PR TITLE
add stump_str fuzz test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1352,6 +1352,11 @@ if(FUZZ)
     CORPUS_NAME cstring
   )
 
+  add_fuzz_test(stump_str
+    SOURCES ${PROJECT_SOURCE_DIR}/test/fuzz/stump_str.cpp
+    CORPUS_NAME cstring
+  )
+
   add_custom_target(fuzz
     DEPENDS ${STUMPLESS_FUZZ_TESTS}
   )

--- a/test/fuzz/stump_str.cpp
+++ b/test/fuzz/stump_str.cpp
@@ -10,6 +10,7 @@ LLVMFuzzerTestOneInput( const uint8_t *data, size_t size ) {
   char buffer[8192];
   struct stumpless_target *target;
 
+  // Function will send message to the last opened target.
   target = stumpless_open_buffer_target( "fuzzer", buffer, sizeof( buffer ) );
   stump_str( fuzz_str.c_str(  ) );
   stumpless_close_buffer_target( target );

--- a/test/fuzz/stump_str.cpp
+++ b/test/fuzz/stump_str.cpp
@@ -1,0 +1,18 @@
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <stumpless.h>
+
+extern "C"
+int
+LLVMFuzzerTestOneInput( const uint8_t *data, size_t size ) {
+  std::string fuzz_str ( ( char * ) data, size );
+  char buffer[8192];
+  struct stumpless_target *target;
+
+  target = stumpless_open_buffer_target( "fuzzer", buffer, sizeof( buffer ) );
+  stump_str( fuzz_str.c_str(  ) );
+  stumpless_close_buffer_target( target );
+
+  return 0;
+}


### PR DESCRIPTION
Resolving issue: #330 
Added a fuzz test for the stump_str() function in test/fuzz. CMakeLists.txt has been modified to handle the test. 
