### PR TITLE
draft: RFC5424 origin structure added

### DIFF
--- a/include/stumpless/log.h
+++ b/include/stumpless/log.h
@@ -689,4 +689,22 @@ vstumplog_trace( int priority,
 }                               /* extern "C" */
 #  endif
 
+/*
+ * Returns RFC 5424 origin structured data element that provides information about the originator of the log message.
+ * see: https://datatracker.ietf.org/doc/html/rfc5424#section-7.2
+ *
+ * It used by stumpless' syslog and vsyslogs replacement - stumplog, and vstumplog.
+ *
+ * @return stumpless_element with origin structure
+ * ip - Origin IP address (for now just first address used ipv4 or ipv6)
+ * enterpriseId - Enterprise ID (skipped for now)
+ * software - Software name (stumpless)
+ * swVersion Software version (current version of stumpless)
+ *
+ * @since 2.1.1
+*/
+STUMPLESS_PUBLIC_FUNCTION
+struct stumpless_element*
+get_origin_struct_instance( void );
+
 #endif                          /* __STUMPLESS_LOG_H */

--- a/src/log.c
+++ b/src/log.c
@@ -17,9 +17,25 @@
  */
 
 #include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include <stumpless/log.h>
+#include "private/memory.h"
 #include <stumpless/target.h>
+#include <stumpless/version.h>
+
 #include "private/target.h"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <iphlpapi.h>
+#include <ws2tcpip.h>
+#else
+#include <ifaddrs.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#endif
 
 int
 stump( const char *message, ... ) {
@@ -198,4 +214,157 @@ vstumplog_trace( int priority,
   }
 
   vstumpless_trace_log( target, priority, file, line, func, message, subs );
+}
+
+
+char** get_ip_addresses() {
+  char **ip_addresses = NULL;
+  int ip_addresses_counter = 0;
+  char ip[INET6_ADDRSTRLEN];
+
+  #ifdef _WIN32
+    WSADATA wsaData;
+    if ( WSAStartup( MAKEWORD(2, 2), &wsaData ) != 0 ) {
+        perror( "WSAStartup failed" );
+        return NULL;
+    }
+
+    // Get the list of network interfaces
+    ULONG size = 0;
+    GetAdaptersAddresses( AF_UNSPEC, 0, NULL, NULL, &size );
+    IP_ADAPTER_ADDRESSES *adapterAddresses = (IP_ADAPTER_ADDRESSES *)malloc( size );
+    if ( !adapterAddresses ) {
+      WSACleanup(); // Cleanup before returning
+      return NULL;
+    }
+      if ( GetAdaptersAddresses( AF_UNSPEC, 0, NULL, adapterAddresses, &size ) == NO_ERROR ) {
+        IP_ADAPTER_ADDRESSES *adapter = adapterAddresses;
+        while ( adapter ) {
+          IP_ADAPTER_UNICAST_ADDRESS *unicast = adapter->FirstUnicastAddress;
+          while ( unicast ) {
+            if ( unicast->Address.lpSockaddr->sa_family == AF_INET ) {
+              struct sockaddr_in *sockaddr_in = (struct sockaddr_in *)unicast->Address.lpSockaddr;
+              inet_ntop(AF_INET, &sockaddr_in->sin_addr, ip, sizeof(ip));
+
+              char **temp = realloc( ip_addresses, ( ip_addresses_counter + 1 ) * sizeof(char*) );
+              if (!temp) {
+                // Reallocation failed, cleanup
+                free( adapterAddresses );
+                WSACleanup();
+                for ( int i = 0; i < ip_addresses_counter; i++ ) {
+                  free(ip_addresses[i]);
+                }
+                free(ip_addresses);
+                return NULL;
+              }
+              ip_addresses = temp;
+              ip_addresses[ip_addresses_counter++] = strdup( ip );
+
+            } else if ( unicast->Address.lpSockaddr->sa_family == AF_INET6 ) {
+              struct sockaddr_in6 *sockaddr_in6 = (struct sockaddr_in6 *)unicast->Address.lpSockaddr;
+              inet_ntop( AF_INET6, &sockaddr_in6->sin6_addr, ip, sizeof( ip ) );
+
+              char **temp = realloc( ip_addresses, ( ip_addresses_counter + 1 ) * sizeof(char*) );
+              if ( !temp ) {
+                // Reallocation failed, cleanup
+                free( adapterAddresses );
+                WSACleanup();
+                for ( int i = 0; i < ip_addresses_counter; i++ ) {
+                  free( ip_addresses[i] );
+                }
+                free( ip_addresses );
+                return NULL;
+              }
+              ip_addresses = temp;
+              ip_addresses[ip_addresses_counter++] = strdup(ip);
+            }
+            unicast = unicast->Next;
+          }
+          adapter = adapter->Next;
+        }
+      }
+    free( adapterAddresses );
+    WSACleanup();
+  #else
+    struct ifaddrs *ifaddr, *ifa;
+
+    // Get the list of network interfaces
+    if ( getifaddrs( &ifaddr ) == -1 ) {
+        perror( "getifaddrs" );
+        return NULL;
+    }
+
+    // Loop through all the interfaces
+    for ( ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next ) {
+      if ( ifa->ifa_addr == NULL )
+        continue;
+
+      if ( ifa->ifa_addr->sa_family == AF_INET ) {  // IPv4
+        struct sockaddr_in *addr = (struct sockaddr_in *)ifa->ifa_addr;
+        inet_ntop( AF_INET, &addr->sin_addr, ip, sizeof( ip ) );
+        char **temp = realloc( ip_addresses, ( ip_addresses_counter + 1 ) * sizeof(char*) );
+        if (!temp) {
+          perror("realloc failed");
+          freeifaddrs(ifaddr);
+          for ( int i = 0; i < ip_addresses_counter; i++ ) {
+            free( ip_addresses[i] );
+          }
+          free( ip_addresses );
+          return NULL;
+        }
+        ip_addresses = temp;
+        ip_addresses[ip_addresses_counter++] = strdup( ip );
+
+      } else if ( ifa->ifa_addr->sa_family == AF_INET6 ) {  // IPv6
+        struct sockaddr_in6 *addr = (struct sockaddr_in6 *)ifa->ifa_addr;
+        inet_ntop( AF_INET6, &addr->sin6_addr, ip, sizeof( ip ) );
+        char **temp = realloc( ip_addresses, ( ip_addresses_counter + 1 ) * sizeof( char* ) );
+        if ( !temp ) {
+          perror( "realloc failed" );
+          freeifaddrs( ifaddr );
+          for ( int i = 0; i < ip_addresses_counter; i++ ) {
+            free( ip_addresses[i] );
+          }
+          free( ip_addresses );
+          return NULL;
+        }
+        ip_addresses = temp;
+        ip_addresses[ip_addresses_counter++] = strdup( ip );
+      }
+    }
+
+    // Free the memory allocated by getifaddrs
+    freeifaddrs(ifaddr);
+  #endif
+
+  // Add a NULL terminator to mark the end of the array
+  ip_addresses = realloc( ip_addresses, ( ip_addresses_counter + 1 ) * sizeof( char* ) );
+  if ( ip_addresses ) {
+    ip_addresses[ip_addresses_counter] = NULL;
+  }
+
+  return ip_addresses;
+}
+
+
+struct stumpless_element* get_origin_struct_instance( void ) {
+  char** ip_addressess = get_ip_addresses();
+  int ip_addresses_counter = 0;
+
+  struct stumpless_version* version = stumpless_get_version();
+
+  struct stumpless_element *origin_element = alloc_mem( sizeof( *origin_element ) );
+  stumpless_set_element_name( origin_element, "origin structure" );
+  stumpless_add_new_param( origin_element, "software", "stumpless" );
+  stumpless_add_new_param( origin_element, "swVersion", stumpless_version_to_string( version ) ) ;
+
+  if ( ip_addressess[ ip_addresses_counter ] != NULL ) {
+    stumpless_add_new_param( origin_element, "ip", ip_addressess[ ip_addresses_counter ] );
+
+    while ( ip_addressess[ ip_addresses_counter ] != NULL ) {
+      free( ip_addressess[ ip_addresses_counter ] );
+      ip_addresses_counter++;
+    }
+    free( ip_addressess );
+  }
 }


### PR DESCRIPTION
**draft: RFC5424 origin structure added; addressing #225**

What I don't like: 

1. default stumpless_element_to_string function returns the origin structure in an incorrect format. Correct format should be: ``[origin ip="example.ip" software="stumpless" swVersion="example.version"]``. Should I override function to account for it?
2. stumpless syslog and vsyslog replacements don't return origin structure by default. Should an option be added to them to include origin structure?