### PR TITLE
#455: Added errors to severity functions

### DIFF
--- a/include/stumpless/severity.h
+++ b/include/stumpless/severity.h
@@ -229,7 +229,8 @@ enum stumpless_severity {
  *
  * @param severity The severity to get the string from.
  *
- * @return The string representation of the given severity.
+ * @return The string representation of the given severity. An error code
+ * STUMPLESS_INVALID_SEVERITY is raised if the given severity is not valid.
  */
 STUMPLESS_PUBLIC_FUNCTION
 const char *
@@ -253,7 +254,8 @@ stumpless_get_severity_string( enum stumpless_severity severity );
  * @param severity_string The severity name to get the enum from.
  *
  * @return The enum integer corresponding to the given severity or -1 if
- * the string is not a valid severity name.
+ * the string is not a valid severity name. An error code STUMPLESS_INVALID_SEVERITY
+ * is raised if the string is not a valid severity name.
  */
 STUMPLESS_PUBLIC_FUNCTION
 enum stumpless_severity
@@ -279,7 +281,8 @@ stumpless_get_severity_enum( const char *severity_string );
  * @param length The length of the buffer.
  *
  * @return The enum integer corresponding to the given severity or -1 if
- * the string is not a valid severity name.
+ * the string is not a valid severity name. An error code STUMPLESS_INVALID_SEVERITY
+ * is raised if the string is not a valid severity name.
  */
 STUMPLESS_PUBLIC_FUNCTION
 enum stumpless_severity

--- a/src/severity.c
+++ b/src/severity.c
@@ -19,6 +19,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <stumpless/severity.h>
+#include "private/error.h"
 #include "private/severity.h"
 #include "private/strhelper.h"
 
@@ -29,13 +30,22 @@ static char *severity_enum_to_string[] = {
 const char *
 stumpless_get_severity_string( enum stumpless_severity severity ) {
   if ( !severity_is_invalid( severity ) ) {
+    clear_error(  ); 
     return severity_enum_to_string[severity];
   }
+
+  raise_invalid_severity( severity );
   return "NO_SUCH_SEVERITY";
 }
 
 enum stumpless_severity stumpless_get_severity_enum(const char *severity_string) {
-  return stumpless_get_severity_enum_from_buffer(severity_string, strlen(severity_string));
+  enum stumpless_severity severity_val = stumpless_get_severity_enum_from_buffer(severity_string, strlen(severity_string));
+  if ( severity_is_invalid( severity_val ) ) {
+    raise_invalid_severity( severity_val );
+  } else {
+    clear_error(  );
+  }
+  return severity_val;
 }
 
 enum stumpless_severity stumpless_get_severity_enum_from_buffer(const char *severity_buffer, size_t severity_buffer_length) {
@@ -43,6 +53,8 @@ enum stumpless_severity stumpless_get_severity_enum_from_buffer(const char *seve
   size_t i;
   const int str_offset = 19; // to ommit "STUMPLESS_SEVERITY_"
 
+  clear_error(  );
+  
   severity_bound = sizeof( severity_enum_to_string ) /
                      sizeof( severity_enum_to_string[0] );
 
@@ -64,6 +76,7 @@ enum stumpless_severity stumpless_get_severity_enum_from_buffer(const char *seve
     return STUMPLESS_SEVERITY_WARNING_VALUE;
   }
 
+  raise_invalid_severity( -1 );
   return -1;
 }
 

--- a/test/function/severity.cpp
+++ b/test/function/severity.cpp
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <cstddef>
 #include <gtest/gtest.h>
 #include <stumpless.h>
 #include "test/helper/assert.hpp"
@@ -47,6 +48,26 @@ namespace {
 
     result = stumpless_get_severity_string( wrong_severity );
     EXPECT_STREQ( result, "NO_SUCH_SEVERITY" );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
+  }
+
+  TEST( GetSeverityString, ClearError ) {
+    int severity_count = 0;
+    const char *result;
+    const char *version;
+    
+    version = stumpless_version_to_string( NULL );
+    EXPECT_NULL( version );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+
+    #define COUNT_SEVERITY( STRING, ENUM ) ++severity_count;
+    STUMPLESS_FOREACH_SEVERITY( COUNT_SEVERITY )
+
+    stumpless_severity correct_severity =
+        static_cast<stumpless_severity>(severity_count - 1);
+
+    result = stumpless_get_severity_string( correct_severity );
+    EXPECT_NO_ERROR;
   }
 
   TEST( GetSeverityEnum, EachValidSeverity ) {
@@ -104,6 +125,20 @@ namespace {
 
     result = stumpless_get_severity_enum( "an_invalid_severity" );
     EXPECT_EQ( result, -1 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
+  }
+
+  TEST( GetSeverityEnum, ClearError ) {
+    int severity_count = 0;
+    int result;
+    const char *version;
+    
+    version = stumpless_version_to_string( NULL );
+    EXPECT_NULL( version );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
+
+    result = stumpless_get_severity_enum( "EMERG" );
+    EXPECT_NO_ERROR;
   }
 
   TEST( GetSeverityEnumFromBuffer, NoSuchSeverity ) {
@@ -116,9 +151,11 @@ namespace {
   TEST( GetSeverityEnumFromBuffer, IncompleteSeverity ) {
     enum stumpless_severity result = stumpless_get_severity_enum( "war" );
     EXPECT_EQ( result, -1 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
     
     result = stumpless_get_severity_enum( "not" );
     EXPECT_EQ( result, -1 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
   }	
 
 
@@ -128,13 +165,25 @@ namespace {
     
     result = stumpless_get_severity_enum( "notices are bad" );
     EXPECT_EQ( result, -1 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
 
     result = stumpless_get_severity_enum( "panic you should not" );
     EXPECT_EQ( result, -1 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
 
   }	
 
+  TEST( GetSeverityEnumFromBuffer, ClearError ) {
+    int result;
+    const char *version;
+    
+    version = stumpless_version_to_string( NULL );
+    EXPECT_NULL( version );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
 
+    result = stumpless_get_severity_enum_from_buffer( "EMERG", 5 );
+    EXPECT_NO_ERROR;
+  }
 
 
 }


### PR DESCRIPTION
Issue #455. Summary of changes

1. Raised STUMPLESS_INVALID_SEVERITY error at appropriate places and cleared the error in case of success.
2. Updated the function documentation mentioning the error code raised.
3. Enhanced existing tests to validate error code raised and added new tests to verify clear_error behavior.