### PR TITLE
remove unused strhelper functions

### DIFF
--- a/include/private/strhelper.h
+++ b/include/private/strhelper.h
@@ -34,12 +34,6 @@ copy_cstring( const char *str );
 char *
 copy_cstring_with_length( const char *str, size_t *length );
 
-char *
-copy_cstring_length( const char *str, size_t length );
-
-void
-to_upper_case( char *str );
-
 int
 strncasecmp_custom( const char *s1, const char *s2, size_t n );
 

--- a/src/strhelper.c
+++ b/src/strhelper.c
@@ -56,30 +56,6 @@ copy_cstring_with_length( const char *str, size_t *length ) {
   return new_string;
 }
 
-char *
-copy_cstring_length( const char *str, size_t length ) {
-  char *new_string;
-
-  new_string = alloc_mem( length + 1 );
-  if( !new_string ) {
-    return NULL;
-  }
-
-  memcpy( new_string, str, length );
-  new_string[length] = '\0';
-
-  return new_string;
-}
-
-void
-to_upper_case( char *str ) {
-  size_t i;
-
-  for( i = 0; str[i]; i++) {
-    str[i] = toupper( str[i] );
-  }
-}
-
 int
 strncasecmp_custom( const char *s1, const char *s2, size_t n ) {
   if (n != 0) {

--- a/src/strhelper.c
+++ b/src/strhelper.c
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-#include <ctype.h>
 #include <stddef.h>
 #include <string.h>
 #include "private/memory.h"

--- a/src/strhelper.c
+++ b/src/strhelper.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <ctype.h>
 #include <stddef.h>
 #include <string.h>
 #include "private/memory.h"

--- a/tools/check_headers/c_standard_library.yml
+++ b/tools/check_headers/c_standard_library.yml
@@ -16,6 +16,7 @@
   - "stdlib.h"
   - "string.h"
   - "time.h"
+"tolower": "ctype.h"
 "true": "stdbool.h"
 "va_end": "stdarg.h"
 "va_list": "stdarg.h"

--- a/tools/check_headers/stumpless.yml
+++ b/tools/check_headers/stumpless.yml
@@ -43,8 +43,6 @@
 "copy_cstring_with_length": "private/strhelper.h"
 "copy_wel_data": "private/config/wel_supported.h"
 "create_entry": "test/helper/fixture.hpp"
-"copy_cstring_length": "private/strhelper.h"
-"to_upper_case": "private/strhelper.h"
 "destroy_buffer_target": "private/target/buffer.h"
 "destroy_file_target": "private/target/file.h"
 "destroy_network_target": "private/target/network.h"


### PR DESCRIPTION
Regarding issue #446.

Removed strhelper function definitions from C files include/private/strhelper.h and src/strhelper.c, as well as from the header manifest tools/check_headers/stumpless.yml. Built successfully.
