### PR TITLE
Issue #445. Testing the behavior of the strncasecmp_custom function. 

### DIFF
--- a/src/strhelper.c
+++ b/src/strhelper.c
@@ -89,7 +89,7 @@ strncasecmp_custom( const char *s1, const char *s2, size_t n ) {
       if (*s1++ == '\0')
         break;
     } while (--n != 0);
-    if(*s2 != '\0') return tolower(*s1) - tolower(*s2);
+    if(*s2 != '\0') return tolower(*s2) - tolower(*s1);
   }
   return 0;
 }

--- a/src/strhelper.c
+++ b/src/strhelper.c
@@ -85,10 +85,11 @@ strncasecmp_custom( const char *s1, const char *s2, size_t n ) {
   if (n != 0) {
     do {
       if (tolower(*s1) != tolower(*s2++))
-        return tolower(*s1) - tolower(*--s2);
+        return tolower(*--s2) - tolower(*s1);
       if (*s1++ == '\0')
         break;
     } while (--n != 0);
+    if(*s2 != '\0') return tolower(*s1) - tolower(*s2);
   }
   return 0;
 }

--- a/test/function/severity.cpp
+++ b/test/function/severity.cpp
@@ -122,5 +122,19 @@ namespace {
   }	
 
 
+  TEST( GetSeverityEnumFromBuffer, OverextendedSeverity ) {
+    enum stumpless_severity result = stumpless_get_severity_enum( "warnings are neat" );
+    EXPECT_EQ( result, -1 );
+    
+    result = stumpless_get_severity_enum( "notices are bad" );
+    EXPECT_EQ( result, -1 );
+
+    result = stumpless_get_severity_enum( "panic you should not" );
+    EXPECT_EQ( result, -1 );
+
+  }	
+
+
+
 
 }

--- a/test/function/severity.cpp
+++ b/test/function/severity.cpp
@@ -114,19 +114,11 @@ namespace {
   }
 
   TEST( GetSeverityEnumFromBuffer, IncompleteSeverity ) {
-    int result;
-
-    result = stumpless_get_severity_enum_from_buffer( "not", 14 );
+    enum stumpless_severity result = stumpless_get_severity_enum( "war" );
     EXPECT_EQ( result, -1 );
-
-    result = stumpless_get_severity_enum_from_buffer( "war", 14 );
+    
+    result = stumpless_get_severity_enum( "not" );
     EXPECT_EQ( result, -1 );
-
-    result = stumpless_get_severity_enum_from_buffer( "pa", 14 );
-    EXPECT_EQ( result, -1 );
-
-    result = stumpless_get_severity_enum_from_buffer( "e", 14 );
-    EXPECT_EQ( result, -1 ); 
   }	
 
 

--- a/test/function/severity.cpp
+++ b/test/function/severity.cpp
@@ -113,4 +113,22 @@ namespace {
     EXPECT_EQ( result, -1 );
   }
 
+  TEST( GetSeverityEnumFromBuffer, IncompleteSeverity ) {
+    int result;
+
+    result = stumpless_get_severity_enum_from_buffer( "not", 14 );
+    EXPECT_EQ( result, -1 );
+
+    result = stumpless_get_severity_enum_from_buffer( "war", 14 );
+    EXPECT_EQ( result, -1 );
+
+    result = stumpless_get_severity_enum_from_buffer( "pa", 14 );
+    EXPECT_EQ( result, -1 );
+
+    result = stumpless_get_severity_enum_from_buffer( "e", 14 );
+    EXPECT_EQ( result, -1 ); 
+  }	
+
+
+
 }


### PR DESCRIPTION
Related to issue #445 fix custom strncasecmp implementation.

It was described that the strncasecmp_custom function was going to fail and emit that strings like "not" and "NOTICE" were equal. However, the current implementation passed tests of this style (I added them).

This was a not a notable change so I did not add anything to ChangeLog.

Thanks.
