### PR TITLE
Fixes #450: Adds new function for generating a shorter form prival string.

### DIFF
--- a/include/stumpless/prival.h
+++ b/include/stumpless/prival.h
@@ -59,6 +59,33 @@ STUMPLESS_PUBLIC_FUNCTION
 const char *
 stumpless_get_prival_string( int prival );
 
+/** 
+ * Gets the string representation of the given prival in the format
+ * "facility.level".
+ * 
+ * The string returned must be freed by the caller when it is no longer
+ * needed to avoid memory leaks.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe.
+ *
+ * **Async Signal Safety: AS-Unsafe heap**
+ * This function is not safe to call from signal handlers due to the use of
+ * memory management functions.
+ *
+ * **Async Cancel Safety: AC-Unsafe heap**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled due to the use of memory management functions.
+ * 
+ * @param prival int to get the string from.
+ * 
+ * @return The string representation of the given prival.
+ * 
+*/
+STUMPLESS_PUBLIC_FUNCTION
+const char *
+stumpless_get_priority_string( int prival );
+
 /**
  * Extract PRIVAL number (Facility and Severity) from the given string with
  * the direct number or with two names divided with a period in the order:

--- a/src/prival.c
+++ b/src/prival.c
@@ -58,6 +58,31 @@ stumpless_get_prival_string( int prival ) {
   return prival_string;
 }
 
+const char *
+stumpless_get_priority_string( int prival ) {
+  const char *severity;
+  const char *facility;
+  size_t priority_string_size;
+  char* priority_string;
+
+  severity = stumpless_get_severity_string( get_severity( prival ) );
+  facility = stumpless_get_facility_string( get_facility( prival ) );
+   
+  size_t len_severity = strlen(severity);
+  size_t len_facility = strlen(facility);
+
+  // +1 for '.' formatting, +1 for termination
+  priority_string_size = ( len_severity + len_facility + 2);
+  priority_string = alloc_mem( priority_string_size );
+
+  memcpy( priority_string, severity , len_severity); 
+  memcpy( priority_string + len_severity, ".", 1); 
+  memcpy( priority_string + len_severity + 1, facility, len_facility);
+  memcpy( priority_string + len_severity + 1 + len_facility, "\0", 1);
+
+  return priority_string;
+}
+
 int
 stumpless_prival_from_string( const char *string ) {
   int prival;

--- a/src/prival.c
+++ b/src/prival.c
@@ -75,10 +75,10 @@ stumpless_get_priority_string( int prival ) {
   priority_string_size = ( len_severity + len_facility + 2);
   priority_string = alloc_mem( priority_string_size );
 
-  memcpy( priority_string, severity , len_severity); 
-  memcpy( priority_string + len_severity, ".", 1); 
-  memcpy( priority_string + len_severity + 1, facility, len_facility);
-  memcpy( priority_string + len_severity + 1 + len_facility, "\0", 1);
+  memcpy( priority_string, facility , len_facility); 
+  priority_string[len_severity] = '.';
+  memcpy( priority_string + len_facility + 1, severity, len_severity);
+  priority_string[priority_string_size-1] = "\0";
 
   return priority_string;
 }

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -247,3 +247,4 @@ EXPORTS
   
   stumpless_get_prival_string                   @230
   stumpless_set_severity_color                  @231
+  stumpless_get_priority_string                 @232

--- a/test/function/prival.cpp
+++ b/test/function/prival.cpp
@@ -121,4 +121,15 @@ namespace {
 
     free( ( void * ) result );
   }
+
+  TEST(GetPriorityString, ValidPrival) {
+    int prival;
+    const char *result;
+
+    prival = STUMPLESS_SEVERITY_ERR | STUMPLESS_FACILITY_USER;
+    result = stumpless_get_priority_string( prival );
+    EXPECT_STREQ( result, "STUMPLESS_SEVERITY_ERR.STUMPLESS_FACILITY_USER" );
+
+    free( ( void * ) result );
+  }
 }

--- a/test/function/prival.cpp
+++ b/test/function/prival.cpp
@@ -128,7 +128,7 @@ namespace {
 
     prival = STUMPLESS_SEVERITY_ERR | STUMPLESS_FACILITY_USER;
     result = stumpless_get_priority_string( prival );
-    EXPECT_STREQ( result, "STUMPLESS_SEVERITY_ERR.STUMPLESS_FACILITY_USER" );
+    EXPECT_STREQ( result, "STUMPLESS_FACILITY_USER.STUMPLESS_SEVERITY_ERR" );
 
     free( ( void * ) result );
   }


### PR DESCRIPTION
Adds a new function for a condensed and logger-standard prival string.
