### PR TITLE
Terminal ansi colors

### DIFF
--- a/include/private/target/stream.h
+++ b/include/private/target/stream.h
@@ -22,6 +22,7 @@
 #  include <stddef.h>
 #  include <stdio.h>
 #  include <stumpless/config.h>
+#  include <stumpless/entry.h>
 #  include "private/config/wrapper/thread_safety.h"
 
 /**
@@ -30,6 +31,8 @@
 struct stream_target {
 /** The stream this target writes to. */
   FILE *stream;
+/** ANSI colors for different severities (when using ansi terminal) */
+  char escape_codes[8][32];
 #  ifdef STUMPLESS_THREAD_SAFETY_SUPPORTED
 /**
  * Protects stream. This mutex must be locked by a thread before it can write
@@ -61,6 +64,7 @@ new_stream_target( FILE *stream );
 int
 sendto_stream_target( struct stream_target *target,
                       const char *msg,
-                      size_t msg_length );
+                      size_t msg_length,
+		      const struct stumpless_entry *entry );
 
 #endif /* __STUMPLESS_PRIVATE_TARGET_STREAM_H */

--- a/include/stumpless/severity.h
+++ b/include/stumpless/severity.h
@@ -191,6 +191,20 @@ enum stumpless_severity {
 };
 
 /**
+ * The default stumpless ansi terminal color values
+ */
+#define STUMPLESS_SEVERITY_EMERG_DEFAULT_COLOR   "\33[31;1m"
+#define STUMPLESS_SEVERITY_ALERT_DEFAULT_COLOR   "\33[31;1m"
+#define STUMPLESS_SEVERITY_CRIT_DEFAULT_COLOR    "\33[31m"
+#define STUMPLESS_SEVERITY_ERR_DEFAULT_COLOR     "\33[31m"
+#define STUMPLESS_SEVERITY_WARNING_DEFAULT_COLOR "\33[33m"
+#define STUMPLESS_SEVERITY_NOTICE_DEFAULT_COLOR  "\33[32m"
+#define STUMPLESS_SEVERITY_INFO_DEFAULT_COLOR    "\33[37m"
+#define STUMPLESS_SEVERITY_DEBUG_DEFAULT_COLOR   "\33[0m"
+
+
+
+/**
  * Equivalent to the DEBUG severity. Trace level messages include extra
  * information, but do not have a distinct severity value in log entries.
  *

--- a/include/stumpless/target/stream.h
+++ b/include/stumpless/target/stream.h
@@ -38,6 +38,7 @@
 #  include <stdio.h>
 #  include <stumpless/config.h>
 #  include <stumpless/target.h>
+#  include <stumpless/severity.h>
 
 #  ifdef __cplusplus
 extern "C" {
@@ -153,6 +154,32 @@ stumpless_open_stdout_target( const char *name );
 STUMPLESS_PUBLIC_FUNCTION
 struct stumpless_target *
 stumpless_open_stream_target( const char *name, FILE *stream );
+
+/**
+ * Sets the ANSI code to be printed in a specific target when a log is made at some severity
+ *
+ * It should be used with stdout or stderr as targets, since it is only for aesthetic purposes.
+ *
+ * **Thread Safety: MT-Safe race:name**
+ * This function is thread safe, of course assuming that escape_code is not modified by
+ * any other threads during execution.
+ *
+ * **Async Signal Safety: AS-Unsafe heap**
+ * This function is safe to call from signal handlers.
+ *
+ * **Async Cancel Safety: AC-Unsafe heap**
+ * This function is safe to call from threads that may be asynchronously
+ * cancelled.
+ *
+ * @param target The name of the target for which to set the colors.
+ *
+ * @param severity The severity code (LOG_ERR etc.) to which we set the specific color.
+ *
+ * @param escape_code The ANSI escape code representing the color.
+ */
+STUMPLESS_PUBLIC_FUNCTION
+void
+stumpless_set_severity_color( struct stumpless_target *target, enum stumpless_severity severity, const char *escape_code );
 
 #  ifdef __cplusplus
 }                               /* extern "C" */

--- a/include/stumpless/target/stream.h
+++ b/include/stumpless/target/stream.h
@@ -156,20 +156,22 @@ struct stumpless_target *
 stumpless_open_stream_target( const char *name, FILE *stream );
 
 /**
- * Sets the ANSI code to be printed in a specific target when a log is made at some severity
+ * Sets the ANSI escape code (https://en.wikipedia.org/wiki/ANSI_escape_code) to 
+ * be printed in a specific target when a log is made at some severity.
  *
  * It should be used with stdout or stderr as targets, since it is only for aesthetic purposes.
  *
- * **Thread Safety: MT-Safe race:name**
+ * **Thread Safety: MT-Safe race:escape_code**
  * This function is thread safe, of course assuming that escape_code is not modified by
  * any other threads during execution.
  *
- * **Async Signal Safety: AS-Unsafe heap**
- * This function is safe to call from signal handlers.
+ * **Async Signal Safety: AS-Unsafe lock**
+ * This function is not safe to call from signal handlers due to the destruction
+ * of a lock that may be in use.
  *
- * **Async Cancel Safety: AC-Unsafe heap**
- * This function is safe to call from threads that may be asynchronously
- * cancelled.
+ * **Async Cancel Safety: AC-Unsafe lock**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, as the cleanup of the lock may not be completed.
  *
  * @param target The name of the target for which to set the colors.
  *

--- a/src/target.c
+++ b/src/target.c
@@ -267,7 +267,7 @@ stumpless_add_entry( struct stumpless_target *target,
       break;
 
     case STUMPLESS_STREAM_TARGET:
-      result = sendto_stream_target( target->id, buffer, builder_length );
+      result = sendto_stream_target( target->id, buffer, builder_length, entry );
       break;
 
     case STUMPLESS_WINDOWS_EVENT_LOG_TARGET:

--- a/src/target/stream.c
+++ b/src/target/stream.c
@@ -172,38 +172,35 @@ sendto_stream_target( struct stream_target *target,
   const char *reset_code = "\33[0m";
   unsigned short reset_code_len = strlen(sev_code);
   
+  config_lock_mutex( &target->stream_mutex );
   if (sev_code_len != 0)
   {
-    config_lock_mutex( &target->stream_mutex );
     fwrite_result = fwrite( sev_code, sizeof( char ), sev_code_len, target->stream );
-    config_unlock_mutex( &target->stream_mutex );
 
     if( fwrite_result != sev_code_len ) {
       goto write_failure;
     }
   }
 
-  config_lock_mutex( &target->stream_mutex );
   fwrite_result = fwrite( msg, sizeof( char ), msg_length, target->stream );
-  config_unlock_mutex( &target->stream_mutex );
   if( fwrite_result != msg_length ) {
     goto write_failure;
   }
 
   if (sev_code_len != 0)
   {
-    config_lock_mutex( &target->stream_mutex );
     fwrite_result = fwrite( reset_code, sizeof( char ), reset_code_len, target->stream );
-    config_unlock_mutex( &target->stream_mutex );
 
     if( fwrite_result != reset_code_len ) {
       goto write_failure;
     }
   }
 
+  config_unlock_mutex( &target->stream_mutex );
   return cap_size_t_to_int( fwrite_result + 1 );
 
 write_failure:
+  config_unlock_mutex( &target->stream_mutex );
   raise_stream_write_failure(  );
   return -1;
 }

--- a/src/target/stream.c
+++ b/src/target/stream.c
@@ -52,6 +52,8 @@ stumpless_close_stream_target( const struct stumpless_target *target ) {
 struct stumpless_target *
 stumpless_open_stderr_target( const char *name ) {
   struct stumpless_target *target = stumpless_open_stream_target( name, stderr );
+
+  if (target == NULL) return NULL;
   
   stumpless_set_severity_color(target, STUMPLESS_SEVERITY_EMERG_VALUE  , STUMPLESS_SEVERITY_EMERG_DEFAULT_COLOR  );
   stumpless_set_severity_color(target, STUMPLESS_SEVERITY_ALERT_VALUE  , STUMPLESS_SEVERITY_ALERT_DEFAULT_COLOR  );
@@ -68,6 +70,8 @@ stumpless_open_stderr_target( const char *name ) {
 struct stumpless_target *
 stumpless_open_stdout_target( const char *name ) {
   struct stumpless_target *target = stumpless_open_stream_target( name, stdout );
+
+  if (target == NULL) return NULL;
 
   stumpless_set_severity_color(target, STUMPLESS_SEVERITY_EMERG_VALUE  , STUMPLESS_SEVERITY_EMERG_DEFAULT_COLOR  );
   stumpless_set_severity_color(target, STUMPLESS_SEVERITY_ALERT_VALUE  , STUMPLESS_SEVERITY_ALERT_DEFAULT_COLOR  );

--- a/src/target/stream.c
+++ b/src/target/stream.c
@@ -170,7 +170,7 @@ sendto_stream_target( struct stream_target *target,
   const char *sev_code = target->escape_codes[severity];
   unsigned short sev_code_len = strlen(sev_code);
   const char *reset_code = "\33[0m";
-  unsigned short reset_code_len = strlen(sev_code);
+  unsigned short reset_code_len = strlen(reset_code);
   
   config_lock_mutex( &target->stream_mutex );
   if (sev_code_len != 0)

--- a/src/target/stream.c
+++ b/src/target/stream.c
@@ -134,6 +134,7 @@ stumpless_set_severity_color( struct stumpless_target *target, enum stumpless_se
   starget->escape_codes[severity][31] = 0;
 
   unlock_target(target);
+  clear_error();
 }
 
 

--- a/src/target/stream.c
+++ b/src/target/stream.c
@@ -121,8 +121,8 @@ fail:
 void
 stumpless_set_severity_color( struct stumpless_target *target, enum stumpless_severity severity, const char *escape_code )
 {
-  if (severity > 7)
-    raise_index_out_of_bounds("Severity value must be part of 'stumpless_severity' enum (0-7)", severity);
+  if (severity_is_invalid(severity))
+    raise_invalid_severity(severity);
 
   if (target->type != STUMPLESS_STREAM_TARGET)
     raise_target_unsupported("This function is only supported for stream targets");

--- a/src/target/stream.c
+++ b/src/target/stream.c
@@ -124,11 +124,11 @@ stumpless_set_severity_color( struct stumpless_target *target, enum stumpless_se
   if (severity_is_invalid(severity))
     raise_invalid_severity(severity);
 
+  lock_target(target);
   if (target->type != STUMPLESS_STREAM_TARGET)
     raise_target_unsupported("This function is only supported for stream targets");
 
   struct stream_target *starget = (struct stream_target *)target->id;
-  lock_target(target);
 
   strncpy(starget->escape_codes[severity], escape_code, 32);
   starget->escape_codes[severity][31] = 0;

--- a/src/target/stream.c
+++ b/src/target/stream.c
@@ -122,12 +122,16 @@ fail:
 void
 stumpless_set_severity_color( struct stumpless_target *target, enum stumpless_severity severity, const char *escape_code )
 {
-  if (severity_is_invalid(severity))
+  if (severity_is_invalid(severity)) {
     raise_invalid_severity(severity);
+    return;
+  }
 
   lock_target(target);
-  if (target->type != STUMPLESS_STREAM_TARGET)
+  if (target->type != STUMPLESS_STREAM_TARGET) {
     raise_target_unsupported("This function is only supported for stream targets");
+    return;
+  }
 
   struct stream_target *starget = (struct stream_target *)target->id;
 

--- a/src/target/stream.c
+++ b/src/target/stream.c
@@ -31,6 +31,7 @@
 #include "private/target.h"
 #include "private/target/stream.h"
 #include "private/validate.h"
+#include "private/severity.h"
 
 void
 stumpless_close_stream_target( const struct stumpless_target *target ) {

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -246,3 +246,4 @@ EXPORTS
   stumpless_set_entry_message_str_w             @229
   
   stumpless_get_prival_string                   @230
+  stumpless_set_severity_color                  @231

--- a/test/function/target/stream.cpp
+++ b/test/function/target/stream.cpp
@@ -404,4 +404,17 @@ namespace {
 
     remove( filename );
   }
+
+  TEST(StreamSetSeverityColorTest, InvalidSeverity) {
+    struct stumpless_target *target = stumpless_open_stdout_target("stdout");
+    stumpless_set_severity_color(target, (enum stumpless_severity) 15, "\33[0m");
+    EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_SEVERITY);
+  }
+
+  TEST(StreamSetSeverityColorTest, WrongTargetType) {
+    char buf;
+    struct stumpless_target *target = stumpless_open_buffer_target("buffer", &buf, 1);
+    stumpless_set_severity_color(target, STUMPLESS_SEVERITY_ALERT, "\33[0m");
+    EXPECT_ERROR_ID_EQ(STUMPLESS_TARGET_UNSUPPORTED);
+  }
 }

--- a/test/function/target/stream.cpp
+++ b/test/function/target/stream.cpp
@@ -282,7 +282,8 @@ namespace {
 #endif
     }
 
-    stumpless_close_stream_target(target);
+    stumpless_close_target(target);
+    stumpless_free_all();
 
     std::ifstream infile(filename);
 /*
@@ -353,7 +354,8 @@ namespace {
 #endif
     }
 
-    stumpless_close_stream_target(target);
+    stumpless_close_target(target);
+    stumpless_free_all();
 
     std::ifstream infile(filename);
 /* See comment in StreamTargetStderrTest.ColoredStream */
@@ -418,13 +420,21 @@ namespace {
   TEST(StreamSetSeverityColorTest, InvalidSeverity) {
     struct stumpless_target *target = stumpless_open_stdout_target("stdout");
     stumpless_set_severity_color(target, (enum stumpless_severity) 15, "\33[0m");
+
     EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_SEVERITY);
+
+    stumpless_close_target(target);
+    stumpless_free_all();
   }
 
   TEST(StreamSetSeverityColorTest, WrongTargetType) {
     char buf;
     struct stumpless_target *target = stumpless_open_buffer_target("buffer", &buf, 1);
     stumpless_set_severity_color(target, STUMPLESS_SEVERITY_ALERT, "\33[0m");
+
     EXPECT_ERROR_ID_EQ(STUMPLESS_TARGET_UNSUPPORTED);
+
+    stumpless_close_target(target);
+    stumpless_free_all();
   }
 }

--- a/test/function/target/stream.cpp
+++ b/test/function/target/stream.cpp
@@ -285,6 +285,15 @@ namespace {
     stumpless_close_stream_target(target);
 
     std::ifstream infile(filename);
+/*
+ * Google Test uses a more simplified regex engine for windows
+ * (see here: https://google.github.io/googletest/advanced.html#regular-expression-syntax) 
+ * which does not support things like conditionals, grouping or brackets.
+ * Hence we use the following preprocessor statement to use a different
+ * test when this is run on platforms with the simple regex, and hopefully 
+ * once a reasonably complex regex engine is implemented in all the major
+ * platforms this is not needed.
+ **/
 #ifdef GTEST_USES_SIMPLE_RE
     std::string line;
     bool first = true;
@@ -347,6 +356,7 @@ namespace {
     stumpless_close_stream_target(target);
 
     std::ifstream infile(filename);
+/* See comment in StreamTargetStderrTest.ColoredStream */
 #ifdef GTEST_USES_SIMPLE_RE
     std::string line;
     bool first = true;

--- a/test/function/target/stream.cpp
+++ b/test/function/target/stream.cpp
@@ -257,17 +257,29 @@ namespace {
 
     target = stumpless_open_stderr_target( "stderr-target" );
     ASSERT_NOT_NULL( target );
-
+#ifndef STDERR_FILENO
+    int save_stderr = _dup(_fileno(stderr));
+#else
     int save_stderr = dup(STDERR_FILENO);
+#endif
     for (i = 0; i < 8; i++)
     {
+#ifndef STDERR_FILENO
+      save_stderr = _dup(save_stderr);
+#else
       save_stderr = dup(save_stderr);
+#endif
       freopen(filename, "a+", stderr);
 
       stumpless_add_log_str(target, i, stumpless_get_severity_string((enum stumpless_severity)i)); 
-
+      
+      
+#ifndef STDERR_FILENO
+      _dup2(save_stderr, _fileno(stderr));
+#else
       fclose(stderr);
       stderr = fdopen(save_stderr, "w");
+#endif
     }
 
     stumpless_close_stream_target(target);
@@ -287,17 +299,28 @@ namespace {
 
     target = stumpless_open_stdout_target( "stdout-target" );
     ASSERT_NOT_NULL( target );
-
+#ifndef STDOUT_FILENO
+    int save_stdout = _dup(_fileno(stdout));
+#else
     int save_stdout = dup(STDOUT_FILENO);
+#endif
     for (i = 0; i < 8; i++)
     {
+#ifndef STDOUT_FILENO
+      save_stdout = _dup(save_stdout);
+#else
       save_stdout = dup(save_stdout);
+#endif
       freopen(filename, "a+", stdout);
 
       stumpless_add_log_str(target, i, stumpless_get_severity_string((enum stumpless_severity)i)); 
 
+#ifndef STDOUT_FILENO
+      _dup2(save_stdout, _fileno(stdout));
+#else
       fclose(stdout);
       stdout = fdopen(save_stdout, "w");
+#endif
     }
 
     stumpless_close_stream_target(target);

--- a/test/function/target/stream.cpp
+++ b/test/function/target/stream.cpp
@@ -284,12 +284,33 @@ namespace {
 
     stumpless_close_stream_target(target);
 
-    std::ifstream infile( filename );
+    std::ifstream infile(filename);
+#ifdef GTEST_USES_SIMPLE_RE
+    std::string line;
+    bool first = true;
+
+    while (std::getline(infile, line))
+    {
+        EXPECT_THAT(line, testing::Conditional(
+            first,
+            testing::AnyOf(
+                testing::MatchesRegex("\33\\[3\\d;?1?m.*"),
+                testing::MatchesRegex("\33\\[0m.*")
+            ),
+            testing::AnyOf(
+                testing::MatchesRegex("\33\\[0m\33\\[3\\d;?1?m.*"),
+                testing::MatchesRegex("\33\\[0m\33\\[0m.*"),
+                testing::MatchesRegex("\33\\[0m.*")
+            )  
+        ));
+        if (first) first = false;
+    }
+#else
     std::stringstream buf;
     buf << infile.rdbuf();
     std::string src = buf.str();
-
     EXPECT_THAT(src, testing::MatchesRegex("(\33\\[(0|3[0-7]);?1?m.*\n\33\\[0m)*"));
+#endif
   }
 
   TEST( StreamTargetStdoutTest, ColoredStream ) {
@@ -325,12 +346,33 @@ namespace {
 
     stumpless_close_stream_target(target);
 
-    std::ifstream infile( filename );
+    std::ifstream infile(filename);
+#ifdef GTEST_USES_SIMPLE_RE
+    std::string line;
+    bool first = true;
+
+    while (std::getline(infile, line))
+    {
+        EXPECT_THAT(line, testing::Conditional(
+            first,
+            testing::AnyOf(
+                testing::MatchesRegex("\33\\[3\\d;?1?m.*"),
+                testing::MatchesRegex("\33\\[0m.*")
+            ),
+            testing::AnyOf(
+                testing::MatchesRegex("\33\\[0m\33\\[3\\d;?1?m.*"),
+                testing::MatchesRegex("\33\\[0m\33\\[0m.*"),
+                testing::MatchesRegex("\33\\[0m.*")
+            )
+        ));
+        if (first) first = false;
+    }
+#else
     std::stringstream buf;
     buf << infile.rdbuf();
     std::string src = buf.str();
-
     EXPECT_THAT(src, testing::MatchesRegex("(\33\\[(0|3[0-7]);?1?m.*\n\33\\[0m)*"));
+#endif
   }
 
   TEST( StreamTargetWriteTest, ReadOnlyStream ) {


### PR DESCRIPTION
Adds support for using ansi escape codes to represent different severity levels when printing to a terminal, and presents some default escape codes. Allows for . Solves #103.

Unit tests were not written however, as I was unsure how to capture the stdout to check it was correctly printing ansi terminals (I did check with a script on my side that it was working).

This is my first open source contribution so any feedback is welcome.