### PR TITLE
Implemented Strcasecomp

### DIFF
--- a/src/facility.c
+++ b/src/facility.c
@@ -46,12 +46,11 @@ stumpless_get_facility_enum_from_buffer(const char *facility_buffer, size_t faci
  size_t i;
  char *facility_name;
  const int str_offset = 19; // to ommit "STUMPLESS_FACILITY_"
- size_t buf_length;
 
  facility_bound = sizeof( facility_enum_to_string ) /
            sizeof( facility_enum_to_string[0] );
 
- facility_name = copy_cstring_with_length(facility_buffer, &buf_length);
+ facility_name = copy_cstring_length(facility_buffer, facility_buffer_length);
  if( !facility_name ) {
   return -1;
  }

--- a/src/facility.c
+++ b/src/facility.c
@@ -44,38 +44,27 @@ enum stumpless_facility
 stumpless_get_facility_enum_from_buffer(const char *facility_buffer, size_t facility_buffer_length) {
  size_t facility_bound;
  size_t i;
- char *facility_name;
  const int str_offset = 19; // to ommit "STUMPLESS_FACILITY_"
 
  facility_bound = sizeof( facility_enum_to_string ) /
            sizeof( facility_enum_to_string[0] );
 
- facility_name = copy_cstring_length(facility_buffer, facility_buffer_length);
- if( !facility_name ) {
-  return -1;
- }
-
- to_upper_case(facility_name);
  for( i = 0; i < facility_bound; i++ ) {
-  if( strcmp( facility_name, facility_enum_to_string[i] + str_offset ) == 0 ) {
-   free_mem( facility_name );
+  if( strncasecmp( facility_buffer, facility_enum_to_string[i] + str_offset, facility_buffer_length ) == 0 ) {
    return i << 3;
   }
  }
 
  // exeption, for 'security' return 'auth' enum value
-  if( strcmp( facility_name, "SECURITY" ) == 0 ) {
-  free_mem( facility_name );
+  if( strncasecmp( facility_buffer, "SECURITY", facility_buffer_length ) == 0 ) {
   return STUMPLESS_FACILITY_AUTH_VALUE;
  }
 
  // exeption, for 'authpriv' not presented in enum list
-  if( strcmp( facility_name, "AUTHPRIV" ) == 0 ) {
-  free_mem( facility_name );
+  if( strncasecmp( facility_buffer, "AUTHPRIV", facility_buffer_length ) == 0 ) {
   return STUMPLESS_FACILITY_AUTH2_VALUE;
  }
 
- free_mem( facility_name );
  return -1;
 }
 

--- a/src/prival.c
+++ b/src/prival.c
@@ -114,7 +114,7 @@ stumpless_prival_from_string( const char *string ) {
 
   severity = stumpless_get_severity_enum_from_buffer( period + 1, len );
 
-  if( severity < 0 ) {
+  if( severity < 0 && !stumpless_has_error()) {
     raise_invalid_param(  );
     return -1;
   }

--- a/src/prival.c
+++ b/src/prival.c
@@ -64,7 +64,6 @@ stumpless_prival_from_string( const char *string ) {
   int prival;
   int severity;
   int facility;
-  const char *param;
   const char *period;
   const char *sec_period;
   size_t len;
@@ -103,15 +102,7 @@ stumpless_prival_from_string( const char *string ) {
   // Calculate the facility length, up to the first period character
   len = period - string;
 
-  // Copy the facility substring to the param buffer
-  param = copy_cstring_length( string, len );
-  if( !param ) {
-    return -1;
-  }
-
-  facility = stumpless_get_facility_enum( param );
-
-  free_mem( param );
+  facility = stumpless_get_facility_enum_from_buffer( string, len );
 
   if( facility < 0 ) {
     raise_invalid_param(  );
@@ -122,15 +113,7 @@ stumpless_prival_from_string( const char *string ) {
   len++;
   len = slen - len;
 
-  // Copy the severity substring to the param buffer
-  param = copy_cstring_length( period + 1, len );
-  if( !param ) {
-    return -1;
-  }
-
-  severity = stumpless_get_severity_enum( param );
-
-  free_mem( param );
+  severity = stumpless_get_severity_enum_from_buffer( period + 1, len );
 
   if( severity < 0 ) {
     raise_invalid_param(  );

--- a/src/prival.c
+++ b/src/prival.c
@@ -24,6 +24,7 @@
 #include <stumpless/prival.h>
 #include <stumpless/severity.h>
 #include <stumpless/facility.h>
+#include <stumpless/error.h>
 #include "private/config.h"
 #include "private/config/wrapper/locale.h"
 #include "private/error.h"

--- a/src/prival.c
+++ b/src/prival.c
@@ -31,7 +31,6 @@
 #include "private/memory.h"
 #include "private/prival.h"
 #include "private/severity.h"
-#include "private/strhelper.h"
 #include "private/validate.h"
 
 const char *

--- a/src/severity.c
+++ b/src/severity.c
@@ -42,41 +42,29 @@ enum stumpless_severity stumpless_get_severity_enum(const char *severity_string)
 enum stumpless_severity stumpless_get_severity_enum_from_buffer(const char *severity_buffer, size_t severity_buffer_length) {
   size_t severity_bound;
   size_t i;
-  char *severity_name;
   const int str_offset = 19; // to ommit "STUMPLESS_SEVERITY_"
 
   severity_bound = sizeof( severity_enum_to_string ) /
                      sizeof( severity_enum_to_string[0] );
 
-  severity_name = copy_cstring_length( severity_buffer, severity_buffer_length );
-  if( !severity_name ) {
-    return -1;
-  }
-
-  to_upper_case( severity_name );
   for( i = 0; i < severity_bound; i++ ) {
-    if( strcmp( severity_name, severity_enum_to_string[i] + str_offset ) == 0 ) {
-      free_mem( severity_name );
+    if( strncasecmp( severity_buffer, severity_enum_to_string[i] + str_offset, severity_buffer_length ) == 0 ) {
       return i;
     }
   }
 
-  if( strcmp( severity_name, "PANIC" ) == 0 ) {
-    free_mem( severity_name );
+  if( strncasecmp( severity_buffer, "PANIC", severity_buffer_length ) == 0 ) {
     return STUMPLESS_SEVERITY_EMERG_VALUE;
   }
 
-  if( strcmp( severity_name, "ERROR" ) == 0 ) {
-    free_mem( severity_name );
+  if( strncasecmp( severity_buffer, "ERROR", severity_buffer_length ) == 0 ) {
     return STUMPLESS_SEVERITY_ERR_VALUE;
   }
 
-  if( strcmp( severity_name, "WARN" ) == 0 ) {
-    free_mem( severity_name );
+  if( strncasecmp( severity_buffer, "WARN", severity_buffer_length ) == 0 ) {
     return STUMPLESS_SEVERITY_WARNING_VALUE;
   }
 
-  free_mem( severity_name );
   return -1;
 }
 

--- a/src/severity.c
+++ b/src/severity.c
@@ -44,12 +44,11 @@ enum stumpless_severity stumpless_get_severity_enum_from_buffer(const char *seve
   size_t i;
   char *severity_name;
   const int str_offset = 19; // to ommit "STUMPLESS_SEVERITY_"
-  size_t buf_length;
 
   severity_bound = sizeof( severity_enum_to_string ) /
                      sizeof( severity_enum_to_string[0] );
 
-  severity_name = copy_cstring_with_length( severity_buffer, &buf_length );
+  severity_name = copy_cstring_length( severity_buffer, severity_buffer_length );
   if( !severity_name ) {
     return -1;
   }

--- a/test/function/prival.cpp
+++ b/test/function/prival.cpp
@@ -112,34 +112,6 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_PARAM_STRING );
   }
 
-  TEST( GetPrivalFromString, InvalidMemFacilityPriority ) {
-    int result;
-    void * (*set_malloc_result)(size_t);
-    set_malloc_result = stumpless_set_malloc( MALLOC_FAIL );
-    ASSERT_NOT_NULL( set_malloc_result );
-
-    result = stumpless_prival_from_string( "user.err" );
-    EXPECT_EQ( result, -1 );
-
-    set_malloc_result = stumpless_set_malloc( malloc );
-    EXPECT_TRUE( set_malloc_result == malloc );
-  }
-
-  TEST( GetPrivalFromString, InvalidMemSeverityPriority ) {
-    int result;
-    void * (*set_malloc_result)(size_t);
-    set_malloc_result = stumpless_set_malloc( MALLOC_FAIL_ON_SIZE( 4 ) );
-    ASSERT_NOT_NULL( set_malloc_result );
-
-    result = stumpless_prival_from_string( "syslog.err" );
-    EXPECT_EQ( result, -1 );
-
-    EXPECT_ERROR_ID_EQ( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
-
-    set_malloc_result = stumpless_set_malloc( malloc );
-    EXPECT_TRUE( set_malloc_result == malloc );
-  }
-
   TEST(GetPrivalString, ValidPrival) {
     int prival;
     const char *result;

--- a/test/function/prival.cpp
+++ b/test/function/prival.cpp
@@ -134,6 +134,8 @@ namespace {
     result = stumpless_prival_from_string( "syslog.err" );
     EXPECT_EQ( result, -1 );
 
+    EXPECT_ERROR_ID_EQ( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
+
     set_malloc_result = stumpless_set_malloc( malloc );
     EXPECT_TRUE( set_malloc_result == malloc );
   }

--- a/test/function/prival.cpp
+++ b/test/function/prival.cpp
@@ -134,8 +134,6 @@ namespace {
     result = stumpless_prival_from_string( "syslog.err" );
     EXPECT_EQ( result, -1 );
 
-    EXPECT_ERROR_ID_EQ( STUMPLESS_MEMORY_ALLOCATION_FAILURE );
-
     set_malloc_result = stumpless_set_malloc( malloc );
     EXPECT_TRUE( set_malloc_result == malloc );
   }

--- a/test/function/prival.cpp
+++ b/test/function/prival.cpp
@@ -21,7 +21,6 @@
 #include <gtest/gtest.h>
 #include <stumpless.h>
 #include "test/helper/assert.hpp"
-#include "test/helper/memory_allocation.hpp"
 
 namespace {
 


### PR DESCRIPTION
This pr fixes #438. With the usage of `strncasecmp` the function `stumpless_prival_from_string`no longer allocates extra memory.

From the tests I ran this reduced the benchmark time (PrivalFromString) from ~2s to ~0.5s.

I removed 2 tests because they no longer made sense.
