### PR TITLE
test cache page allocation failure

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -71,6 +71,7 @@ add_page( struct cache *c ) {
   if( !new_pages ) {
     return -1;
   }
+  c->pages = new_pages;
 
   new_page = alloc_mem( c->page_size );
   if( !new_page ) {
@@ -80,7 +81,6 @@ add_page( struct cache *c ) {
   new_page_index = c->page_count;
   c->page_count++;
 
-  c->pages = new_pages;
   c->pages[new_page_index] = new_page;
   init_page( c, new_page_index );
 

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -1868,7 +1868,6 @@ namespace {
 
   TEST(NewEntryTest, MallocFailureAfterCacheFill) {
     struct stumpless_entry *entries[2000];
-    struct stumpless_entry *entry;
     size_t i,j;
     const char *app_name = "test-app-name";
     const char *msgid = "test-msgid";

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -1866,6 +1866,49 @@ namespace {
     stumpless_free_all(  );
   }
 
+  TEST(NewEntryTest, MallocFailureAfterCacheFill) {
+    struct stumpless_entry *entries[2000];
+    struct stumpless_entry *entry;
+    size_t i,j;
+    const char *app_name = "test-app-name";
+    const char *msgid = "test-msgid";
+    void *(*set_malloc_result)(size_t);
+
+    // create an entry to initialize the cache
+    entries[0] = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                                      STUMPLESS_SEVERITY_INFO,
+                                      app_name,
+                                      msgid,
+                                      NULL );
+    EXPECT_NOT_NULL(entries[0]);
+
+    set_malloc_result = stumpless_set_malloc(MALLOC_FAIL);
+    ASSERT_NOT_NULL(set_malloc_result);
+
+    for (i = 1; i < 2000; i++) {
+      entries[i] = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                                        STUMPLESS_SEVERITY_INFO,
+                                        app_name,
+                                        msgid,
+                                        NULL );
+
+      if (!entries[i]) {
+        EXPECT_ERROR_ID_EQ(STUMPLESS_MEMORY_ALLOCATION_FAILURE);
+        break;
+      }
+    }
+
+    EXPECT_NE(i, 2000);
+
+    set_malloc_result = stumpless_set_malloc(malloc);
+    EXPECT_TRUE(set_malloc_result == malloc);
+
+    for (j = 0; j < i; j++) {
+        stumpless_destroy_entry_and_contents(entries[j]);
+    }
+    stumpless_free_all();
+  }
+
   TEST( NewEntryTest, MallocFailureOnMsgid ) {
     void *(*set_malloc_result)(size_t);
     const char *app_name = "test-app-name";


### PR DESCRIPTION
This PR solves #442. This test creates an `entry` structure to initialize the cache and then creates more structures to  fill the cache until a new page allocation fails.