### PR TITLE
fix l10n script

### DIFF
--- a/include/private/config/locale/bg-bg.h
+++ b/include/private/config/locale/bg-bg.h
@@ -230,6 +230,10 @@ ARG_NAME " беше NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "неуспешно изпращане с winsock2 сокет"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "неуспешно отваряне на сокет"
 

--- a/include/private/config/locale/bn-in.h
+++ b/include/private/config/locale/bn-in.h
@@ -217,6 +217,10 @@ ARG_NAME " NULL ছিল"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "একটি winsock2 সকেট দিয়ে পাঠাতে ব্যর্থ হয়েছে"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "একটি সকেট খুলতে ব্যর্থ"
 

--- a/include/private/config/locale/cz-cz.h
+++ b/include/private/config/locale/cz-cz.h
@@ -222,6 +222,10 @@ ARG_NAME " měl hodnotu NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "odesílání winsock2 socketu selhalo"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "otevření socketu selhalo"
 

--- a/include/private/config/locale/da-dk.h
+++ b/include/private/config/locale/da-dk.h
@@ -208,6 +208,10 @@ ARG_NAME " var NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "send fejlede med et winsock2 socket"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "kunne ikke åbne et socket"
 

--- a/include/private/config/locale/de-de.h
+++ b/include/private/config/locale/de-de.h
@@ -238,6 +238,10 @@ ARG_NAME " war NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "Senden mit einem winsock2-Socket fehlgeschlagen"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "Konnte keinen Socket öffnen"
 

--- a/include/private/config/locale/el-gr.h
+++ b/include/private/config/locale/el-gr.h
@@ -225,6 +225,10 @@ ARG_NAME " κατέχει την τιμή NULL"
 # define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "αποτυχία συνάρτησης send σε υποδοχέα winsock2"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 # define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "αποτυχία ανοίγματος υποδοχέα"
 

--- a/include/private/config/locale/en-us.h
+++ b/include/private/config/locale/en-us.h
@@ -209,6 +209,9 @@ ARG_NAME " was NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "send failed with a winsock2 socket"
 
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "failed to open a socket"
 

--- a/include/private/config/locale/es-es.h
+++ b/include/private/config/locale/es-es.h
@@ -210,6 +210,10 @@ ARG_NAME " fue NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "se ha fallado al enviar con socket winsock2"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "se ha fallado al abrir el socket"
 

--- a/include/private/config/locale/fr-fr.h
+++ b/include/private/config/locale/fr-fr.h
@@ -208,6 +208,10 @@ ARG_NAME " a été NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "envoi échoué avec un socket winsock2"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "échec d'ouverture d'un socket"
 

--- a/include/private/config/locale/he-il.h
+++ b/include/private/config/locale/he-il.h
@@ -209,6 +209,10 @@
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "winsock2 נכשל עם השקע send"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "נכשל בפתיחת שקע"
 

--- a/include/private/config/locale/hi-in.h
+++ b/include/private/config/locale/hi-in.h
@@ -212,6 +212,10 @@ ARG_NAME " NULL था"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "winsock2 सॉकेट के साथ भेजना विफल रहा"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "सॉकेट खोलने में विफल"
 

--- a/include/private/config/locale/hu-hu.h
+++ b/include/private/config/locale/hu-hu.h
@@ -214,6 +214,10 @@ ARG_NAME " volt NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "a küldés nem sikerült winsock2 sockettel"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "nem sikerült kinyitni az aljzatot"
 

--- a/include/private/config/locale/it-it.h
+++ b/include/private/config/locale/it-it.h
@@ -210,6 +210,10 @@ ARG_NAME " era NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "send fallita con un socket winsock2"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "fallita apertura di un socket"
 

--- a/include/private/config/locale/ja-jp.h
+++ b/include/private/config/locale/ja-jp.h
@@ -207,6 +207,10 @@ ARG_NAME "NULL でした"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "winsock2 ソケットで送信に失敗しました"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "ソケットを開けませんでした"
 

--- a/include/private/config/locale/ko-kr.h
+++ b/include/private/config/locale/ko-kr.h
@@ -206,6 +206,10 @@ ARG_NAME "이 NULL입니다"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "winsock2 소켓으로 send 호출에 실패"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "소켓 열기에 실패했습니다"
 

--- a/include/private/config/locale/pl-pl.h
+++ b/include/private/config/locale/pl-pl.h
@@ -225,6 +225,10 @@ ARG_NAME " miał wartość NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "wysyłanie winsock2 socketu przegrany"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "otwór w gnieździe przegrany"
 

--- a/include/private/config/locale/pt-br.h
+++ b/include/private/config/locale/pt-br.h
@@ -211,6 +211,10 @@ ARG_NAME " era NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "envio falhou com um socket winsock2"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "erro ao tentar abrir um socket"
 

--- a/include/private/config/locale/si-lk.h
+++ b/include/private/config/locale/si-lk.h
@@ -208,6 +208,10 @@ ARG_NAME " NULL විය"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "winsock2 socket සමඟ යැවීම අසාර්ථක විය"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "සොකට් එකක් විවෘත කිරීමට අසමත් විය"
 

--- a/include/private/config/locale/sk-sk.h
+++ b/include/private/config/locale/sk-sk.h
@@ -234,6 +234,10 @@ ARG_NAME " mal hodnotu NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "odosielanie winsock2 socketu zlyhalo"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "otvorenie socketu zlyhalo"
 

--- a/include/private/config/locale/sq-al.h
+++ b/include/private/config/locale/sq-al.h
@@ -215,6 +215,10 @@ ARG_NAME " ishte NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "dërgimi dështoi me një prizë (socket) të tipit winsock2"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "dështoi hapja e një prize (socket-e)"
 

--- a/include/private/config/locale/sv-se.h
+++ b/include/private/config/locale/sv-se.h
@@ -237,6 +237,10 @@ ARG_NAME " var NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "misslyckades att skicka med en winsock2-Socket"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "misslyckades med att öppna en Socket"
 

--- a/include/private/config/locale/sw-ke.h
+++ b/include/private/config/locale/sw-ke.h
@@ -214,6 +214,10 @@ ARG_NAME " ilikuwa NULL"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "tuma umeshindwa na soketi ya winsock2"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "kushindwa kufungua soketi"
 

--- a/include/private/config/locale/te-in.h
+++ b/include/private/config/locale/te-in.h
@@ -207,6 +207,10 @@ ARG_NAME " శూన్యం"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "విన్సాక్2 సాకెట్తో పంపడం విఫలమైంది"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "సాకెట్ తెరవడంలో విఫలమైంది"
 

--- a/include/private/config/locale/tr-tr.h
+++ b/include/private/config/locale/tr-tr.h
@@ -212,6 +212,10 @@ ARG_NAME " NULL idi"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "winsock2 soketi ile gönderme başarısız oldu"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "soket açılamadı"
 

--- a/include/private/config/locale/zh-cn.h
+++ b/include/private/config/locale/zh-cn.h
@@ -213,6 +213,10 @@ ARG_NAME "是空的"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "sendfailed带有winsock2 socket"
 
+// todo translate
+#  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
+"severity colors are only supported for stream targets"
+
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "无法打开套接字"
 

--- a/scripts/add_l10n_string.rb
+++ b/scripts/add_l10n_string.rb
@@ -50,7 +50,7 @@ define_lines = ["#  define #{define_name} \\\n", english_lines].flatten
 
 root_dir = File.expand_path('..', __dir__)
 locale_dir = File.join(root_dir, 'include', 'private', 'config', 'locale')
-Dir.new(locale_dir).each do |file|
+Dir.new(locale_dir).each_child do |file|
   new_file_lines = []
   line_buffer = []
   inserted = false

--- a/src/target/stream.c
+++ b/src/target/stream.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2018-2020 Joel E. Anderson
+ * Copyright 2018-2024 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,7 +129,8 @@ stumpless_set_severity_color( struct stumpless_target *target, enum stumpless_se
 
   lock_target(target);
   if (target->type != STUMPLESS_STREAM_TARGET) {
-    raise_target_unsupported("This function is only supported for stream targets");
+    raise_target_unsupported(
+      L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE );
     return;
   }
 


### PR DESCRIPTION
Fixes the functionality of the `add_l10n_string.rb` script and localizes the error message for severity colors with non-stream targets, as this was not added due to the broken script. This was identified during work on #427.
