### PR TITLE
Fixed warning regarding unsequenced modification.

### DIFF
--- a/src/priority.c
+++ b/src/priority.c
@@ -89,7 +89,8 @@ stumpless_prival_from_string( const char *string ) {
   }
 
   // Calculate the severity length
-  len = slen - ++len;
+  len++;
+  len = slen - len;
 
   // Copy the severity substring to the param buffer
   param = copy_cstring_length( ++period, len );


### PR DESCRIPTION
Minor refactoring to silence an unsequenced modification warning. Increments 'len' before assigning it's new value.
