### PR TITLE
improve portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,11 +38,20 @@ string(CONCAT enable_deprecation_warnings_help_string
 )
 option(ENABLE_DEPRECATION_WARNINGS ${enable_deprecation_warnings_help_string} ON)
 
+
+# default settings
 string(CONCAT default_facility_help_string
   "The facility code to use for messages where one is not explicitly provided."
 )
 set(DEFAULT_FACILITY "STUMPLESS_FACILITY_USER"
   CACHE STRING ${default_facility_help_string}
+)
+
+string(CONCAT default_filename_help_string
+  "The name of the file opened if the default target is to a file."
+)
+set(DEFAULT_FILE "stumpless-default.log"
+  CACHE STRING "${default_file_help_string}"
 )
 
 string(CONCAT default_severity_help_string

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,8 @@ if(HAVE_GMTIME_R)
   list(APPEND STUMPLESS_SOURCES ${PROJECT_SOURCE_DIR}/src/config/have_gmtime_r.c)
 elseif(NOT SUPPORT_WINDOWS_GET_NOW AND HAVE_GMTIME)
   list(APPEND STUMPLESS_SOURCES ${PROJECT_SOURCE_DIR}/src/config/have_gmtime.c)
+else()
+  list(APPEND STUMPLESS_SOURCES ${PROJECT_SOURCE_DIR}/src/config/no_gmtime.c)
 endif()
 
 if(HAVE_UNISTD_GETHOSTNAME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ set(DEFAULT_FACILITY "STUMPLESS_FACILITY_USER"
   CACHE STRING ${default_facility_help_string}
 )
 
-string(CONCAT default_filename_help_string
+string(CONCAT default_file_help_string
   "The name of the file opened if the default target is to a file."
 )
 set(DEFAULT_FILE "stumpless-default.log"

--- a/include/private/config/no_gmtime.h
+++ b/include/private/config/no_gmtime.h
@@ -26,7 +26,10 @@
 #include <stddef.h>
 
 /**
- * Gets the current time as a string and places it into the given buffer.
+ * Writes an RFC 5424 NILVALUE to the provided buffer and returns its size.
+ *
+ * This function is used to get the time if no other suitable time function is
+ * available.
  *
  * **Thread Safety: MT-Safe**
  * This function is thread safe.

--- a/include/private/config/no_gmtime.h
+++ b/include/private/config/no_gmtime.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Copyright 2024 Joel E. Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @file
+ * Fallback functionality for getting the current time.
+ */
+
+#ifndef __STUMPLESS_PRIVATE_CONFIG_NO_GMTIME_H
+#define __STUMPLESS_PRIVATE_CONFIG_NO_GMTIME_H
+
+#include <stddef.h>
+
+/**
+ * Gets the current time as a string and places it into the given buffer.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe.
+ *
+ * **Async Signal Safety: AS-Safe**
+ * This function is safe to call from signal handlers.
+ *
+ * **Async Cancel Safety: AC-Safe**
+ * This function is safe to call from threads that may be asynchronously
+ * cancelled.
+ *
+ * @since release v2.2.0
+ *
+ * @param buffer The buffer to write the string into.
+ *
+ * @return The number of characters written into the buffer.
+ */
+size_t
+no_gmtime_get_now( char *buffer );
+
+#endif /* __STUMPLESS_PRIVATE_CONFIG_NO_GMTIME_H */

--- a/include/private/config/wrapper/get_now.h
+++ b/include/private/config/wrapper/get_now.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2022-2023 Joel E. Anderson
+ * Copyright 2022-2024 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,20 +21,23 @@
  */
 
 #ifndef __STUMPLESS_PRIVATE_CONFIG_WRAPPER_GET_NOW_H
-#  define __STUMPLESS_PRIVATE_CONFIG_WRAPPER_GET_NOW_H
+#define __STUMPLESS_PRIVATE_CONFIG_WRAPPER_GET_NOW_H
 
-#  include "private/config.h"
+#include "private/config.h"
 
 /* definition of config_get_now */
-#  ifdef HAVE_GMTIME_R
-#    include "private/config/have_gmtime_r.h"
-#    define config_get_now gmtime_r_get_now
-#  elif SUPPORT_WINDOWS_GET_NOW
-#    include "private/config/windows_get_now_supported.h"
-#    define config_get_now windows_get_now
-#  elif HAVE_GMTIME
-#    include "private/config/have_gmtime.h"
-#    define config_get_now gmtime_get_now
-#  endif
+#ifdef HAVE_GMTIME_R
+#  include "private/config/have_gmtime_r.h"
+#  define config_get_now gmtime_r_get_now
+#elif SUPPORT_WINDOWS_GET_NOW
+#  include "private/config/windows_get_now_supported.h"
+#  define config_get_now windows_get_now
+#elif HAVE_GMTIME
+#  include "private/config/have_gmtime.h"
+#  define config_get_now gmtime_get_now
+#else
+#  include "private/config/no_gmtime.h"
+#  define config_get_now no_gmtime_get_now
+#endif
 
 #endif /* __STUMPLESS_PRIVATE_CONFIG_WRAPPER_GET_NOW_H */

--- a/include/stumpless/config.h.in
+++ b/include/stumpless/config.h.in
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2023 Joel E. Anderson
+ * Copyright 2018-2024 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,9 @@
 
 /** The facility code to use when one is not supplied. */
 #define STUMPLESS_DEFAULT_FACILITY @DEFAULT_FACILITY@
+
+/** The name of the file opened if the default target is to a file. */
+#define STUMPLESS_DEFAULT_FILE "@DEFAULT_FILE@"
 
 /** The severity code to use when one is not supplied. */
 #define STUMPLESS_DEFAULT_SEVERITY @DEFAULT_SEVERITY@

--- a/include/stumpless/facility.h
+++ b/include/stumpless/facility.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2023 Joel E. Anderson
+ * Copyright 2018-2024 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -348,7 +348,7 @@ enum stumpless_facility {
   STUMPLESS_FOREACH_FACILITY( STUMPLESS_GENERATE_ENUM )
 };
 
-  /**
+/**
  * Gets the string representation of the given facility.
  *
  * This is a string literal that should not be modified or freed by the caller.
@@ -373,7 +373,7 @@ STUMPLESS_PUBLIC_FUNCTION
 const char *
 stumpless_get_facility_string( enum stumpless_facility facility );
 
-  /**
+/**
  * Gets the enum value corresponding to the given facility string.
  *
  * **Thread Safety: MT-Safe**
@@ -397,7 +397,7 @@ STUMPLESS_PUBLIC_FUNCTION
 enum stumpless_facility
 stumpless_get_facility_enum( const char *facility_string );
 
-  /**
+/**
  * Gets the enum value corresponding to the given facility string.
  *
  * **Thread Safety: MT-Safe**

--- a/include/stumpless/priority.h
+++ b/include/stumpless/priority.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2022 Joel E. Anderson
+ * Copyright 2022-2024 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,13 @@
  */
 
 #ifndef __STUMPLESS_PRIORITY_H
-#  define __STUMPLESS_PRIORITY_H
+#define __STUMPLESS_PRIORITY_H
 
-#  include <stumpless.h>
+#include <stumpless/config.h>
 
-#  ifdef __cplusplus
+#ifdef __cplusplus
 extern "C" {
-#  endif
+#endif
 
 /**
  * Extract PRIVAL number (Facility and Severity) from the given string with
@@ -59,8 +59,8 @@ STUMPLESS_PUBLIC_FUNCTION
 int
 stumpless_prival_from_string( const char *string );
 
-#  ifdef __cplusplus
+#ifdef __cplusplus
 } /* extern "C" */
-#  endif
+#endif
 
 #endif /* __STUMPLESS_PRIORITY_H */

--- a/include/stumpless/target.h
+++ b/include/stumpless/target.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*
- * Copyright 2018-2023 Joel E. Anderson
+ * Copyright 2018-2024 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,9 +35,6 @@
 #include <stumpless/entry.h>
 #include <stumpless/id.h>
 #include <stumpless/generator.h>
-
-/** The file opened if the default target is to a file. */
-#define STUMPLESS_DEFAULT_FILE "stumpless-default.log"
 
 /** The name of the default target. */
 #define STUMPLESS_DEFAULT_TARGET_NAME "stumpless-default"

--- a/src/config/no_gmtime.c
+++ b/src/config/no_gmtime.c
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2024 Joel E. Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include "private/config/no_gmtime.h"
+
+size_t
+no_gmtime_get_now( char *buffer ) {
+  *buffer = '-';
+  return 1;
+}

--- a/src/element.c
+++ b/src/element.c
@@ -194,8 +194,11 @@ stumpless_element_to_string( const struct stumpless_element *element ) {
     const char *name;
     size_t name_len;
     size_t format_len;
+    const char **params_format;
+    size_t i;
     size_t param_count;
     struct stumpless_param **params;
+    size_t pos_offset;
 
     VALIDATE_ARG_NOT_NULL( element );
 
@@ -209,8 +212,8 @@ stumpless_element_to_string( const struct stumpless_element *element ) {
     // acc total format size
     format_len = name_len;
 
-    const char **params_format = alloc_mem(sizeof(char*) * param_count);
-    for( size_t i = 0; i < param_count; i++ ) {
+    params_format = alloc_mem(sizeof(char*) * param_count);
+    for( i = 0; i < param_count; i++ ) {
       params_format[i] = stumpless_param_to_string(params[i]);
       // does not count '\0' on purpose
       format_len += strlen(params_format[i]);
@@ -232,8 +235,8 @@ stumpless_element_to_string( const struct stumpless_element *element ) {
     memcpy( format, name, name_len );
 
     // build params list "param_1_to_string,param_2_to_string, ..."
-    size_t pos_offset = name_len + 2;
-    for( size_t i = 0; i < param_count; i++) {
+    pos_offset = name_len + 2;
+    for( i = 0; i < param_count; i++) {
       // replace '\0' with ',' at the end of each string
       memcpy( format + pos_offset, params_format[i], strlen(params_format[i]));
       pos_offset += strlen(params_format[i]);

--- a/src/param.c
+++ b/src/param.c
@@ -144,9 +144,6 @@ stumpless_new_param( const char *name, const char *value ) {
 
 struct stumpless_param *
 stumpless_new_param_from_string( const char *string ) {
-  
-  VALIDATE_ARG_NOT_NULL( string );
-
   int i;
   size_t name_len = 0;
   size_t name_start = 0;
@@ -155,6 +152,8 @@ stumpless_new_param_from_string( const char *string ) {
   char *name;
   char *value;
   struct stumpless_param *result;
+
+  VALIDATE_ARG_NOT_NULL( string );
 
   /* Check that the characters in 'name' are allowed. */
   for (i = 0; string[i] != '='; i++) {

--- a/src/priority.c
+++ b/src/priority.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2022 Joel E. Anderson
+ * Copyright 2022-2024 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stddef.h>
-#include <stumpless.h>
+#include <stumpless/facility.h>
+#include <stumpless/priority.h>
+#include <stumpless/severity.h>
 #include "private/memory.h"
 #include "private/entry.h"
 #include "private/validate.h"

--- a/src/strhelper.c
+++ b/src/strhelper.c
@@ -73,7 +73,9 @@ copy_cstring_length( const char *str, size_t length ) {
 
 void
 to_upper_case( char *str ) {
-  for( int i = 0; str[i]; i++) {
+  size_t i;
+
+  for( i = 0; str[i]; i++) {
     str[i] = toupper( str[i] );
   }
 }

--- a/src/target/file.c
+++ b/src/target/file.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2020 Joel E. Anderson
+ * Copyright 2018-2024 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <stumpless/config.h>
 #include <stumpless/target.h>
 #include <stumpless/target/file.h>
 #include "private/config/locale/wrapper.h"

--- a/test/fuzz/add_message_str.cpp
+++ b/test/fuzz/add_message_str.cpp
@@ -12,9 +12,6 @@ LLVMFuzzerTestOneInput( const uint8_t *data, size_t size ) {
 
   memcpy( terminated_data, data, size );
   terminated_data[size] = '\0';
-  if( size >= 8 ) {
-    printf( "%s\n", *((char **)data) );
-  }
 
   target = stumpless_open_buffer_target( "fuzzer", buffer, sizeof( buffer ) );
   stumpless_add_message_str( target, terminated_data );

--- a/test/fuzz/add_message_str.cpp
+++ b/test/fuzz/add_message_str.cpp
@@ -1,17 +1,23 @@
 #include <cstddef>
 #include <cstdint>
-#include <string>
+#include <cstring>
 #include <stumpless.h>
 
 extern "C"
 int
 LLVMFuzzerTestOneInput( const uint8_t *data, size_t size ) {
-  std::string fuzz_str ( ( char * ) data, size );
+  char terminated_data[size+1];
   char buffer[8192];
   struct stumpless_target *target;
 
+  memcpy( terminated_data, data, size );
+  terminated_data[size] = '\0';
+  if( size >= 8 ) {
+    printf( "%s\n", *((char **)data) );
+  }
+
   target = stumpless_open_buffer_target( "fuzzer", buffer, sizeof( buffer ) );
-  stumpless_add_message_str( target, fuzz_str.c_str(  ) );
+  stumpless_add_message_str( target, terminated_data );
   stumpless_close_buffer_target( target );
 
   return 0;

--- a/test/fuzz/stump_str.cpp
+++ b/test/fuzz/stump_str.cpp
@@ -1,18 +1,20 @@
 #include <cstddef>
 #include <cstdint>
-#include <string>
+#include <cstring>
 #include <stumpless.h>
 
 extern "C"
 int
 LLVMFuzzerTestOneInput( const uint8_t *data, size_t size ) {
-  std::string fuzz_str ( ( char * ) data, size );
+  char terminated_data[size+1];
   char buffer[8192];
   struct stumpless_target *target;
 
-  // Function will send message to the last opened target.
+  memcpy( terminated_data, data, size );
+  terminated_data[size] = '\0';
+
   target = stumpless_open_buffer_target( "fuzzer", buffer, sizeof( buffer ) );
-  stump_str( fuzz_str.c_str(  ) );
+  stump_str( terminated_data );
   stumpless_close_buffer_target( target );
 
   return 0;

--- a/tools/check_headers/stumpless.yml
+++ b/tools/check_headers/stumpless.yml
@@ -201,7 +201,7 @@
 "stumpless_close_wel_target": "stumpless/target/wel.h"
 "stumpless_create_default_sqlite3_table": "stumpless/target/sqlite3.h"
 "STUMPLESS_DEFAULT_FACILITY": "stumpless/config.h"
-"STUMPLESS_DEFAULT_FILE": "stumpless/target.h"
+"STUMPLESS_DEFAULT_FILE": "stumpless/config.h"
 "STUMPLESS_DEFAULT_SEVERITY": "stumpless/config.h"
 "STUMPLESS_DEFAULT_SQLITE3_INSERT_SQL": "stumpless/target/sqlite3.h"
 "STUMPLESS_DEFAULT_SQLITE3_TABLE_NAME_STRING": "stumpless/config.h"

--- a/tools/check_headers/stumpless_private.yml
+++ b/tools/check_headers/stumpless_private.yml
@@ -107,6 +107,7 @@
 "new_entry": "private/entry.h"
 "new_sqlite3_target": "private/target/sqlite3.h"
 "no_abstract_socket_names_get_local_socket_name": "private/config/abstract_socket_names_unsupported.h"
+"no_gmtime_get_now": "private/config/no_gmtime.h"
 "no_thread_safety_compare_exchange_bool": "private/config/thread_safety_unsupported.h"
 "no_thread_safety_compare_exchange_ptr": "private/config/thread_safety_unsupported.h"
 "no_wcsrtombs_s_copy_wstring_to_cstring": "private/config/no_wcsrtombs_s.h"


### PR DESCRIPTION
Improve portability by:

 * ensuring all variable declarations are at the beginning of the function
 * ensure that `stumpless.h` is not included in any library sources
 * support builds where `gmtime` is not available
 * make the default log file name a configuration variable
 * remove fuzz test use of C++ `string` class