### PR TITLE
#451: Implement param into string function

### DIFF
--- a/include/private/config/locale/bg-bg.h
+++ b/include/private/config/locale/bg-bg.h
@@ -22,6 +22,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "не може да се свърже с локален unix сокет"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "буферът е твърде малък за даденото съобщение"
 

--- a/include/private/config/locale/bn-in.h
+++ b/include/private/config/locale/bn-in.h
@@ -23,6 +23,10 @@
 "স্থানীয় ইউনিক্স সকেটের"\
  "সাথে আবদ্ধ করা যায়নি"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "প্রদত্ত বার্তার জন্য"\
  "বাফারটি খুবই ছোট"

--- a/include/private/config/locale/cz-cz.h
+++ b/include/private/config/locale/cz-cz.h
@@ -22,6 +22,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "není možné spojení s unixovým socketem"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "buffer je příliš malý pro tuto zprávu"
 

--- a/include/private/config/locale/da-dk.h
+++ b/include/private/config/locale/da-dk.h
@@ -22,6 +22,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "kunne ikke binde til den lokale unix Socket"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "buffer er for lilel til den givne besked"
 

--- a/include/private/config/locale/de-de.h
+++ b/include/private/config/locale/de-de.h
@@ -22,6 +22,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "konnte sich nicht an den lokalen Unix-Socket binden"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "Puffer ist zu klein für die gegebene Nachricht"
 

--- a/include/private/config/locale/el-gr.h
+++ b/include/private/config/locale/el-gr.h
@@ -22,6 +22,10 @@
 # define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "αδυναμία δέσμευσης στην τοπική υποδοχή unix"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 # define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "το μέγεθος του αποθηκευτικού μέσου δεν επαρκεί για το δοθέν μήνυμα"
 

--- a/include/private/config/locale/en-us.h
+++ b/include/private/config/locale/en-us.h
@@ -26,6 +26,9 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "could not bind to the local unix socket"
 
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "buffer is too small for the given message"
 

--- a/include/private/config/locale/es-es.h
+++ b/include/private/config/locale/es-es.h
@@ -22,6 +22,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "no se pudo vincular con el socket unix local"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "el buffer es demasiado pequeño para el mensaje proporcionado"
 

--- a/include/private/config/locale/fr-fr.h
+++ b/include/private/config/locale/fr-fr.h
@@ -22,6 +22,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "impossible de se lier au socket local unix"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "le tampon est trop petit pour le message donné"
 

--- a/include/private/config/locale/he-il.h
+++ b/include/private/config/locale/he-il.h
@@ -26,6 +26,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "המקומי Unix-לא ניתן היה להתחבר לשקע ה"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "החוצץ קטן מידי עבור ההודעה הנתונה"
 

--- a/include/private/config/locale/hi-in.h
+++ b/include/private/config/locale/hi-in.h
@@ -22,6 +22,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "स्थानीय यूनिक्स सॉकेट से नहीं जुड़ सका"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "दिए गए संदेश के लिए बफ़र बहुत छोटा है"
 

--- a/include/private/config/locale/hu-hu.h
+++ b/include/private/config/locale/hu-hu.h
@@ -26,6 +26,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "nem tudott csatlakozni a helyi unix foglalathoz"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "a puffer túl kicsi az adott üzenethez"
 

--- a/include/private/config/locale/it-it.h
+++ b/include/private/config/locale/it-it.h
@@ -22,6 +22,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "bind con socket locale unix fallita"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "il buffer è troppo piccolo per il messaggio"
 

--- a/include/private/config/locale/ja-jp.h
+++ b/include/private/config/locale/ja-jp.h
@@ -26,6 +26,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "ローカルの UNIX ソケットにバインドできませんでした"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "指定されたメッセージに対してバッファが小さすぎます"
 

--- a/include/private/config/locale/ko-kr.h
+++ b/include/private/config/locale/ko-kr.h
@@ -26,6 +26,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "로컬 UNIX 소켓에 바인딩할 수 없습니다"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "주어진 메시지에 대한 버퍼가 너무 작습니다"
 

--- a/include/private/config/locale/pl-pl.h
+++ b/include/private/config/locale/pl-pl.h
@@ -22,6 +22,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "nie można podłączyć do gniazda unix"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "buffer jest za mały dla tej wiadomości"
 

--- a/include/private/config/locale/pt-br.h
+++ b/include/private/config/locale/pt-br.h
@@ -22,6 +22,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "não foi possível conectar com o socket unix local"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "o buffer é pequeno demais para a mensagem dada"
 

--- a/include/private/config/locale/si-lk.h
+++ b/include/private/config/locale/si-lk.h
@@ -26,6 +26,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "දේශීය යුනික්ස් සොකට් එකට බැඳීමට නොහැකි විය"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "දී ඇති පණිවිඩයට බෆරය කුඩා වැඩිය"
 

--- a/include/private/config/locale/sk-sk.h
+++ b/include/private/config/locale/sk-sk.h
@@ -22,6 +22,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "nieje možné spojenie s unixovým socketom"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "buffer je príliš malý pre tuto správu"
 

--- a/include/private/config/locale/sq-al.h
+++ b/include/private/config/locale/sq-al.h
@@ -26,6 +26,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "nuk mund të bëhej lidhja me unix prizën (socket-ën) lokale"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "buffer-i është shumë i vogël për mesazhin e dhënë"
 

--- a/include/private/config/locale/sv-se.h
+++ b/include/private/config/locale/sv-se.h
@@ -22,6 +22,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "kunde inte binda till den lokala Unix-Socketen"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "buffern är för liten för det givna meddelandet"
 

--- a/include/private/config/locale/sw-ke.h
+++ b/include/private/config/locale/sw-ke.h
@@ -26,6 +26,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "haikuweza kushikamana na soketi ya unix ya ndani" 
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "buffer ni ndogo sana kwa ujumbe uliotolewa"
 

--- a/include/private/config/locale/te-in.h
+++ b/include/private/config/locale/te-in.h
@@ -26,6 +26,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "స్థానిక యునిక్స్ సాకెట్కు బంధించబడలేదు"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "ఇచ్చిన సందేశానికి బఫర్ చాలా చిన్నది"
 

--- a/include/private/config/locale/tr-tr.h
+++ b/include/private/config/locale/tr-tr.h
@@ -26,6 +26,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "yerel unix soketine bağlanamadı"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "tampon bellek verilen mesaj için çok küçük"
 

--- a/include/private/config/locale/zh-cn.h
+++ b/include/private/config/locale/zh-cn.h
@@ -28,6 +28,10 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "无法绑定到本地unix socket"
 
+// todo translate
+#  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
+"buffer used to store the message"
+
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "缓冲区对于给定消息太小"
 

--- a/include/private/error.h
+++ b/include/private/error.h
@@ -53,6 +53,12 @@ raise_argument_too_big( const char *message,
 
 COLD_FUNCTION
 void
+raise_argument_too_small( const char *message,
+                        size_t arg_size,
+                        const char *arg_type );
+
+COLD_FUNCTION
+void
 raise_duplicate_element( void );
 
 COLD_FUNCTION

--- a/include/stumpless/error.h
+++ b/include/stumpless/error.h
@@ -158,7 +158,7 @@ extern "C" {
  */\
   ERROR( STUMPLESS_NETWORK_CLOSED, 33 ) \
 /** 
- * A provided argument was too big, for example maximum alloted buffer size. 
+ * A provided argument was too small, for example maximum allotted buffer size. 
  * 
  * @since release v3.0.0
  */\

--- a/include/stumpless/error.h
+++ b/include/stumpless/error.h
@@ -162,7 +162,7 @@ extern "C" {
  * 
  * @since release v3.0.0
  */\
-  ERROR(STUMPLESS_ARGUMENT_TOO_SMALL, 34)	
+  ERROR( STUMPLESS_ARGUMENT_TOO_SMALL, 34 )	
 
 /**
  * An (enum) identifier of the types of errors that might be encountered.

--- a/include/stumpless/error.h
+++ b/include/stumpless/error.h
@@ -156,7 +156,13 @@ extern "C" {
  *
  * @since release v2.2.0
  */\
-  ERROR( STUMPLESS_NETWORK_CLOSED, 33 )
+  ERROR( STUMPLESS_NETWORK_CLOSED, 33 ) \
+/** 
+ * A provided argument was too big, for example maximum alloted buffer size. 
+ * 
+ * @since release v3.0.0
+ */\
+  ERROR(STUMPLESS_ARGUMENT_TOO_SMALL, 34)	
 
 /**
  * An (enum) identifier of the types of errors that might be encountered.

--- a/include/stumpless/param.h
+++ b/include/stumpless/param.h
@@ -448,6 +448,35 @@ const char *
 stumpless_param_to_string( const struct stumpless_param *param );
 
 /**
+ * Copies the name and the value from param to a buffer string.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe. A mutex is used to coordinate the read of the
+ * param with other accesses and modifications.
+ *
+ * **Async Signal Safety: AS-Unsafe lock heap**
+ * This function is not safe to call from signal handlers due to the use of a
+ * non-reentrant lock to coordinate access and the use of memory management
+ * functions to create the result.
+ *
+ * **Async Cancel Safety: AC-Unsafe lock heap**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, due to the use of a lock that could be left locked as well as
+ * memory management functions.
+ *
+ * @since release v3.0.0
+ *
+ * @param param The param to get the name and the value from.
+ *
+ * @return The size written to the buffer string if no error is
+ * encountered. If an error is encountered, then minimum required size of
+ * the buffer is returned.
+ */
+STUMPLESS_PUBLIC_FUNCTION
+size_t
+stumpless_param_into_string( const struct stumpless_param *param, char *str, size_t max_size );
+
+/**
  * Unloads a param.
  *
  * Either this function, stumpless_unload_element_and_contents, or

--- a/include/stumpless/param.h
+++ b/include/stumpless/param.h
@@ -469,8 +469,9 @@ stumpless_param_to_string( const struct stumpless_param *param );
  * @param param The param to get the name and the value from.
  *
  * @return The size written to the buffer string if no error is
- * encountered. If an error is encountered, then minimum required size of
- * the buffer is returned.
+ * encountered. If error code 'STUMPLESS_ARGUMENT_TOO_SMALL' is encountered, 
+ * then minimum required size of the buffer is returned. If a NULL argument is 
+ * encountered, 0 is returned.
  */
 STUMPLESS_PUBLIC_FUNCTION
 size_t

--- a/src/error.c
+++ b/src/error.c
@@ -158,6 +158,16 @@ raise_argument_too_big( const char *message,
 }
 
 void
+raise_argument_too_small( const char *message,
+                        size_t arg_size,
+                        const char *arg_type ) {
+  raise_error( STUMPLESS_ARGUMENT_TOO_SMALL,
+               message,
+               cap_size_t_to_int( arg_size ),
+               arg_type );
+}
+
+void
 raise_duplicate_element( void ) {
   raise_error( STUMPLESS_DUPLICATE_ELEMENT,
                L10N_DUPLICATE_ELEMENT_ERROR_MESSAGE,

--- a/src/param.c
+++ b/src/param.c
@@ -318,6 +318,48 @@ fail:
     return NULL;
 }
 
+size_t
+stumpless_param_into_string( const struct stumpless_param *param, char *str, size_t max_size ) {
+  const char *name;
+  const char *value;
+  size_t value_len;
+  size_t name_len;
+  size_t min_buff_size;
+
+  VALIDATE_ARG_NOT_NULL( param );
+
+  lock_param( param );
+
+  name  = param->name;
+  value = param->value;
+  name_len = param->name_length;
+  value_len = param->value_length;
+
+  min_buff_size = name_len + value_len + 4;
+  if ( min_buff_size > max_size ) {
+    raise_argument_too_small( L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE,
+                              max_size,
+                              L10N_BUFFER_SIZE_ERROR_CODE_TYPE );
+    goto fail;
+  }
+
+  memcpy(str, name, name_len);
+  memcpy(str + name_len + 2, value, value_len);
+
+  unlock_param( param );
+
+  str[name_len ] = '=';
+  str[name_len + 1] = '\"';
+  str[name_len + value_len + 2] = '\"';
+  str[name_len + value_len + 3] = '\0';
+
+  return min_buff_size;
+
+fail:
+  unlock_param( param );
+  return min_buff_size;
+}
+
 void
 stumpless_unload_param( const struct stumpless_param *param ) {
   if( !param ) {

--- a/src/param.c
+++ b/src/param.c
@@ -326,7 +326,7 @@ stumpless_param_into_string( const struct stumpless_param *param, char *str, siz
   size_t name_len;
   size_t min_buff_size;
 
-  VALIDATE_ARG_NOT_NULL( param );
+  VALIDATE_ARG_NOT_NULL_UNSIGNED_RETURN( param );
 
   lock_param( param );
 

--- a/src/param.c
+++ b/src/param.c
@@ -327,6 +327,7 @@ stumpless_param_into_string( const struct stumpless_param *param, char *str, siz
   size_t min_buff_size;
 
   VALIDATE_ARG_NOT_NULL_UNSIGNED_RETURN( param );
+  VALIDATE_ARG_NOT_NULL_UNSIGNED_RETURN( str );
 
   lock_param( param );
 

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -256,3 +256,4 @@ EXPORTS
   stumpless_get_free                            @231
   stumpless_get_realloc                         @232
   stumpless_get_priority_string                 @233
+  stumpless_param_into_string                   @234

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -209,6 +209,15 @@ namespace {
     free( buffer );
   }
 
+  TEST_F( ParamTest, ParamIntoStringNullBuffer) {
+    const size_t max_size = 100;
+    size_t param_size;
+
+    param_size = stumpless_param_into_string( &basic_param, NULL, max_size );
+    ASSERT_EQ( param_size, 0 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+  }
+
   TEST_F( ParamTest, ParamIntoStringInsufficientBuffer) {
     const size_t max_size = 10;
     size_t param_size;

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -196,6 +196,29 @@ namespace {
     EXPECT_TRUE( set_malloc_result == malloc );
   }
 
+  TEST_F( ParamTest, GetParamIntoString) {
+    const size_t max_size = 100;
+    size_t param_size;
+    char *buffer = (char*)malloc(max_size);
+
+    param_size = stumpless_param_into_string( &basic_param, buffer, max_size );
+    ASSERT_EQ( param_size, (&basic_param)->name_length + (&basic_param)->value_length + 4 );
+    EXPECT_STREQ( buffer, "basic-name=\"basic-value\"" );
+    EXPECT_NO_ERROR;
+  }
+
+  TEST_F( ParamTest, ParamIntoStringInsufficientBuffer) {
+    const size_t max_size = 10;
+    size_t param_size;
+    char *buffer = (char*)malloc(max_size);
+
+    param_size = stumpless_param_into_string( &basic_param, buffer, max_size );
+    ASSERT_EQ( param_size, (&basic_param)->name_length + (&basic_param)->value_length + 4 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_SMALL );
+
+    free( buffer );
+  }
+
   /* non-fixture tests */
 
   TEST( CopyParamTest, NullParam ) {
@@ -588,6 +611,33 @@ namespace {
     result = stumpless_param_to_string( NULL );
     EXPECT_NULL( result );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+  }
+
+  TEST( ParamIntoStringTest, NullParam) {
+    const size_t max_size = 100;
+    size_t param_size;
+    char *buffer = (char*)malloc(max_size);
+
+    param_size = stumpless_param_into_string( NULL, buffer, max_size );
+    ASSERT_EQ( param_size, 0 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+
+    free( buffer );
+  }
+
+  TEST( ParamIntoStringTest, InsufficientBuffer) {
+    const size_t max_size = 10;
+    struct stumpless_param *param;
+    size_t param_size;
+    char *buffer = (char*)malloc(max_size);
+
+    param = stumpless_new_param_from_string( "some-name=\"some-value\"" );
+    param_size = stumpless_param_into_string( param, buffer, max_size );
+    ASSERT_EQ( param_size, param->name_length + param->value_length + 4 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_SMALL );
+
+    free( buffer );
+    stumpless_destroy_param( param );
   }
 
   TEST( UnloadParamTest, NullParam ) {

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -625,21 +625,6 @@ namespace {
     free( buffer );
   }
 
-  TEST( ParamIntoStringTest, InsufficientBuffer) {
-    const size_t max_size = 10;
-    struct stumpless_param *param;
-    size_t param_size;
-    char *buffer = (char*)malloc(max_size);
-
-    param = stumpless_new_param_from_string( "some-name=\"some-value\"" );
-    param_size = stumpless_param_into_string( param, buffer, max_size );
-    ASSERT_EQ( param_size, param->name_length + param->value_length + 4 );
-    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_TOO_SMALL );
-
-    free( buffer );
-    stumpless_destroy_param( param );
-  }
-
   TEST( UnloadParamTest, NullParam ) {
     stumpless_unload_param( NULL );
 

--- a/test/function/param.cpp
+++ b/test/function/param.cpp
@@ -205,6 +205,8 @@ namespace {
     ASSERT_EQ( param_size, (&basic_param)->name_length + (&basic_param)->value_length + 4 );
     EXPECT_STREQ( buffer, "basic-name=\"basic-value\"" );
     EXPECT_NO_ERROR;
+    
+    free( buffer );
   }
 
   TEST_F( ParamTest, ParamIntoStringInsufficientBuffer) {


### PR DESCRIPTION
Issue #451. Summary of changes

1. Implemented `stumpless_param_into_string` function.
2. Added a new error code `STUMPLESS_ARGUMENT_TOO_SMALL` and implemented its raise function.
3. Added a new error code type `L10N_BUFFER_SIZE_ERROR_CODE_TYPE` under all locale header files.
4. Added tests covering basic behaviors of the function.
