### PR TITLE
Added benchmark for stumpless_param_from_string

### DIFF
--- a/test/performance/param.cpp
+++ b/test/performance/param.cpp
@@ -24,6 +24,25 @@ NEW_MEMORY_COUNTER( copy_param )
 NEW_MEMORY_COUNTER( load_param )
 NEW_MEMORY_COUNTER( new_param )
 NEW_MEMORY_COUNTER( set_param_name )
+NEW_MEMORY_COUNTER( from_string )
+
+static void FromString(benchmark::State& state) {
+  const char *param = "test-param-name=\"test-param-value\"";
+  struct stumpless_param *result;
+
+  INIT_MEMORY_COUNTER( from_string );
+
+  for (auto _ : state) {
+    result = stumpless_new_param_from_string(param);
+    if (!result) {
+      state.SkipWithError("could not create a new param from string");
+    }
+
+    stumpless_destroy_param(result);
+  }
+
+  SET_STATE_COUNTERS(state, from_string);
+}
 
 static void CopyParam(benchmark::State& state){
   struct stumpless_param *param;
@@ -115,3 +134,4 @@ BENCHMARK(CopyParam);
 BENCHMARK(LoadParam);
 BENCHMARK(NewParam);
 BENCHMARK(SetParamName);
+BENCHMARK(FromString);


### PR DESCRIPTION
This fixes https://github.com/goatshriek/stumpless/issues/374 

![image](https://github.com/goatshriek/stumpless/assets/54947026/1643432f-e1a9-4a1f-96c1-e2fd39c46a6e)


Make sure that your pull request follows the guidelines specified in the
[Guidelines for Contributing](../docs/CONTRIBUTING.md). 
