### PR TITLE
#361 stumpless_param_to_string format changes

### DIFF
--- a/include/stumpless/element.h
+++ b/include/stumpless/element.h
@@ -369,7 +369,7 @@ stumpless_element_has_param( const struct stumpless_element *element,
  *
  * @param element The element to get the name and params from.
  *
- * @return The formatted string of <name> or <name>:[param1,...] if no error is encountered.
+ * @return The formatted string of name or name=[param1,...] if no error is encountered.
  * If an error is  encountered, then NULL is returned and an error code is set appropriately.
  */
 STUMPLESS_PUBLIC_FUNCTION

--- a/include/stumpless/param.h
+++ b/include/stumpless/param.h
@@ -411,7 +411,7 @@ stumpless_set_param_value( struct stumpless_param *param, const char *value );
  *
  * @param param The param to get the name and the value from.
  *
- * @return The formatted string of "param_name: param_value" if no error is
+ * @return The formatted string of "param_name=param_value" if no error is
  * encountered. If an error is  encountered, then NULL is returned and an
  * error code is set appropriately.
  */

--- a/src/param.c
+++ b/src/param.c
@@ -215,23 +215,31 @@ stumpless_param_to_string( const struct stumpless_param *param ) {
     name_len = param->name_length;
     value_len = param->value_length;
 
-    /* <name>:<value> */
-    format = alloc_mem( value_len + name_len + 6 );
+    // /* <name>:<value> */
+    /* name="value"*/
+    format = alloc_mem( value_len + name_len + 4 );
     if( !format ) {
       goto fail;
     }
 
-    memcpy(format + 1, name, name_len);
-    memcpy(format + name_len + 4, value, value_len);
+    // memcpy(format + 1, name, name_len);
+    // memcpy(format + name_len + 4, value, value_len);
+    memcpy(format, name, name_len);
+    memcpy(format + name_len + 2, value, value_len);
 
     unlock_param( param );
 
-    format[0] = '<';
-    format[name_len + 1] = '>';
-    format[name_len + 2] = ':';
-    format[name_len + 3] = '<';
-    format[name_len + value_len + 4] = '>';
-    format[name_len + value_len + 5] = '\0';
+    // format[0] = '<';
+    // format[name_len + 1] = '>';
+    // format[name_len + 2] = ':';
+    // format[name_len + 3] = '<';
+    // format[name_len + value_len + 4] = '>';
+    // format[name_len + value_len + 5] = '\0';
+
+    format[name_len ] = '=';
+    format[name_len + 1] = '\"';
+    format[name_len + value_len + 2] = '"';
+    format[name_len + value_len + 3] = '\0'
 
 
     clear_error( );

--- a/src/param.c
+++ b/src/param.c
@@ -215,26 +215,17 @@ stumpless_param_to_string( const struct stumpless_param *param ) {
     name_len = param->name_length;
     value_len = param->value_length;
 
-    // /* <name>:<value> */
     /* name="value"*/
     format = alloc_mem( value_len + name_len + 4 );
     if( !format ) {
       goto fail;
     }
 
-    // memcpy(format + 1, name, name_len);
-    // memcpy(format + name_len + 4, value, value_len);
+  
     memcpy(format, name, name_len);
     memcpy(format + name_len + 2, value, value_len);
 
     unlock_param( param );
-
-    // format[0] = '<';
-    // format[name_len + 1] = '>';
-    // format[name_len + 2] = ':';
-    // format[name_len + 3] = '<';
-    // format[name_len + value_len + 4] = '>';
-    // format[name_len + value_len + 5] = '\0';
 
     format[name_len ] = '=';
     format[name_len + 1] = '\"';

--- a/src/param.c
+++ b/src/param.c
@@ -238,8 +238,8 @@ stumpless_param_to_string( const struct stumpless_param *param ) {
 
     format[name_len ] = '=';
     format[name_len + 1] = '\"';
-    format[name_len + value_len + 2] = '"';
-    format[name_len + value_len + 3] = '\0'
+    format[name_len + value_len + 2] = '\"';
+    format[name_len + value_len + 3] = '\0';
 
 
     clear_error( );

--- a/test/function/element.cpp
+++ b/test/function/element.cpp
@@ -808,7 +808,7 @@ namespace {
     format = stumpless_element_to_string( element_with_params );
     ASSERT_NOT_NULL( format );
 
-    EXPECT_STREQ( format, "<element-with-params>:[<param-1>:<value-1>,<param-2>:<value-2>]" );
+    EXPECT_STREQ( format, "<element-with-params>:[param-1=\"value-1\",param-2=\"value-2\"]" );
     EXPECT_NO_ERROR;
 
     free( ( void * ) format );

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -174,7 +174,7 @@ namespace {
       format = stumpless_param_to_string( &basic_param );
       ASSERT_NOT_NULL( format );
 
-      EXPECT_STREQ( format, "<basic-name>:<basic-value>" );
+      EXPECT_STREQ( format, "basic-name=\"basic-value\"" );
       EXPECT_NO_ERROR;
 
       free( ( void * ) format );


### PR DESCRIPTION
Have made changes to the files requested in the issue#361. The format for `stumpless_param_to_string` has been changed and test run successfully.
