### PR TITLE
Add stumpless_new_param_from_string function

### DIFF
--- a/include/private/config/locale/bg-bg.h
+++ b/include/private/config/locale/bg-bg.h
@@ -116,6 +116,10 @@
 "a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
 " characters"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "невалидната тежест"
 

--- a/include/private/config/locale/bn-in.h
+++ b/include/private/config/locale/bn-in.h
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-#ifndef __STUMPLESS_PRIVATE_CONFIG_LOCALE_EN_US_H
-#  define __STUMPLESS_PRIVATE_CONFIG_LOCALE_EN_US_H
+#ifndef __STUMPLESS_PRIVATE_CONFIG_LOCALE_BN_IN_H
+#  define __STUMPLESS_PRIVATE_CONFIG_LOCALE_BN_IN_H
 
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "স্থানীয় ইউনিক্স সকেটের"\
@@ -112,6 +112,10 @@
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
 "একটি MULTI_SZ রেজিস্ট্রি মান খালি ছিল না" \
 "বা দুটি NULL অক্ষর দিয়ে শেষ করা হয়নি"
+
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
 
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "অসফল severity"
@@ -259,4 +263,4 @@ L"উইন্ডোজ ইভেন্ট লগ সোর্সের স্�
 #  define L10N_WSAGETLASTERROR_ERROR_CODE_TYPE \
 "ব্যর্থ কলের পরে WSAGEtLastError এর ফলাফল"
 
-#endif /* __STUMPLESS_PRIVATE_CONFIG_LOCALE_BN_IN_H */
+#endif  /* __STUMPLESS_PRIVATE_CONFIG_LOCALE_BN_IN_H */

--- a/include/private/config/locale/cz-cz.h
+++ b/include/private/config/locale/cz-cz.h
@@ -112,6 +112,10 @@
 "a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
 " characters"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "neplatná služba"
 
@@ -268,4 +272,4 @@ L"Stumpless registration of Windows Event Log Source"
 #  define L10N_WSAGETLASTERROR_ERROR_CODE_TYPE \
 "výsledek WSAGetLastError po selhání volání"
 
-#endif //STUMPLESS_CZ_CZ_H
+#endif  /* __STUMPLESS_PRIVATE_CONFIG_LOCALE_CZ_CZ_H */

--- a/include/private/config/locale/da-dk.h
+++ b/include/private/config/locale/da-dk.h
@@ -108,6 +108,10 @@
 "en MULTI_SZ registreringsdatabase værdi var hverken tom eller Afsluttet " \
 " characters med to NULL's"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "den ugyldige alvorlighed"
 

--- a/include/private/config/locale/de-de.h
+++ b/include/private/config/locale/de-de.h
@@ -123,6 +123,10 @@
 "a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
 " characters"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "Ungültiger Schweregrad"
 

--- a/include/private/config/locale/el-gr.h
+++ b/include/private/config/locale/el-gr.h
@@ -114,6 +114,10 @@
 "a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
 " characters"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 # define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "μη έγκυρη σοβαρότητα"
 
@@ -271,4 +275,4 @@ L"Stumpless registration of Windows Event Log Source"
 # define L10N_WSAGETLASTERROR_ERROR_CODE_TYPE \
 "το αποτέλεσμα της WSAGetLastError εφόσον απότυχε η κλήση της συνάρτησης"
 
-#endif /* __STUMPLESS_PRIVATE_CONFIG_LOCALE_EN_US_H */
+#endif /* __STUMPLESS_PRIVATE_CONFIG_LOCALE_EL_GR_H */

--- a/include/private/config/locale/en-us.h
+++ b/include/private/config/locale/en-us.h
@@ -112,6 +112,9 @@
 "a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
 " characters"
 
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "the invalid severity"
 

--- a/include/private/config/locale/es-es.h
+++ b/include/private/config/locale/es-es.h
@@ -108,6 +108,10 @@
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
 "un valor de registro MULTI_SZ no estaba ni vacío ni terminado con dos NULL"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "la gravedad inválida"
 
@@ -253,4 +257,4 @@ L"registro de Stumpless del Registro de Eventos de Windows"
 #  define L10N_WSAGETLASTERROR_ERROR_CODE_TYPE \
 "el resultado de WSAGetLastError despues que la llamada fallara"
 
-#endif /* __STUMPLESS_PRIVATE_CONFIG_LOCALE_ES_ES_H */
+#endif /*  __STUMPLESS_PRIVATE_CONFIG_LOCALE_ES_ES_H */

--- a/include/private/config/locale/fr-fr.h
+++ b/include/private/config/locale/fr-fr.h
@@ -107,6 +107,10 @@
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
 "la valeur d'un registre MULTI_SZ n'était ni vide ni terminée par deux NULL"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "la sévérité invalide"
 

--- a/include/private/config/locale/he-il.h
+++ b/include/private/config/locale/he-il.h
@@ -110,6 +110,10 @@
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
 "NULL לא היה ריק ולא הסתיים עם שני תווי MULTI_SZ ערך רישום של"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "שאינו חוקי Severity-ה"
 

--- a/include/private/config/locale/hi-in.h
+++ b/include/private/config/locale/hi-in.h
@@ -109,6 +109,10 @@
 "एक MULTI_SZ रजिस्ट्री मान न तो खाली था और न ही दो NULL" \
 " अक्षर "
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "अमान्य गंभीरता"
 

--- a/include/private/config/locale/it-it.h
+++ b/include/private/config/locale/it-it.h
@@ -108,6 +108,10 @@
 "un valore MULTI_SZ nel registro non è nè vuoto nè terminato con due" \
 " caratteri nullo"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "gravità non valida"
 

--- a/include/private/config/locale/pl-pl.h
+++ b/include/private/config/locale/pl-pl.h
@@ -114,6 +114,10 @@
 "a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
 " characters"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "nieprawidłowa usługa"
 
@@ -271,4 +275,4 @@ L"Stumpless registration of Windows Event Log Source"
 #  define L10N_WSAGETLASTERROR_ERROR_CODE_TYPE \
 "wynik WSAGetLastError po niepowodzeniu połączenia"
 
-#endif //STUMPLESS_PL_PL_H
+#endif /* __STUMPLESS_PRIVATE_CONFIG_LOCALE_PL_PL_H */

--- a/include/private/config/locale/pt-br.h
+++ b/include/private/config/locale/pt-br.h
@@ -108,6 +108,10 @@
 "um valor de registro MULTI_SZ não estava nem vazio nem finalizado" \
 "com dois caracteres NULL"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "a gravidade inválida"
 
@@ -253,4 +257,4 @@ L"Registro do Stumpless no Windows Event Log Source"
 #  define L10N_WSAGETLASTERROR_ERROR_CODE_TYPE \
 "o resultado de WSAGetLastError depois da chamada com erro"
 
-#endif /* __STUMPLESS_PRIVATE_CONFIG_LOCALE_EN_US_H */
+#endif /* __STUMPLESS_PRIVATE_CONFIG_LOCALE_PT_BR_H */

--- a/include/private/config/locale/sk-sk.h
+++ b/include/private/config/locale/sk-sk.h
@@ -122,6 +122,10 @@
 "a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
 " characters"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "neplatná služba"
 
@@ -284,4 +288,4 @@ L"Stumpless registration of Windows Event Log Source"
 #  define L10N_WSAGETLASTERROR_ERROR_CODE_TYPE \
 "výsledok WSAGetLastError po zlyhaní volania"
 
-#endif //STUMPLESS_SK_SK_H
+#endif /* __STUMPLESS_PRIVATE_CONFIG_LOCALE_SK_SK_H */

--- a/include/private/config/locale/sv-se.h
+++ b/include/private/config/locale/sv-se.h
@@ -123,6 +123,10 @@
 "a MULTI_SZ registry value was neither empty nor terminated with two NULL" \
 " characters"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "den ogiltiga allvarligheten"
 

--- a/include/private/config/locale/sw-ke.h
+++ b/include/private/config/locale/sw-ke.h
@@ -112,6 +112,10 @@
 "thamani ya usajili wa MULTI_SZ haikuwa tupu wala haikumalizika na herufi" \
 " mbili za NULL"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "ukali batili"
 

--- a/include/private/config/locale/zh-cn.h
+++ b/include/private/config/locale/zh-cn.h
@@ -112,6 +112,10 @@
 #  define L10N_INVALID_MULTI_SZ_ERROR_MESSAGE \
 "MULTI_SZ注册表值既不为空，也不以两个NULL字符结束"
 
+// todo translate
+#  define L10N_INVALID_PARAM_ERROR_MESSAGE \
+"the string is not of the name=\"value\" format"
+
 #  define L10N_INVALID_SEVERITY_ERROR_CODE_TYPE \
 "severity无效"
 

--- a/include/private/error.h
+++ b/include/private/error.h
@@ -147,6 +147,10 @@ raise_invalid_id( void );
 
 COLD_FUNCTION
 void
+raise_invalid_param( void );
+
+COLD_FUNCTION
+void
 raise_invalid_severity( int severity );
 
 COLD_FUNCTION

--- a/include/stumpless/error.h
+++ b/include/stumpless/error.h
@@ -126,8 +126,13 @@ extern "C" {
  *
  * @since release v2.1.0
  */\
-  ERROR( STUMPLESS_WINDOWS_FAILURE, 28 )
-
+  ERROR( STUMPLESS_WINDOWS_FAILURE, 28 ) \
+/**
+ * The format of the given string is incorrect.
+ *
+ * @since release v2.2.0
+ */\
+  ERROR( STUMPLESS_INVALID_PARAM_STRING, 29 )
 
 /**
  * An (enum) identifier of the types of errors that might be encountered.

--- a/include/stumpless/param.h
+++ b/include/stumpless/param.h
@@ -329,6 +329,34 @@ struct stumpless_param *
 stumpless_new_param( const char *name, const char *value );
 
 /**
+ * Creates a new param given a string by parsing the string and calling stumpless_new_param.
+ *
+ * **Thread Safety: MT-Safe
+ * This function is thread safe, assuming the the given string is not changed
+ * by other threads during execution.
+ *
+ * **Async Signal Safety: AS-Unsafe heap**
+ * This function is not safe to call from signal handlers since it calls
+ * stumpless_new_param() which has usage of memory management functions.
+ *
+ * **Async Cancel Safety: AC_Unsafe heap**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, since it calls stumpless_new_param() which has usage of
+ * memory management functions.
+ *
+ * @since release v2.2.0
+ *
+ * @param string The string to create the stumpless_param from.
+ *
+ * @return The created param, if no error is encountered. If an error is
+ * encountered, NULL is returned and an error code set appropriately.
+ */
+  
+STUMPLESS_PUBLIC_FUNCTION
+struct stumpless_param *
+stumpless_new_param_from_string( const char *string );
+
+/**
  * Sets the name of the given param.
  *
  * **Thread Safety: MT-Safe**

--- a/src/error.c
+++ b/src/error.c
@@ -399,3 +399,11 @@ write_to_error_stream( const char *msg, size_t msg_size ) {
 
   config_write_bool( &error_stream_free, true );
 }
+
+void
+raise_invalid_param( void ) {
+  raise_error( STUMPLESS_INVALID_PARAM_STRING,
+               L10N_INVALID_PARAM_ERROR_MESSAGE,
+               0,
+               NULL );
+}

--- a/src/param.c
+++ b/src/param.c
@@ -143,6 +143,76 @@ stumpless_new_param( const char *name, const char *value ) {
 }
 
 struct stumpless_param *
+stumpless_new_param_from_string( const char *string ) {
+  
+  VALIDATE_ARG_NOT_NULL( string );
+
+  int i;
+  size_t name_len = 0;
+  size_t name_start = 0;
+  size_t value_len = 0;
+  size_t value_start = 0;
+  char *name;
+  char *value;
+  struct stumpless_param *result;
+
+  /* Check that the characters in 'name' are allowed. */
+  for (i = 0; string[i] != '='; i++) {
+    if (!((string[i] >= 'a' && string[i] <= 'z') ||
+	  (string[i] >= 'A' && string[i] <= 'Z') ||
+	  (string[i] >= '0' && string[i] <= '9') ||
+	  (string[i] == '-') ||
+	  (string[i] == '.') ||
+	  (string[i] == '_'))){
+      raise_invalid_param(  );
+      return NULL;
+    }
+  }
+  
+  /* Check if the character after the '=' is '"', else raise an error. */
+  if (string[i + 1] != '"'){
+    raise_invalid_param(  );
+    return NULL;
+  }
+
+  name_len = i;
+  /* We add 1 to the length for the '\0' character. */
+  name = alloc_mem( name_len + 1 );
+  /* We make this addition to skip '=' and '"' characters. */
+  i += 2;
+  value_start = i;
+
+  /* Iterate to the end of the 'value' string. */
+  //for (; string[i] != '\0'; i++){}
+  while (string[i] != '\0'){
+    i++;
+  }
+  /* If the final character isn't '"' we raise an error. */
+  if (string[i - 1] != '"') {
+    raise_invalid_param(  );
+    /* We need to free name here to avoid memory leaks */
+    free_mem( name );
+    return NULL;
+  } else {
+    /* We make this substraction for the 2 '"' characters and for the '=' character. */
+    value_len = i - name_len - 3;
+  }
+  
+  /* We add 1 to the length for the '\0' character. */
+  value = alloc_mem( value_len + 1 );
+  
+  memcpy(name, string + name_start, name_len);
+  name[name_len] = '\0';
+  memcpy(value, string + value_start, value_len);
+  value[value_len] = '\0';
+  result = stumpless_new_param(name, value);
+  free_mem( name );
+  free_mem( value );
+  
+  return result;
+}
+
+struct stumpless_param *
 stumpless_set_param_name( struct stumpless_param *param, const char *name ) {
   size_t new_size;
 

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -212,10 +212,11 @@ EXPORTS
   stumpless_set_entry_hostname                  @197
 
 ; added in v2.2.0
-  stumpless_load_element                        @198
-  stumpless_load_entry                          @199
-  stumpless_load_entry_str                      @200
-  stumpless_load_param                          @201
+  stumpless_new_param_from_string               @198
+  stumpless_load_element                        @199
+  stumpless_load_entry                          @200
+  stumpless_load_entry_str                      @201
+  stumpless_load_param                          @202
   stumpless_unload_element_and_contents         @203
   stumpless_unload_element_only                 @204
   stumpless_unload_entry_and_contents           @205

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -628,4 +628,90 @@ namespace {
 
     stumpless_free_all(  );
   }
+
+  TEST( ParamFromStringTest, New ) {
+    struct stumpless_param *param;
+    const char *param_string = "test-param-name=\"test-param-value\"";
+
+    size_t name_length = strlen("test-param-name");
+    size_t value_length = strlen("test-param-value");
+
+    param = stumpless_new_param_from_string( param_string );
+    ASSERT_NOT_NULL( param );
+    EXPECT_NO_ERROR;
+
+    ASSERT_EQ( name_length, param->name_length );
+    ASSERT_NOT_NULL( param->name );
+    ASSERT_EQ( 0, memcmp( param->name, "test-param-name", name_length ) );
+
+    ASSERT_EQ( value_length, param->value_length );
+    ASSERT_NOT_NULL( param->value );
+    ASSERT_EQ( 0, memcmp( param->value, "test-param-value", value_length ) );
+
+    stumpless_destroy_param( param );
+
+    stumpless_free_all(  );
+  }
+
+  TEST( ParamFromStringTest, NullName ) {
+    struct stumpless_param *param;
+    const struct stumpless_error *error;
+    
+    param = stumpless_new_param_from_string( NULL );
+
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+
+    stumpless_destroy_param( param );
+
+    stumpless_free_all(  );
+  }
+
+  TEST( ParamFromStringTest, InvalidName ) {
+    struct stumpless_param *param;
+    const struct stumpless_error *error;
+    
+    param = stumpless_new_param_from_string( "test-param-na=me=\"test-param-value\"" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_PARAM_STRING );
+    
+    param = stumpless_new_param_from_string( "test-param-name\"test-param-value\"" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_PARAM_STRING );
+
+    param = stumpless_new_param_from_string( "test-param]-name=\"test-value\"" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_PARAM_STRING );
+
+    param = stumpless_new_param_from_string( "test-p\"aram-name=\"test-value\"" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_PARAM_STRING );
+
+    param = stumpless_new_param_from_string( "!test-param-name=\"test-value\"" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_PARAM_STRING );
+
+    param = stumpless_new_param_from_string( "test-param,name=\"test-value\"" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_PARAM_STRING );
+
+    param = stumpless_new_param_from_string( "test-param-name%%=\"test-value\"" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_PARAM_STRING );
+
+    param = stumpless_new_param_from_string( "test-param-name==\"test-value\"" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_PARAM_STRING );
+        
+    param = stumpless_new_param_from_string( "test-param-name=\"test-value" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_PARAM_STRING );
+
+    param = stumpless_new_param_from_string( "" );
+    EXPECT_NULL( param );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_PARAM_STRING );
+
+    stumpless_destroy_param( param );
+
+    stumpless_free_all(  );
+  }
 }


### PR DESCRIPTION
This function takes a string with a specific format and returns a 'param' struct.
The commit also contains error handling and tests for success and failure cases.

This PR is in regards to issue #360.