### PR TITLE
Added a release number and date consistency check as github workflows step

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -93,4 +93,46 @@ jobs:
           else
             exit 0
           fi
+  release-version-and-date-analysis:
+    name: "release version and date analysis"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          fetch-depth: 0
+      - name: Release Version and Date Analysis
+        run: |  
+          # search for release and date line from CITATION.cff with format:
+					# 'version: X.X.X' and 'date-released: XXXX-XX-XX' then extract to variables
 
+					# find the line with each, then extract the value wanted (version number or date) as well as line number
+					version_citation_info=$(grep -n -E -m1 '^version: [0-9]+\.[0-9]+\.[0-9]+' "../../CITATION.cff")
+					version_citation_line=$(echo "$version_citation_info" | cut -d: -f1)
+					version_citation=$(echo "$version_citation_info" | awk '{print $2}')
+
+					date_citation_info=$(grep -n -E -m1 'date-released: [0-9]{4}-[0-9]{2}-[0-9]{2}' "../../CITATION.cff")
+					date_citation_line=$(echo "$date_citation_info" | cut -d: -f1)
+					date_citation=$(echo "$date_citation_info" | awk '{print $2}')
+
+					# search for version and date line from ChangeLog.md with format:
+					# '## [X.X.X] - [XX-XX-XXXX]'
+
+					# find most recent line with version and date of release in ChangeLog.md
+					vd_changelog_info=$(grep -n -E -m1 '## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}' "../../ChangeLog.md")
+					vd_changelog_line=$(echo "$vd_changelog_info" | cut -d: -f1)
+
+					# extract version, date and line number (since it's always on one line) to variables
+					version_changelog=$(echo "$vd_changelog_info" | awk -F'[][]' '{print $2}')
+					date_changelog=$(echo "$vd_changelog_info" | awk -F' - ' '{print $2}')
+
+
+					# compare version numbers and dates between files, listing discrepancies where found
+					if [[ "$version_changelog" != "$version_citation" ]]; then
+						echo "Release version numbers do not match: $version_changelog (ChangeLog.md on line $vd_changelog_line) vs $version_citation (CITATION.cff on line $version_citation_line)"
+						exit 1
+					fi
+
+					if [[ "$date_changelog" != "$date_citation" ]]; then
+						echo "Release dates do not match: $date_changelog (ChangeLog.md on line $vd_changelog_line) vs $date_citation (CITATION.cff on line $date_citation_line)"
+						exit 1
+					fi

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -106,11 +106,11 @@ jobs:
 					# 'version: X.X.X' and 'date-released: XXXX-XX-XX' then extract to variables
 
 					# find the line with each, then extract the value wanted (version number or date) as well as line number
-					version_citation_info=$(grep -n -E -m1 '^version: [0-9]+\.[0-9]+\.[0-9]+' "../../CITATION.cff")
+					version_citation_info=$(grep -n -E -m1 '^version: [0-9]+\.[0-9]+\.[0-9]+' "CITATION.cff")
 					version_citation_line=$(echo "$version_citation_info" | cut -d: -f1)
 					version_citation=$(echo "$version_citation_info" | awk '{print $2}')
 
-					date_citation_info=$(grep -n -E -m1 'date-released: [0-9]{4}-[0-9]{2}-[0-9]{2}' "../../CITATION.cff")
+					date_citation_info=$(grep -n -E -m1 'date-released: [0-9]{4}-[0-9]{2}-[0-9]{2}' "CITATION.cff")
 					date_citation_line=$(echo "$date_citation_info" | cut -d: -f1)
 					date_citation=$(echo "$date_citation_info" | awk '{print $2}')
 
@@ -118,7 +118,7 @@ jobs:
 					# '## [X.X.X] - [XX-XX-XXXX]'
 
 					# find most recent line with version and date of release in ChangeLog.md
-					vd_changelog_info=$(grep -n -E -m1 '## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}' "../../ChangeLog.md")
+					vd_changelog_info=$(grep -n -E -m1 '## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}' "ChangeLog.md")
 					vd_changelog_line=$(echo "$vd_changelog_info" | cut -d: -f1)
 
 					# extract version, date and line number (since it's always on one line) to variables

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -103,36 +103,28 @@ jobs:
       - name: Release Version and Date Analysis
         run: |  
           # search for release and date line from CITATION.cff with format:
-					# 'version: X.X.X' and 'date-released: XXXX-XX-XX' then extract to variables
-
-					# find the line with each, then extract the value wanted (version number or date) as well as line number
-					version_citation_info=$(grep -n -E -m1 '^version: [0-9]+\.[0-9]+\.[0-9]+' "CITATION.cff")
-					version_citation_line=$(echo "$version_citation_info" | cut -d: -f1)
-					version_citation=$(echo "$version_citation_info" | awk '{print $2}')
-
-					date_citation_info=$(grep -n -E -m1 'date-released: [0-9]{4}-[0-9]{2}-[0-9]{2}' "CITATION.cff")
-					date_citation_line=$(echo "$date_citation_info" | cut -d: -f1)
-					date_citation=$(echo "$date_citation_info" | awk '{print $2}')
-
-					# search for version and date line from ChangeLog.md with format:
-					# '## [X.X.X] - [XX-XX-XXXX]'
-
-					# find most recent line with version and date of release in ChangeLog.md
-					vd_changelog_info=$(grep -n -E -m1 '## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}' "ChangeLog.md")
-					vd_changelog_line=$(echo "$vd_changelog_info" | cut -d: -f1)
-
-					# extract version, date and line number (since it's always on one line) to variables
-					version_changelog=$(echo "$vd_changelog_info" | awk -F'[][]' '{print $2}')
-					date_changelog=$(echo "$vd_changelog_info" | awk -F' - ' '{print $2}')
-
-
-					# compare version numbers and dates between files, listing discrepancies where found
-					if [[ "$version_changelog" != "$version_citation" ]]; then
-						echo "Release version numbers do not match: $version_changelog (ChangeLog.md on line $vd_changelog_line) vs $version_citation (CITATION.cff on line $version_citation_line)"
-						exit 1
-					fi
-
-					if [[ "$date_changelog" != "$date_citation" ]]; then
-						echo "Release dates do not match: $date_changelog (ChangeLog.md on line $vd_changelog_line) vs $date_citation (CITATION.cff on line $date_citation_line)"
-						exit 1
-					fi
+          # 'version: X.X.X' and 'date-released: XXXX-XX-XX' then extract to variables
+          # find the line with each, then extract the value wanted (version number or date) as well as line number
+          version_citation_info=$(grep -n -E -m1 '^version: [0-9]+\.[0-9]+\.[0-9]+' "CITATION.cff")
+          version_citation_line=$(echo "$version_citation_info" | cut -d: -f1)
+          version_citation=$(echo "$version_citation_info" | awk '{print $2}')
+          date_citation_info=$(grep -n -E -m1 'date-released: [0-9]{4}-[0-9]{2}-[0-9]{2}' "CITATION.cff")
+          date_citation_line=$(echo "$date_citation_info" | cut -d: -f1)
+          date_citation=$(echo "$date_citation_info" | awk '{print $2}')
+          # search for version and date line from ChangeLog.md with format:
+          # '## [X.X.X] - [XX-XX-XXXX]'
+          # find most recent line with version and date of release in ChangeLog.md
+          vd_changelog_info=$(grep -n -E -m1 '## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}' "ChangeLog.md")
+          vd_changelog_line=$(echo "$vd_changelog_info" | cut -d: -f1)
+          # extract version, date and line number (since it's always on one line) to variables
+          version_changelog=$(echo "$vd_changelog_info" | awk -F'[][]' '{print $2}')
+          date_changelog=$(echo "$vd_changelog_info" | awk -F' - ' '{print $2}')
+          # compare version numbers and dates between files, listing discrepancies where found
+          if [[ "$version_changelog" != "$version_citation" ]]; then
+           echo "Release version numbers do not match: $version_changelog (ChangeLog.md on line $vd_changelog_line) vs $version_citation (CITATION.cff on line $version_citation_line)"
+           exit 1
+          fi
+          if [[ "$date_changelog" != "$date_citation" ]]; then
+           echo "Release dates do not match: $date_changelog (ChangeLog.md on line $vd_changelog_line) vs $date_citation (CITATION.cff on line $date_citation_line)"
+           exit 1
+          fi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: Stumpless Logging Library
 license: Apache-2.0
 repository-code: "https://github.com/goatshriek/stumpless"
 version: 2.2.0
-date-released: 2023-01-16
+date-released: 2024-05-26
 keywords:
   - journald
   - logging


### PR DESCRIPTION
Added a small amount of shellcode to analysis.yml that will be run on push and pull request to ensure the version number and date of release are consistent between two files that track them (CITATION.cff and ChangeLog.md). 

I had a lot of headache with trying to figure out why my indents we're being registered as way larger than 2 spaces, but ended up just fixing the indents on github. 

Finally, I changed the date on CITATION.cff to represent the matching date in ChangeLog.md.


