### PR TITLE
Document Undocumented Functions in entry.h for Issue #371

### DIFF
--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -300,6 +300,7 @@ unchecked_unload_entry( const struct stumpless_entry *entry );
  * Note (to delete before merge) : i'm concern this comment is not 100% accurate,
  * i have some difficulties to understand the config_unlock_mutex macro
  * if it does something or not
+ * (implement thread safety #136)
  * 
  * Unlocks the mutex of a given entry.
  * 

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -180,6 +180,32 @@ struct strbuilder *
 strbuilder_append_message( struct strbuilder *builder,
                            const struct stumpless_entry *entry );
 
+/**
+ * Appends the process ID to the string builder.
+ *
+ * This function gets the current process ID using `config_getpid` and appends
+ * it to the provided string builder object. It is useful for adding process
+ * identification information to a string being constructed.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread-safe as it does not modify shared data and relies
+ * on thread-safe underlying functions.
+ *
+ * **Async Signal Safety: AS-Unsafe**
+ * This function is not safe to call from asynchronous signal handlers as it
+ * relies on functions that may not be async-signal-safe.
+ *
+ * **Async Cancel Safety: AC-Unsafe**
+ * The function is not safe in the context of asynchronous cancellation due to
+ * potential resource cleanup issues.
+ *
+ * @since release v1.0.0
+ *
+ * @param builder A pointer to the string builder to which the process ID is appended.
+ *                Must not be NULL.
+ *
+ * @return The string builder with the process ID appended, or NULL if an error occurs.
+ */
 struct strbuilder *
 strbuilder_append_procid( struct strbuilder *builder );
 

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -122,27 +122,27 @@ locked_add_element( struct stumpless_entry *entry,
                     struct stumpless_element *element );
 
 /**
- * Retrieves an element by name from a Stumpless entry, ensuring thread safety.
+ * Retrieves an element by index from a Stumpless entry, assuming external thread safety management.
  *
- * This function searches for an element within the given entry by its name.
- * It locks each element during comparison to ensure thread safety. If the
- * element with the specified name is found, it is returned.
+ * This function locates an element within the provided entry using its index.
+ * It does not manage thread safety internally but assumes that the calling function
+ * has already acquired the necessary locks on the entry.
  *
- * **Thread Safety: MT-Safe**
- * This function is thread-safe as it locks individual elements during the search process.
+ * **Thread Safety: MT-Unsafe**
+ * The function is not inherently thread-safe and relies on the caller to manage thread safety.
  *
  * **Async Signal Safety: AS-Unsafe**
- * Unsafe to call from asynchronous signal handlers due to lock manipulation.
+ * Not safe to call from asynchronous signal handlers due to potential shared data access.
  *
  * **Async Cancel Safety: AC-Unsafe**
- * Not safe in contexts of asynchronous cancellation, as it might involve lock manipulation.
+ * Not safe in contexts of asynchronous cancellation, as it might involve unsafe data access.
  *
  * @since release 2.0.0
-  *
- * @param entry The entry containing the elements to search through. Must not be NULL.
- * @param name The name of the element to find. Must be a NULL-terminated string.
  *
- * @return A pointer to the found element, or NULL if not found or an error occurs.
+ * @param entry The entry containing the elements. Must not be NULL.
+ * @param index The index of the element to retrieve.
+ *
+ * @return A pointer to the element at the specified index, or NULL if not found or in case of an error.
  */
 struct stumpless_element *
 locked_get_element_by_index( const struct stumpless_entry *entry,
@@ -533,18 +533,22 @@ unchecked_unload_entry( const struct stumpless_entry *entry );
 /**
  * Unlocks the mutex of a given entry.
  *
- * This function is used internally to ensure that the mutex of an entry
- * is properly unlocked after operations that required synchronization are
- * completed. It uses the config_unlock_unchecked_entry_has_element
+ * This function is used internally to unlock the mutex of an entry after
+ * operations requiring synchronization are completed. It is part of the internal
+ * locking mechanism and relies on the `config_unlock_mutex` macro.
+ *
+ * **Thread Safety: MT-Unsafe**
+ * This function is not thread-safe as it manipulates mutexes without additional safety checks.
+ *
+ * **Async Signal Safety: AS-Unsafe**
+ * Not safe to call from signal handlers as it involves mutex operations which are not async-signal-safe.
+ *
  * **Async Cancel Safety: AC-Unsafe**
- * This function is not safe to call from threads that may be asynchronously
- * cancelled, as the cleanup of the lock may not be completed if a cancellation
- * request is received during execution.
+ * Not safe to call from threads that may be asynchronously cancelled, as the lock might not be properly released.
  *
  * @since release v2.0.0
  *
- * @param entry The entry whose mutex is to be unlocked. The entry must not
- *              be NULL, and it must have a valid mutex initialized.
+ * @param entry The entry whose mutex is to be unlocked. Must not be NULL and must have an initialized mutex.
  */
 void
 unlock_entry( const struct stumpless_entry *entry );

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -29,7 +29,7 @@
 
 /**
  * Frees entry cache
- *
+ *stumpless_entry
  * **Thread Safety: MT-Unsafe**
  * This function is not thread safe as it destroys resources(entry cache)
  * that other threads can use.
@@ -296,6 +296,37 @@ unchecked_load_entry( struct stumpless_entry *entry,
 void
 unchecked_unload_entry( const struct stumpless_entry *entry );
 
+/**
+ * Note (to delete before merge) : i'm concern this comment is not 100% accurate,
+ * i have some difficulties to understand the config_unlock_mutex macro
+ * if it does something or not
+ * 
+ * Unlocks the mutex of a given entry.
+ * 
+ * This function is used internally to ensure that the mutex of an entry
+ * is properly unlocked after operations that required synchronization are
+ * completed. It uses the config_unlock_mutex macro to perform the actual
+ * unlocking.
+ *
+ * **Thread Safety: MT-Unsafe**
+ * This function is not thread-safe as it directly manipulates the mutex
+ * of the entry. The caller must ensure that this function is not called
+ * concurrently with other functions that might be modifying the same entry.
+ *
+ * **Async Signal Safety: AS-Unsafe**
+ * This function is not safe to call from asynchronous signal handlers as it
+ * involves lock manipulation which is not async-signal-safe.
+ *
+ * **Async Cancel Safety: AC-Unsafe**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, as the cleanup of the lock may not be completed if a cancellation
+ * request is received during execution.
+ * 
+ * @since release v2.0.0
+ * 
+ * @param entry The entry whose mutex is to be unlocked. The entry must not
+ *              be NULL, and it must have a valid mutex initialized.
+ */
 void
 unlock_entry( const struct stumpless_entry *entry );
 

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -531,18 +531,7 @@ unchecked_unload_entry( const struct stumpless_entry *entry );
  * 
  * This function is used internally to ensure that the mutex of an entry
  * is properly unlocked after operations that required synchronization are
- * completed. It uses the config_unlock_mutex macro to perform the actual
- * unlocking.
- *
- * **Thread Safety: MT-Unsafe**
- * This function is not thread-safe as it directly manipulates the mutex
- * of the entry. The caller must ensure that this function is not called
- * concurrently with other functions that might be modifying the same entry.
- *
- * **Async Signal Safety: AS-Unsafe**
- * This function is not safe to call from asynchronous signal handlers as it
- * involves lock manipulation which is not async-signal-safe.
- *
+ * completed. It uses the config_unlock_unchecked_entry_has_element
  * **Async Cancel Safety: AC-Unsafe**
  * This function is not safe to call from threads that may be asynchronously
  * cancelled, as the cleanup of the lock may not be completed if a cancellation

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -147,9 +147,34 @@ locked_get_element_by_name( const struct stumpless_entry *entry,
                             const char *name );
 
 /**
- * Creates a new entry with the given parameters.
+ * Creates a new Stumpless entry with specified parameters.
  *
- * @since release v2.1.0.
+ * This function allocates a new entry and initializes it with the provided facility,
+ * severity, application name, message ID, and message. It uses internal cache
+ * mechanisms for memory management and performs necessary validations and initializations.
+ *
+ * **Thread Safety: MT-Unsafe**
+ * This function is not thread-safe as it involves memory allocation and modification of
+ * shared resources without synchronization.
+ *
+ * **Async Signal Safety: AS-Unsafe**
+ * Unsafe to call from asynchronous signal handlers due to memory allocation and
+ * manipulation operations.
+ *
+ * **Async Cancel Safety: AC-Unsafe**
+ * Not safe in contexts of asynchronous cancellation, as it might leave allocated
+ * resources in an inconsistent state.
+ *
+ * @since release v2.1.0
+ *
+ * @param facility The facility code for the entry.
+ * @param severity The severity code for the entry.
+ * @param app_name The application name for the entry. Can be NULL.
+ * @param msgid The message ID for the entry. Can be NULL.
+ * @param message The message for the entry. Can be NULL.
+ * @param message_length The length of the message.
+ *
+ * @return A pointer to the newly created entry, or NULL if an error occurs.
  */
 struct stumpless_entry *
 new_entry( enum stumpless_facility facility,

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -182,9 +182,7 @@ locked_get_element_by_name( const struct stumpless_entry *entry,
  * Allocates a new entry and initializes it with the provided facility,
  * severity, application name, message ID, and message. It assumes that memory
  * allocation (e.g., for the entry itself and string copies) is thread-safe as
- * provided by the system's standard library.
- *
- * **Thread Safety: MT-Safe race:app_name race:msgid race:message**
+ * provided by the system's standard librarylock_entryace:msgid race:message**
  * This function is considered thread-safe under the condition that the string
  * parameters (app_name, msgid, message) are not concurrently modified. The entry
  * itself is a new, unshared resource, thus it is safe to modify in this context.
@@ -265,7 +263,7 @@ strbuilder_append_app_name( struct strbuilder *builder,
  * involves system calls and memory manipulation.
  *
  * **Async Cancel Safety: AC-Unsafe**
- * Not safe for use in contexts of asynchronous cancellation due to potential
+ * Not safe for use in contexts of asynchronolock_entryus cancellation due to potential
  * system call interruption and memory state inconsistency.
  *
  * @since release 1.0.0
@@ -346,11 +344,7 @@ strbuilder_append_message( struct strbuilder *builder,
  * Appends the process ID to the string builder.
  *
  * This function gets the current process ID using `config_getpid` and appends
- * it to the provided string builder object. It is useful for adding process
- * identification information to a string being constructed.
- *
- * **Thread Safety: MT-Safe**
- * This function is thread-safe as it does not modify shared data and relies
+ * it to the provided string builder object. It lock_entry modify shared data and relies
  * on thread-safe underlying functions.
  *
  * **Async Signal Safety: AS-Unsafe**
@@ -419,8 +413,7 @@ strbuilder_append_structured_data( struct strbuilder *builder,
  * Not safe in the context of asynchronous cancellation due to potential resource
  * cleanup issues.
  *
- * @since release v1.5.0
- *
+ * @since release v1.5.0lock_entry
  * @param entry A pointer to the entry to be destroyed. Must not be NULL.
  */
 void
@@ -533,24 +526,25 @@ unchecked_unload_entry( const struct stumpless_entry *entry );
 /**
  * Unlocks the mutex of a given entry.
  *
- * This function is used internally to unlock the mutex of an entry after
- * operations requiring synchronization are completed. It is part of the internal
- * locking mechanism and relies on the `config_unlock_mutex` macro.
- *
- * **Thread Safety: MT-Unsafe**
- * This function is not thread-safe as it manipulates mutexes without additional safety checks.
+ * **Thread Safety: MT-Safe**
+ * This function is thread-safe as it properly releases a mutex, allowing for safe
+ * concurrent access to shared resources.
  *
  * **Async Signal Safety: AS-Unsafe**
- * Not safe to call from signal handlers as it involves mutex operations which are not async-signal-safe.
+ * Since mutex operations are not safe in signal handlers, this function is also
+ * considered unsafe for asynchronous signal handling.
  *
  * **Async Cancel Safety: AC-Unsafe**
- * Not safe to call from threads that may be asynchronously cancelled, as the lock might not be properly released.
+ * The function is unsafe for asynchronous cancellation as the cleanup of the mutex
+ * may not be completed if a thread is cancelled during execution.
  *
  * @since release v2.0.0
  *
- * @param entry The entry whose mutex is to be unlocked. Must not be NULL and must have an initialized mutex.
+ * @param entry The entry whose mutex is to be unlocked. Must not be NULL, and it
+ *              must have a valid mutex initialized.
  */
 void
-unlock_entry( const struct stumpless_entry *entry );
+unlock_entry(const struct stumpless_entry *entry);
+
 
 #endif /* __STUMPLESS_PRIVATE_ENTRY_H */

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -212,6 +212,29 @@ struct strbuilder *
 strbuilder_append_structured_data( struct strbuilder *builder,
                                    const struct stumpless_entry *entry );
 
+/**
+ * Destroys a Stumpless entry without performing any checks.
+ *
+ * This function deallocates resources associated with the given entry, including
+ * unloading the entry and freeing its memory from the cache. It assumes the entry
+ * is valid and does not perform any safety checks.
+ *
+ * **Thread Safety: MT-Unsafe**
+ * This function is not thread-safe as it modifies shared resources (the entry and
+ * its associated data) without synchronization.
+ *
+ * **Async Signal Safety: AS-Unsafe**
+ * Not safe to call from signal handlers as it involves operations like memory
+ * deallocation and mutex destruction.
+ *
+ * **Async Cancel Safety: AC-Unsafe**
+ * Not safe in the context of asynchronous cancellation due to potential resource
+ * cleanup issues.
+ *
+ * @since release v1.5.0
+ *
+ * @param entry A pointer to the entry to be destroyed. Must not be NULL.
+ */
 void
 unchecked_destroy_entry( const struct stumpless_entry *entry );
 

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -176,6 +176,34 @@ struct strbuilder *
 strbuilder_append_msgid( struct strbuilder *builder,
                          const struct stumpless_entry *entry );
 
+/**
+ * Appends the message from a Stumpless entry to a string builder.
+ *
+ * This function extracts the message from the provided Stumpless entry and
+ * appends it to the specified string builder. It is useful for constructing
+ * strings that include log messages.
+ *
+ * **Thread Safety: MT-Unsafe**
+ * This function is not thread-safe as it accesses shared data (the entry's message)
+ * without synchronization mechanisms.
+ *
+ * **Async Signal Safety: AS-Unsafe**
+ * This function is not safe to call from asynchronous signal handlers as it
+ * involves memory manipulation and access to shared data structures.
+ *
+ * **Async Cancel Safety: AC-Unsafe**
+ * Not safe for use in contexts where threads may be asynchronously cancelled,
+ * as it could leave shared data in an inconsistent state.
+ *
+ * @since release 1.0.0
+ *
+ * @param builder A pointer to the string builder to which the entry's message is appended.
+ *                Must not be NULL.
+ * @param entry The Stumpless entry containing the message to be appended.
+ *              Must not be NULL.
+ *
+ * @return The string builder with the message appended, or NULL if an error occurs.
+ */
 struct strbuilder *
 strbuilder_append_message( struct strbuilder *builder,
                            const struct stumpless_entry *entry );

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -522,11 +522,6 @@ void
 unchecked_unload_entry( const struct stumpless_entry *entry );
 
 /**
- * Note (to delete before merge) : i'm concern this comment is not 100% accurate,
- * i have some difficulties to understand the config_unlock_mutex macro
- * if it does something or not
- * (implement thread safety #136)
- * 
  * Unlocks the mutex of a given entry.
  * 
  * This function is used internally to ensure that the mutex of an entry

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -142,6 +142,29 @@ struct stumpless_element *
 locked_get_element_by_index( const struct stumpless_entry *entry,
                              size_t index );
 
+/**
+ * Retrieves an element by name from a Stumpless entry, ensuring thread safety.
+ *
+ * This function searches for an element within the given entry by its name. 
+ * It locks each element during comparison to ensure thread safety. If the 
+ * element with the specified name is found, it is returned.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread-safe as it locks individual elements during the search process.
+ *
+ * **Async Signal Safety: AS-Unsafe**
+ * Unsafe to call from asynchronous signal handlers due to lock manipulation.
+ *
+ * **Async Cancel Safety: AC-Unsafe**
+ * Not safe in contexts of asynchronous cancellation, as it might involve lock manipulation.
+ *
+ * @since release 2.0.0
+ *
+ * @param entry The entry containing the elements to search through. Must not be NULL.
+ * @param name The name of the element to find. Must be a NULL-terminated string.
+ *
+ * @return A pointer to the found element, or NULL if not found or an error occurs.
+ */
 struct stumpless_element *
 locked_get_element_by_name( const struct stumpless_entry *entry,
                             const char *name );

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -172,6 +172,34 @@ strbuilder_append_app_name( struct strbuilder *builder,
 struct strbuilder *
 strbuilder_append_hostname( struct strbuilder *builder );
 
+/**
+ * Appends the message ID from a Stumpless entry to a string builder.
+ *
+ * This function takes the message ID from the provided Stumpless entry and
+ * appends it to the given string builder. It's designed for building strings
+ * that include the message ID of log entries.
+ *
+ * **Thread Safety: MT-Unsafe**
+ * This function is not thread-safe as it accesses shared data (the entry's message ID)
+ * without synchronization mechanisms.
+ *
+ * **Async Signal Safety: AS-Unsafe**
+ * Unsafe to call from asynchronous signal handlers due to memory manipulation
+ * and accessing shared data structures.
+ *
+ * **Async Cancel Safety: AC-Unsafe**
+ * Not safe in contexts of asynchronous cancellation, as it might lead to inconsistent
+ * states of shared data.
+ *
+ * @since release 1.0.0
+ *
+ * @param builder A pointer to the string builder to append the message ID.
+ *                Must not be NULL.
+ * @param entry The Stumpless entry containing the message ID.
+ *              Must not be NULL.
+ *
+ * @return The string builder with the message ID appended, or NULL if an error occurs.
+ */
 struct strbuilder *
 strbuilder_append_msgid( struct strbuilder *builder,
                          const struct stumpless_entry *entry );

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -137,7 +137,7 @@ locked_add_element( struct stumpless_entry *entry,
  * **Async Cancel Safety: AC-Unsafe**
  * Not safe in contexts of asynchronous cancellation, as it might involve unsafe data access.
  *
- * @since release 2.0.0
+ * @since release v2.0.0
  *
  * @param entry The entry containing the elements. Must not be NULL.
  * @param index The index of the element to retrieve.
@@ -165,7 +165,7 @@ locked_get_element_by_index( const struct stumpless_entry *entry,
  * **Async Cancel Safety: AC-Unsafe**
  * Not safe in contexts of asynchronous cancellation, as it might involve unsafe data access.
  *
- * @since release 2.0.0
+ * @since release v2.0.0
  *
  * @param entry The entry containing the elements to be searched. Must not be NULL.
  * @param name The name of the element to find. Must be a NULL-terminated string.
@@ -233,7 +233,7 @@ new_entry( enum stumpless_facility facility,
  * Not safe in contexts of asynchronous cancellation, as it might lead to inconsistent
  * states of shared data.
  *
- * @since release 1.0.0
+ * @since release v1.0.0
  *
  * @param builder A pointer to the string builder to append the application name.
  *                Must not be NULL.
@@ -266,7 +266,7 @@ strbuilder_append_app_name( struct strbuilder *builder,
  * Not safe for use in contexts of asynchronolock_entryus cancellation due to potential
  * system call interruption and memory state inconsistency.
  *
- * @since release 1.0.0
+ * @since release v1.0.0
  *
  * @param builder A pointer to the string builder to which the hostname is appended.
  *                Must not be NULL.
@@ -295,7 +295,7 @@ strbuilder_append_hostname( struct strbuilder *builder );
  * Not safe in contexts of asynchronous cancellation, as it might lead to inconsistent
  * states of shared data.
  *
- * @since release 1.0.0
+ * @since release v1.0.0
  *
  * @param builder A pointer to the string builder to append the message ID.
  *                Must not be NULL.
@@ -327,7 +327,7 @@ strbuilder_append_msgid( struct strbuilder *builder,
  * Not safe for use in contexts where threads may be asynchronously cancelled,
  * as it could leave shared data in an inconsistent state.
  *
- * @since release 1.0.0
+ * @since release v1.0.0
  *
  * @param builder A pointer to the string builder to which the entry's message is appended.
  *                Must not be NULL.

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -215,6 +215,29 @@ strbuilder_append_structured_data( struct strbuilder *builder,
 void
 unchecked_destroy_entry( const struct stumpless_entry *entry );
 
+/**
+ * Checks if the specified entry contains an element with the given name.
+ *
+ * **Thread Safety: MT-Safe race:entry race:name**
+ * This function is thread-safe assuming that the 'entry' and 'name' arguments
+ * are not modified concurrently by other threads. It relies on the immutability
+ * of these parameters during execution to maintain thread safety.
+ *
+ * **Async Signal Safety: AS-Unsafe**
+ * This function is not safe to call from asynchronous signal handlers due to
+ * potential manipulation of shared data structures.
+ *
+ * **Async Cancel Safety: AC-Unsafe**
+ * This function is not safe for contexts where threads might be asynchronously
+ * cancelled, as it could leave shared data in an inconsistent state.
+ *
+ * @since release v1.6.0
+ *
+ * @param entry The entry to be checked for the element. Must not be NULL.
+ * @param name The name of the element to look for. Must be a NULL-terminated string.
+ *
+ * @return Returns true if the element is found, false otherwise.
+ */
 bool
 unchecked_entry_has_element( const struct stumpless_entry *entry,
                              const char *name );

--- a/include/private/entry.h
+++ b/include/private/entry.h
@@ -54,13 +54,7 @@ entry_free_all( void );
  * RFC 5424 Section 6.2.1. The shift operation is done prior to get_prival()
  * function with macros in "facility.h"
  *
- * **Thread Safety: MT-Safe**
- * This function is thread safe.
- *
- * **Async Signal Safety: AS-Safe **
- * This function must be safe to call from signal handlers
- *
- * **Async Cancel Safety: AC-Safe**
+ * **Thread Safety: MT-Safe[appropriate version]afe**
  * This function must be safe to call from threads that may be asynchronously
  * cancelled.
  *
@@ -165,10 +159,65 @@ new_entry( enum stumpless_facility facility,
            char *message,
            size_t message_length );
 
+/**
+ * Appends the application name from a Stumpless entry to a string builder.
+ *
+ * This function takes the application name from the provided Stumpless entry and
+ * appends it to the specified string builder. It is designed for building strings
+ * that include the application name of log entries.
+ *
+ * **Thread Safety: MT-Unsafe**
+ * This function is not thread-safe as it accesses shared data (the entry's application name)
+ * without synchronization mechanisms.
+ *
+ * **Async Signal Safety: AS-Unsafe**
+ * Unsafe to call from asynchronous signal handlers due to memory manipulation
+ * and accessing shared data structures.
+ *
+ * **Async Cancel Safety: AC-Unsafe**
+ * Not safe in contexts of asynchronous cancellation, as it might lead to inconsistent
+ * states of shared data.
+ *
+ * @since release 1.0.0
+ *
+ * @param builder A pointer to the string builder to append the application name.
+ *                Must not be NULL.
+ * @param entry The Stumpless entry containing the application name.
+ *              Must not be NULL.
+ *
+ * @return The string builder with the application name appended, or NULL if an error occurs.
+ */
 struct strbuilder *
 strbuilder_append_app_name( struct strbuilder *builder,
                             const struct stumpless_entry *entry );
 
+/**
+ * Appends the hostname to the string builder.
+ *
+ * This function retrieves the system's current hostname using `config_gethostname`
+ * and appends it to the provided string builder. If the hostname cannot be
+ * obtained, a hyphen ('-') is appended instead.
+ *
+ * **Thread Safety: MT-Safe**
+ * Assuming `config_gethostname` is thread-safe, this function is also thread-safe
+ * as it operates on local buffer and the provided string builder without
+ * sharing data with other threads.
+ *
+ * **Async Signal Safety: AS-Unsafe**
+ * This function is not safe to call from asynchronous signal handlers as it
+ * involves system calls and memory manipulation.
+ *
+ * **Async Cancel Safety: AC-Unsafe**
+ * Not safe for use in contexts of asynchronous cancellation due to potential
+ * system call interruption and memory state inconsistency.
+ *
+ * @since release 1.0.0
+ *
+ * @param builder A pointer to the string builder to which the hostname is appended.
+ *                Must not be NULL.
+ *
+ * @return The string builder with the hostname appended, or NULL if an error occurs.
+ */
 struct strbuilder *
 strbuilder_append_hostname( struct strbuilder *builder );
 


### PR DESCRIPTION
This pull request addresses Issue #371 by providing documentation comments for previously undocumented functions in the include/private/entry.h file. The following functions now have comments detailing their purpose and behavior:

locked_get_element_by_name
new_entry
strbuilder_append_app_name
strbuilder_append_hostname
strbuilder_append_msgid
strbuilder_append_message
strbuilder_append_procid
unchecked_destroy_entry
unchecked_entry_has_element
unlock_entry (Note: There's a relevant discussion left in the comments due to potential thread safety implications as discussed in Issue #136)

As my first ever contribution to an open-source project and pull request, I hope these changes will be beneficial and not waste your time. I have made an effort to ensure that each function is documented according to the project standards. There might be too much commits in this PR, reflecting each step of the documentation process.

Looking forward to feedback and suggestions.

Thank you.