### PR TITLE
fix l10n string validation

### DIFF
--- a/include/private/config/locale/bg-bg.h
+++ b/include/private/config/locale/bg-bg.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2020-2022 Joel E. Anderson
+ * Copyright 2020-2023 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,7 +113,8 @@
 
 // todo translate
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
-"a MULTI_SZ registry value was neither empty nor terminated with two NULL"
+"a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
+" characters"
 
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "невалидната тежест"

--- a/include/private/config/locale/bn-in.h
+++ b/include/private/config/locale/bn-in.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2020-2022 Joel E. Anderson
+ * Copyright 2020-2023 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,9 +110,8 @@
 "অসফল " INDEXED_THING " index"
 
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
-"একটি MULTI_SZ রেজিস্ট্রি মান খালি ছিল না"\
-"বা দুটি NULL অক্ষর দিয়ে শেষ করা হয়নি" \
-
+"একটি MULTI_SZ রেজিস্ট্রি মান খালি ছিল না" \
+"বা দুটি NULL অক্ষর দিয়ে শেষ করা হয়নি"
 
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "অসফল severity"

--- a/include/private/config/locale/cz-cz.h
+++ b/include/private/config/locale/cz-cz.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2020-2022 Joel E. Anderson
+ * Copyright 2020-2023 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,7 +109,8 @@
 
 // todo translate
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
-"a MULTI_SZ registry value was neither empty nor terminated with two NULL"
+"a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
+" characters"
 
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "neplatná služba"

--- a/include/private/config/locale/de-de.h
+++ b/include/private/config/locale/de-de.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2020-2022 Joel E. Anderson
+ * Copyright 2020-2023 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,8 @@
 
 // todo translate
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
-"a MULTI_SZ registry value was neither empty nor terminated with two NULL"
+"a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
+" characters"
 
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "Ungültiger Schweregrad"

--- a/include/private/config/locale/el-gr.h
+++ b/include/private/config/locale/el-gr.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
-* Copyright 2020-2022 Joel E. Anderson
+* Copyright 2020-2023 Joel E. Anderson
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -111,7 +111,8 @@
 
 // todo translate
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
-"a MULTI_SZ registry value was neither empty nor terminated with two NULL"
+"a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
+" characters"
 
 # define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "μη έγκυρη σοβαρότητα"

--- a/include/private/config/locale/pl-pl.h
+++ b/include/private/config/locale/pl-pl.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2020-2022 Joel E. Anderson
+ * Copyright 2020-2023 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,8 @@
 
 // todo translate
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
-"a MULTI_SZ registry value was neither empty nor terminated with two NULL"
+"a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
+" characters"
 
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "nieprawidłowa usługa"

--- a/include/private/config/locale/sk-sk.h
+++ b/include/private/config/locale/sk-sk.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2020-2022 Joel E. Anderson
+ * Copyright 2020-2023 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,7 +119,8 @@
 
 // todo translate
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
-"a MULTI_SZ registry value was neither empty nor terminated with two NULL"
+"a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
+" characters"
 
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "neplatná služba"

--- a/include/private/config/locale/sv-se.h
+++ b/include/private/config/locale/sv-se.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2020-2022 Joel E. Anderson
+ * Copyright 2020-2023 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,8 @@
 
 // todo translate
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
-"a MULTI_SZ registry value was neither empty nor terminated with two NULL"
+"a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
+" characters"
 
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "den ogiltiga allvarligheten"

--- a/scripts/check_l10n.rb
+++ b/scripts/check_l10n.rb
@@ -2,7 +2,7 @@
 
 # frozen_string_literal: true
 
-# Copyright 2022 Joel E. Anderson
+# Copyright 2022-2023 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ ARGV.each do |source_glob|
 
       todo = true if line.rstrip.end_with?('// todo translate')
 
-      str_match = line.match(/^L?"(.*)"/)
+      str_match = line.match(/^L?((("(.*)")|\w+| ))/)
       if current_l10n && str_match
         str << str_match[1]
 

--- a/scripts/check_l10n.rb
+++ b/scripts/check_l10n.rb
@@ -45,11 +45,11 @@ ARGV.each do |source_glob|
 
       todo = true if line.rstrip.end_with?('// todo translate')
 
-      str_match = line.match(/^L?((("(.*)")|\w+| ))/)
+      str_match = line.match(/^L?((("(.*)")|\w+| )+)( \\)?/)
       if current_l10n && str_match
         str << str_match[1]
 
-        unless line.end_with?('\\')
+        unless line.rstrip.end_with?('\\')
           if (last_l10n <=> current_l10n) > 0
             errors << "#{source_filename}: #{current_l10n} not defined in alphabetic order"
           end
@@ -64,7 +64,7 @@ ARGV.each do |source_glob|
         end
       end
 
-      define_match = line.match(/#\s*define\s*L10N_(\w*)(\s|\()/)
+      define_match = line.match(/#\s*define\s*L10N_(\w+)( |\()/)
       current_l10n = define_match[1] if define_match
     end
 


### PR DESCRIPTION
Corrects an issue with the localization validation script that could not handle string literal concatenation. This exposed some other standardization issues in localization headers, which this change also corrects.
