### PR TITLE
Implement ODELAY option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -894,6 +894,7 @@ add_function_test(file
   SOURCES
     test/function/target/file.cpp
     $<TARGET_OBJECTS:test_helper_rfc5424>
+    $<TARGET_OBJECTS:test_helper_fixture>
 )
 
 add_function_test(filter

--- a/include/private/config/have_stdatomic.h
+++ b/include/private/config/have_stdatomic.h
@@ -35,11 +35,17 @@ stdatomic_compare_exchange_ptr( atomic_uintptr_t *p,
 bool
 stdatomic_read_bool( atomic_bool *b );
 
+int
+stdatomic_read_int( atomic_int *i );
+
 void *
 stdatomic_read_ptr( atomic_uintptr_t *p );
 
 void
 stdatomic_write_bool( atomic_bool *b, bool replacement );
+
+void
+stdatomic_write_int( atomic_int *i, int replacement );
 
 void
 stdatomic_write_ptr( atomic_uintptr_t *p, void *replacement );

--- a/include/private/config/wrapper/socket.h
+++ b/include/private/config/wrapper/socket.h
@@ -26,11 +26,15 @@
 #    include <stumpless/target/socket.h>
 #    include "private/target/socket.h"
 #    define config_close_socket_target stumpless_close_socket_target
+#    define config_open_socket_target open_socket_target
 #    define config_sendto_socket_target sendto_socket_target
+#    define config_socket_target_is_open socket_target_is_open
 #  else
 #    include "private/target.h"
 #    define config_close_socket_target close_unsupported_target
+#    define config_open_socket_target open_unsupported_target
 #    define config_sendto_socket_target sendto_unsupported_target
+#    define config_socket_target_is_open unsupported_target_is_open
 #  endif
 
 #  ifdef SUPPORT_ABSTRACT_SOCKET_NAMES

--- a/include/private/config/wrapper/socket.h
+++ b/include/private/config/wrapper/socket.h
@@ -26,10 +26,12 @@
 #    include <stumpless/target/socket.h>
 #    include "private/target/socket.h"
 #    define config_close_socket_target stumpless_close_socket_target
+#    define config_open_socket_target open_socket_target
 #    define config_sendto_socket_target sendto_socket_target
 #  else
 #    include "private/target.h"
 #    define config_close_socket_target close_unsupported_target
+#    define config_open_socket_target open_unsupported_target
 #    define config_sendto_socket_target sendto_unsupported_target
 #  endif
 

--- a/include/private/config/wrapper/thread_safety.h
+++ b/include/private/config/wrapper/thread_safety.h
@@ -33,7 +33,6 @@ typedef void * config_atomic_ptr_t;
 #    define config_assign_cached_mutex( MUTEX ) ( ( void ) 0 )
 #    define config_atomic_bool_false false
 #    define config_atomic_bool_true true
-#    define config_atomic_int_default 0
 #    define config_atomic_ptr_initializer NULL
 #    define config_check_mutex_valid( MUTEX ) ( true )
 #    define config_compare_exchange_bool no_thread_safety_compare_exchange_bool
@@ -67,7 +66,6 @@ typedef pthread_mutex_t config_mutex_t;
 ( MUTEX = thread_safety_new_mutex(  ) )
 #    define config_atomic_bool_false false
 #    define config_atomic_bool_true true
-#    define config_atomic_int_default 0
 #    define config_atomic_ptr_initializer ( uintptr_t ) NULL
 #    define config_check_mutex_valid( MUTEX ) ( MUTEX != NULL )
 #    define config_compare_exchange_bool stdatomic_compare_exchange_bool
@@ -99,7 +97,6 @@ typedef CRITICAL_SECTION config_mutex_t;
 ( MUTEX = thread_safety_new_mutex(  ) )
 #    define config_atomic_bool_false false
 #    define config_atomic_bool_true true
-#    define config_atomic_int_default 0
 #    define config_atomic_ptr_initializer NULL
 #    define config_check_mutex_valid( MUTEX ) ( MUTEX != NULL )
 #    define config_compare_exchange_bool windows_compare_exchange_bool

--- a/include/private/config/wrapper/thread_safety.h
+++ b/include/private/config/wrapper/thread_safety.h
@@ -26,12 +26,14 @@
 
 #  ifndef STUMPLESS_THREAD_SAFETY_SUPPORTED
 typedef bool config_atomic_bool_t;
+typedef int config_atomic_int_t;
 typedef void * config_atomic_ptr_t;
 #    define CONFIG_THREAD_LOCAL_STORAGE
 #    include "private/config/thread_safety_unsupported.h"
 #    define config_assign_cached_mutex( MUTEX ) ( ( void ) 0 )
 #    define config_atomic_bool_false false
 #    define config_atomic_bool_true true
+#    define config_atomic_int_default 0
 #    define config_atomic_ptr_initializer NULL
 #    define config_check_mutex_valid( MUTEX ) ( true )
 #    define config_compare_exchange_bool no_thread_safety_compare_exchange_bool
@@ -42,16 +44,19 @@ typedef void * config_atomic_ptr_t;
 #    define config_lock_mutex( MUTEX ) ( ( void ) 0 )
 #    define CONFIG_MUTEX_T_SIZE 0
 #    define config_read_bool( B ) *( B )
+#    define config_read_int( I ) *( I )
 #    define config_read_ptr( P ) *( P )
 #    define config_thread_safety_free_all(  ) ( ( void ) 0 )
 #    define config_unlock_mutex( MUTEX ) ( ( void ) 0 )
 #    define config_write_bool( B, REPLACEMENT ) *( B ) = ( REPLACEMENT )
+#    define config_write_int( I, REPLACEMENT ) *( I ) = ( REPLACEMENT )
 #    define config_write_ptr( P, REPLACEMENT ) *( P ) = ( REPLACEMENT )
 #  elif defined HAVE_PTHREAD_H && defined HAVE_STDATOMIC_H
 #    include <pthread.h>
 #    include <stdatomic.h>
 #    include <stdint.h>
 typedef atomic_bool config_atomic_bool_t;
+typedef atomic_int config_atomic_int_t;
 typedef atomic_uintptr_t config_atomic_ptr_t;
 typedef pthread_mutex_t config_mutex_t;
 #    define CONFIG_THREAD_LOCAL_STORAGE __thread
@@ -62,6 +67,7 @@ typedef pthread_mutex_t config_mutex_t;
 ( MUTEX = thread_safety_new_mutex(  ) )
 #    define config_atomic_bool_false false
 #    define config_atomic_bool_true true
+#    define config_atomic_int_default 0
 #    define config_atomic_ptr_initializer ( uintptr_t ) NULL
 #    define config_check_mutex_valid( MUTEX ) ( MUTEX != NULL )
 #    define config_compare_exchange_bool stdatomic_compare_exchange_bool
@@ -73,15 +79,18 @@ typedef pthread_mutex_t config_mutex_t;
 #    define config_lock_mutex pthread_lock_mutex
 #    define CONFIG_MUTEX_T_SIZE sizeof( config_mutex_t )
 #    define config_read_bool stdatomic_read_bool
+#    define config_read_int stdatomic_read_int
 #    define config_read_ptr stdatomic_read_ptr
 #    define config_thread_safety_free_all thread_safety_free_all
 #    define config_unlock_mutex pthread_unlock_mutex
 #    define config_write_bool stdatomic_write_bool
+#    define config_write_int stdatomic_write_int
 #    define config_write_ptr stdatomic_write_ptr
 #  elif defined HAVE_WINDOWS_H
 #    include "private/config/have_windows.h"
 #    include "private/windows_wrapper.h"
 typedef LONG volatile config_atomic_bool_t;
+typedef INT volatile config_atomic_int_t;
 typedef PVOID volatile config_atomic_ptr_t;
 typedef CRITICAL_SECTION config_mutex_t;
 #    include "private/config/thread_safety_supported.h"
@@ -90,6 +99,7 @@ typedef CRITICAL_SECTION config_mutex_t;
 ( MUTEX = thread_safety_new_mutex(  ) )
 #    define config_atomic_bool_false false
 #    define config_atomic_bool_true true
+#    define config_atomic_int_default 0
 #    define config_atomic_ptr_initializer NULL
 #    define config_check_mutex_valid( MUTEX ) ( MUTEX != NULL )
 #    define config_compare_exchange_bool windows_compare_exchange_bool
@@ -101,10 +111,12 @@ typedef CRITICAL_SECTION config_mutex_t;
 #    define config_lock_mutex windows_lock_mutex
 #    define CONFIG_MUTEX_T_SIZE sizeof( config_mutex_t )
 #    define config_read_bool( B ) *( B )
+#    define config_read_int( I ) *( I )
 #    define config_read_ptr( P ) *( P )
 #    define config_thread_safety_free_all thread_safety_free_all
 #    define config_unlock_mutex windows_unlock_mutex
 #    define config_write_bool( B, REPLACEMENT ) *( B ) = ( REPLACEMENT )
+#    define config_write_int( I, REPLACEMENT ) *( I ) = ( REPLACEMENT )
 #    define config_write_ptr( P, REPLACEMENT ) *( P ) = ( REPLACEMENT )
 #  endif
 

--- a/include/private/target/file.h
+++ b/include/private/target/file.h
@@ -63,7 +63,7 @@ new_file_target( const char *filename );
  * cancelled, due to the use of a lock that could be left locked.
  */
 int
-sendto_file_target( struct stumpless_target *target,
+sendto_file_target( struct file_target *target,
                     const char *msg,
                     size_t msg_length );
 

--- a/include/private/target/file.h
+++ b/include/private/target/file.h
@@ -63,7 +63,7 @@ new_file_target( const char *filename );
  * cancelled, due to the use of a lock that could be left locked.
  */
 int
-sendto_file_target( struct file_target *target,
+sendto_file_target( struct stumpless_target *target,
                     const char *msg,
                     size_t msg_length );
 

--- a/include/private/target/socket.h
+++ b/include/private/target/socket.h
@@ -33,6 +33,9 @@ struct socket_target {
 void
 destroy_socket_target( const struct socket_target *trgt );
 
+struct stumpless_target *
+open_socket_target( struct stumpless_target *target);
+
 struct socket_target *
 open_bind_socket( struct socket_target *target );
 

--- a/include/private/target/socket.h
+++ b/include/private/target/socket.h
@@ -38,7 +38,7 @@ new_socket_target( const char *dest, size_t dest_len,
                    const char *source, size_t source_len );
 
 int
-sendto_socket_target( const struct socket_target *target,
+sendto_socket_target( struct socket_target *target,
                       const char *msg,
                       size_t msg_length );
 

--- a/include/private/target/socket.h
+++ b/include/private/target/socket.h
@@ -34,11 +34,14 @@ void
 destroy_socket_target( const struct socket_target *trgt );
 
 struct socket_target *
+open_bind_socket( struct socket_target *target );
+
+struct socket_target *
 new_socket_target( const char *dest, size_t dest_len,
                    const char *source, size_t source_len );
 
 int
-sendto_socket_target( struct socket_target *target,
+sendto_socket_target( const struct socket_target *target,
                       const char *msg,
                       size_t msg_length );
 

--- a/include/private/target/socket.h
+++ b/include/private/target/socket.h
@@ -20,6 +20,7 @@
 #  define __STUMPLESS_PRIVATE_TARGET_SOCKET_H
 
 #  include <stddef.h>
+#  include <stumpless/target.h>
 #  include <sys/socket.h>
 #  include <sys/un.h>
 
@@ -32,6 +33,12 @@ struct socket_target {
 
 void
 destroy_socket_target( const struct socket_target *trgt );
+
+int
+socket_target_is_open( const struct stumpless_target *target );
+
+struct stumpless_target *
+open_socket_target( struct stumpless_target *target);
 
 struct socket_target *
 open_bind_socket( struct socket_target *target );

--- a/include/stumpless/option.h
+++ b/include/stumpless/option.h
@@ -68,7 +68,10 @@
 #    define STUMPLESS_OPTION_NDELAY (1<<2)
 #  endif
 
-/** Not currently supported. */
+/** Definitions for ODELAY remains the same for all targets as defined in NDELAY
+ * with the only difference being that they will be executed when the first
+ * message is logged.
+ */
 #  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
 #    define STUMPLESS_OPTION_ODELAY LOG_ODELAY
 #  else

--- a/include/stumpless/target.h
+++ b/include/stumpless/target.h
@@ -892,11 +892,11 @@ stumpless_set_current_target( struct stumpless_target *target );
  *
  * **Async Signal Safety: AS-Safe**
  * This function is safe to call from signal handlers as it only consists of
- * an atomic read.
+ * an atomic write.
  *
  * **Async Cancel Safety: AC-Safe**
  * This function is safe to call from threads that may be asynchronously
- * cancelled, as it only consists of an atomic read.
+ * cancelled, as it only consists of an atomic write.
  *
  * @param option The bitwise 'or' of all options to be set as default.
  */

--- a/include/stumpless/target.h
+++ b/include/stumpless/target.h
@@ -491,6 +491,10 @@ stumpless_get_cons_stream( void );
  * to stumpless_set_current_target(), or the default target if neither of the
  * former exists.
  *
+ * The current target will still be the last target that was opened even if the
+ * target was opened with STUMPLESS_OPTION_ODELAY option and is not yet
+ * connected for logging.
+ *
  * If the target that is designated as the current target is closed, then the
  * current target will be reset to the default target until another target is
  * opened.

--- a/include/stumpless/target.h
+++ b/include/stumpless/target.h
@@ -519,6 +519,30 @@ struct stumpless_target *
 stumpless_get_current_target( void );
 
 /**
+ * Gets the options to be used while initializing a target.
+ *
+ * If no options are set for atomic variable default_option, it will default
+ * to 0.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe. Atomic operations are used to work with the
+ * default option.
+ *
+ * **Async Signal Safety: AS-Safe**
+ * This function is safe to call from signal handlers as it only consists of
+ * an atomic read.
+ *
+ * **Async Cancel Safety: AC-Safe**
+ * This function is safe to call from threads that may be asynchronously
+ * cancelled, as it only consists of an atomic read.
+ *
+ * @return Value store in atomic variable default_option
+ */
+STUMPLESS_PUBLIC_FUNCTION
+int
+stumpless_get_default_option( void );
+
+/**
  * Gets the default facility of a target.
  *
  * **Thread Safety: MT-Safe**
@@ -854,6 +878,31 @@ stumpless_set_cons_stream( FILE *stream );
 STUMPLESS_PUBLIC_FUNCTION
 void
 stumpless_set_current_target( struct stumpless_target *target );
+
+/**
+ * Sets the default options to be used for all new targets created.
+ *
+ * If a target is created without calling this function, STUMPLESS_OPTION_NONE 
+ * will be used as default. Using this function will not affect options for 
+ * targets already created.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe. Atomic operations are used to work with the
+ * default target.
+ *
+ * **Async Signal Safety: AS-Safe**
+ * This function is safe to call from signal handlers as it only consists of
+ * an atomic read.
+ *
+ * **Async Cancel Safety: AC-Safe**
+ * This function is safe to call from threads that may be asynchronously
+ * cancelled, as it only consists of an atomic read.
+ *
+ * @param option The bitwise 'or' of all options to be set as default.
+ */
+STUMPLESS_PUBLIC_FUNCTION
+void
+stumpless_set_default_option( int option );
 
 /**
  * Sets the default facility of a target.

--- a/include/stumpless/target.h
+++ b/include/stumpless/target.h
@@ -540,7 +540,7 @@ stumpless_get_current_target( void );
  */
 STUMPLESS_PUBLIC_FUNCTION
 int
-stumpless_get_default_option( void );
+stumpless_get_default_options( void );
 
 /**
  * Gets the default facility of a target.
@@ -902,7 +902,7 @@ stumpless_set_current_target( struct stumpless_target *target );
  */
 STUMPLESS_PUBLIC_FUNCTION
 void
-stumpless_set_default_option( int option );
+stumpless_set_default_options( int option );
 
 /**
  * Sets the default facility of a target.

--- a/src/config/have_stdatomic.c
+++ b/src/config/have_stdatomic.c
@@ -44,6 +44,11 @@ stdatomic_read_bool( atomic_bool *b ) {
   return ( bool ) atomic_load( b );
 }
 
+int
+stdatomic_read_int( atomic_int *i ) {
+  return ( int ) atomic_load( i );
+}
+
 void *
 stdatomic_read_ptr( atomic_uintptr_t *p ) {
   return ( void * ) atomic_load( p );
@@ -52,6 +57,11 @@ stdatomic_read_ptr( atomic_uintptr_t *p ) {
 void
 stdatomic_write_bool( atomic_bool *b, bool replacement ) {
   atomic_store( b, replacement );
+}
+
+void
+stdatomic_write_int( atomic_int *i, int replacement ) {
+  atomic_store( i, replacement );
 }
 
 void

--- a/src/target.c
+++ b/src/target.c
@@ -70,7 +70,7 @@
 static const char *target_type_enum_to_string[] = {
   STUMPLESS_FOREACH_TARGET_TYPE( GENERATE_STRING )
 };
-static config_atomic_int_t default_option = config_atomic_int_default;
+static config_atomic_int_t default_option = STUMPLESS_OPTION_NDELAY;
 static config_atomic_ptr_t current_target = config_atomic_ptr_initializer;
 static config_atomic_ptr_t default_target = config_atomic_ptr_initializer;
 static config_atomic_ptr_t cons_stream = config_atomic_ptr_initializer;
@@ -203,11 +203,9 @@ stumpless_add_entry( struct stumpless_target *target,
 
   options = target->options;
   if ( ( options & STUMPLESS_OPTION_ODELAY ) ) {
-    if ( !stumpless_target_is_open( target ) ) {
-      target = stumpless_open_target( target );
-      if ( !target ) {
-        return -1;
-      }
+    target = stumpless_open_target( target );
+    if ( !target ) {
+      return -1;
     }
   }
 
@@ -650,43 +648,47 @@ stumpless_open_target( struct stumpless_target *target ) {
   VALIDATE_ARG_NOT_NULL( target );
   clear_error(  );
 
-  lock_target( target );
-  switch ( target->type ) {
-    case STUMPLESS_FILE_TARGET:
-      ( ( struct file_target * )target->id )->stream = config_fopen( target->name, "a" );
-      if ( !( ( struct file_target * )target->id )->stream ) {
-        goto fail;
-      }
-      result = target;
-      break;
-
-    case STUMPLESS_NETWORK_TARGET:
-      result = config_open_network_target( target );
-      if ( !result ) {
-        goto fail;
-      }
-      break;
-
-    case STUMPLESS_SOCKET_TARGET:
-      result = config_open_socket_target( target );
-      if ( !result ) {
-        goto fail;
-      }
-      break;
+  if ( !stumpless_target_is_open( target ) ) {
+    lock_target( target );
     
-    default:
-      raise_target_incompatible( L10N_TARGET_ALWAYS_OPEN_ERROR_MESSAGE );
-      result = NULL;
-      break;
+    switch ( target->type ) {
+      case STUMPLESS_FILE_TARGET:
+        ( ( struct file_target * )target->id )->stream = config_fopen( target->name, "a" );
+        if ( !( ( struct file_target * )target->id )->stream ) {
+          goto fail;
+        }
+        result = target;
+        break;
+
+      case STUMPLESS_NETWORK_TARGET:
+        result = config_open_network_target( target );
+        if ( !result ) {
+          goto fail;
+        }
+        break;
+
+      case STUMPLESS_SOCKET_TARGET:
+        result = config_open_socket_target( target );
+        if ( !result ) {
+          goto fail;
+        }
+        break;
+      
+      default:
+        raise_target_incompatible( L10N_TARGET_ALWAYS_OPEN_ERROR_MESSAGE );
+        result = NULL;
+        break;
+    }
+
+    unlock_target( target );
+  } else {
+    result = target;
   }
-  
-  unlock_target( target );
 
   return result;
 
 fail:
   unlock_target( target );
-  stumpless_close_target( target );
   return NULL;
 }
 
@@ -1145,7 +1147,6 @@ lock_target( const struct stumpless_target *target ) {
 struct stumpless_target *
 new_target( enum stumpless_target_type type, const char *name ) {
   struct stumpless_target *target;
-  int options;
 
   target = alloc_mem( sizeof( *target ) );
   if( !target ) {
@@ -1162,11 +1163,9 @@ new_target( enum stumpless_target_type type, const char *name ) {
     goto fail_mutex;
   }
 
-  options = stumpless_get_default_options(  );
-
   target->id = NULL;
   target->type = type;
-  target->options = STUMPLESS_OPTION_NONE | options;
+  target->options = stumpless_get_default_options(  );
   target->default_prival = get_prival( STUMPLESS_DEFAULT_FACILITY,
                                        STUMPLESS_DEFAULT_SEVERITY );
   target->default_app_name[0] = '-';

--- a/src/target.c
+++ b/src/target.c
@@ -194,7 +194,7 @@ stumpless_add_entry( struct stumpless_target *target,
   VALIDATE_ARG_NOT_NULL_INT_RETURN( target );
   VALIDATE_ARG_NOT_NULL_INT_RETURN( entry );
 
-  if( target->type != STUMPLESS_FILE_TARGET && ( !target->id ) ) {
+  if( target->type != STUMPLESS_FILE_TARGET && unlikely( !target->id ) ) {
     raise_invalid_id(  );
     return -1;
   }

--- a/src/target.c
+++ b/src/target.c
@@ -194,7 +194,7 @@ stumpless_add_entry( struct stumpless_target *target,
   VALIDATE_ARG_NOT_NULL_INT_RETURN( target );
   VALIDATE_ARG_NOT_NULL_INT_RETURN( entry );
 
-  if( unlikely( !target->id ) ) {
+  if( target->type != STUMPLESS_FILE_TARGET && ( !target->id ) ) {
     raise_invalid_id(  );
     return -1;
   }

--- a/src/target.c
+++ b/src/target.c
@@ -202,7 +202,7 @@ stumpless_add_entry( struct stumpless_target *target,
   }
 
   options = target->options;
-  if ( ( options & STUMPLESS_OPTION_ODELAY ) && !( options & STUMPLESS_OPTION_NDELAY ) ) {
+  if ( ( options & STUMPLESS_OPTION_ODELAY ) ) {
     if ( !stumpless_target_is_open( target ) ) {
       target = stumpless_open_target( target );
       if ( !target ) {
@@ -669,7 +669,7 @@ stumpless_open_target( struct stumpless_target *target ) {
 
     case STUMPLESS_SOCKET_TARGET:
       result = config_open_socket_target( target );
-      if ( !target->id ) {
+      if ( !result ) {
         goto fail;
       }
       break;

--- a/src/target.c
+++ b/src/target.c
@@ -63,7 +63,6 @@
 #include "private/target/buffer.h"
 #include "private/target/file.h"
 #include "private/target/function.h"
-#include "private/target/socket.h"
 #include "private/target/stream.h"
 #include "private/validate.h"
 
@@ -669,11 +668,10 @@ stumpless_open_target( struct stumpless_target *target ) {
       break;
 
     case STUMPLESS_SOCKET_TARGET:
-      target->id = open_bind_socket( target->id );
+      result = config_open_socket_target( target );
       if ( !target->id ) {
         goto fail;
       }
-      result = target;
       break;
     
     default:
@@ -688,7 +686,7 @@ stumpless_open_target( struct stumpless_target *target ) {
 
 fail:
   unlock_target( target );
-  free_mem( target );
+  stumpless_close_target( target );
   return NULL;
 }
 
@@ -829,7 +827,7 @@ stumpless_target_is_open( const struct stumpless_target *target ) {
       break;
 
     case STUMPLESS_SOCKET_TARGET:
-      is_open = ( ( (struct socket_target *) target->id )->local_socket != -1 );
+      is_open = config_socket_target_is_open( target );
       break;
     
     default:

--- a/src/target.c
+++ b/src/target.c
@@ -658,6 +658,7 @@ stumpless_open_target( struct stumpless_target *target ) {
       if ( !( ( struct file_target * )target->id )->stream ) {
         goto fail;
       }
+      result = target;
       break;
 
     case STUMPLESS_NETWORK_TARGET:
@@ -672,6 +673,7 @@ stumpless_open_target( struct stumpless_target *target ) {
       if ( !target->id ) {
         goto fail;
       }
+      result = target;
       break;
     
     default:

--- a/src/target.c
+++ b/src/target.c
@@ -43,6 +43,7 @@
 #include "private/config/wrapper/wel.h"
 #include "private/config/wrapper/journald.h"
 #include "private/config/wrapper/network_supported.h"
+#include "private/config/wrapper/fopen.h"
 #include "private/config/wrapper/socket.h"
 #include "private/config/wrapper/sqlite3.h"
 #include "private/config/wrapper/thread_safety.h"
@@ -62,6 +63,7 @@
 #include "private/target/buffer.h"
 #include "private/target/file.h"
 #include "private/target/function.h"
+#include "private/target/socket.h"
 #include "private/target/stream.h"
 #include "private/validate.h"
 
@@ -190,13 +192,24 @@ stumpless_add_entry( struct stumpless_target *target,
   int result;
   FILE *current_cons_stream;
   bool locked;
+  int options;
 
   VALIDATE_ARG_NOT_NULL_INT_RETURN( target );
   VALIDATE_ARG_NOT_NULL_INT_RETURN( entry );
 
-  if( target->type != STUMPLESS_FILE_TARGET && unlikely( !target->id ) ) {
+  if( unlikely( !target->id ) ) {
     raise_invalid_id(  );
     return -1;
+  }
+
+  options = target->options;
+  if ( ( options & STUMPLESS_OPTION_ODELAY ) && !( options & STUMPLESS_OPTION_NDELAY ) ) {
+    if ( !stumpless_target_is_open( target ) ) {
+      target = stumpless_open_target( target );
+      if ( !target ) {
+        return -1;
+      }
+    }
   }
 
   filter = stumpless_get_target_filter( target );
@@ -253,7 +266,7 @@ stumpless_add_entry( struct stumpless_target *target,
       break;
 
     case STUMPLESS_FILE_TARGET:
-      result = sendto_file_target( target, buffer, builder_length );
+      result = sendto_file_target( target->id, buffer, builder_length );
       break;
 
     case STUMPLESS_NETWORK_TARGET:
@@ -468,7 +481,7 @@ stumpless_get_current_target( void ) {
 }
 
 int
-stumpless_get_default_option( void ) {
+stumpless_get_default_options( void ) {
   return config_read_int( &default_option );
 }
 
@@ -639,16 +652,42 @@ stumpless_open_target( struct stumpless_target *target ) {
   clear_error(  );
 
   lock_target( target );
-  if( target->type != STUMPLESS_NETWORK_TARGET ) {
-    unlock_target( target );
-    raise_target_incompatible( L10N_TARGET_ALWAYS_OPEN_ERROR_MESSAGE );
-    return NULL;
-  }
+  switch ( target->type ) {
+    case STUMPLESS_FILE_TARGET:
+      ( ( struct file_target * )target->id )->stream = config_fopen( target->name, "a" );
+      if ( !( ( struct file_target * )target->id )->stream ) {
+        goto fail;
+      }
+      break;
 
-  result = config_open_network_target( target );
+    case STUMPLESS_NETWORK_TARGET:
+      result = config_open_network_target( target );
+      if ( !result ) {
+        goto fail;
+      }
+      break;
+
+    case STUMPLESS_SOCKET_TARGET:
+      target->id = open_bind_socket( target->id );
+      if ( !target->id ) {
+        goto fail;
+      }
+      break;
+    
+    default:
+      raise_target_incompatible( L10N_TARGET_ALWAYS_OPEN_ERROR_MESSAGE );
+      result = NULL;
+      break;
+  }
+  
   unlock_target( target );
 
   return result;
+
+fail:
+  unlock_target( target );
+  free_mem( target );
+  return NULL;
 }
 
 void
@@ -664,7 +703,7 @@ stumpless_set_current_target( struct stumpless_target *target ) {
 }
 
 void
-stumpless_set_default_option( int option ) {
+stumpless_set_default_options( int option ) {
   config_write_int( &default_option, option );
 }
 
@@ -778,8 +817,21 @@ stumpless_target_is_open( const struct stumpless_target *target ) {
   clear_error(  );
 
   lock_target( target );
-  if( target->type == STUMPLESS_NETWORK_TARGET ) {
-    is_open = config_network_target_is_open( target );
+  switch ( target->type ) {
+    case STUMPLESS_FILE_TARGET:
+      is_open = ( ( (struct file_target *) target->id )->stream  != NULL );
+      break;
+
+    case STUMPLESS_NETWORK_TARGET:
+      is_open = config_network_target_is_open( target );
+      break;
+
+    case STUMPLESS_SOCKET_TARGET:
+      is_open = ( ( (struct socket_target *) target->id )->local_socket != -1 );
+      break;
+    
+    default:
+      break;
   }
   unlock_target( target );
 
@@ -1110,7 +1162,7 @@ new_target( enum stumpless_target_type type, const char *name ) {
     goto fail_mutex;
   }
 
-  options = stumpless_get_default_option(  );
+  options = stumpless_get_default_options(  );
 
   target->id = NULL;
   target->type = type;

--- a/src/target.c
+++ b/src/target.c
@@ -69,6 +69,7 @@
 static const char *target_type_enum_to_string[] = {
   STUMPLESS_FOREACH_TARGET_TYPE( GENERATE_STRING )
 };
+static config_atomic_int_t default_option = config_atomic_int_default;
 static config_atomic_ptr_t current_target = config_atomic_ptr_initializer;
 static config_atomic_ptr_t default_target = config_atomic_ptr_initializer;
 static config_atomic_ptr_t cons_stream = config_atomic_ptr_initializer;
@@ -252,7 +253,7 @@ stumpless_add_entry( struct stumpless_target *target,
       break;
 
     case STUMPLESS_FILE_TARGET:
-      result = sendto_file_target( target->id, buffer, builder_length );
+      result = sendto_file_target( target, buffer, builder_length );
       break;
 
     case STUMPLESS_NETWORK_TARGET:
@@ -467,6 +468,11 @@ stumpless_get_current_target( void ) {
 }
 
 int
+stumpless_get_default_option( void ) {
+  return config_read_int( &default_option );
+}
+
+int
 stumpless_get_default_facility( const struct stumpless_target *target ) {
   int prival;
 
@@ -655,6 +661,11 @@ void
 stumpless_set_current_target( struct stumpless_target *target ) {
   clear_error(  );
   config_write_ptr( &current_target, target );
+}
+
+void
+stumpless_set_default_option( int option ) {
+  config_write_int( &default_option, option );
 }
 
 struct stumpless_target *
@@ -1082,6 +1093,7 @@ lock_target( const struct stumpless_target *target ) {
 struct stumpless_target *
 new_target( enum stumpless_target_type type, const char *name ) {
   struct stumpless_target *target;
+  int options;
 
   target = alloc_mem( sizeof( *target ) );
   if( !target ) {
@@ -1098,8 +1110,11 @@ new_target( enum stumpless_target_type type, const char *name ) {
     goto fail_mutex;
   }
 
+  options = stumpless_get_default_option(  );
+
+  target->id = NULL;
   target->type = type;
-  target->options = STUMPLESS_OPTION_NONE;
+  target->options = STUMPLESS_OPTION_NONE | options;
   target->default_prival = get_prival( STUMPLESS_DEFAULT_FACILITY,
                                        STUMPLESS_DEFAULT_SEVERITY );
   target->default_app_name[0] = '-';

--- a/src/target.c
+++ b/src/target.c
@@ -63,7 +63,6 @@
 #include "private/target/buffer.h"
 #include "private/target/file.h"
 #include "private/target/function.h"
-#include "private/target/socket.h"
 #include "private/target/stream.h"
 #include "private/validate.h"
 
@@ -669,11 +668,10 @@ stumpless_open_target( struct stumpless_target *target ) {
       break;
 
     case STUMPLESS_SOCKET_TARGET:
-      target->id = open_bind_socket( target->id );
+      result = config_open_socket_target( target );
       if ( !target->id ) {
         goto fail;
       }
-      result = target;
       break;
     
     default:
@@ -688,7 +686,7 @@ stumpless_open_target( struct stumpless_target *target ) {
 
 fail:
   unlock_target( target );
-  free_mem( target );
+  stumpless_close_target( target );
   return NULL;
 }
 

--- a/src/target/file.c
+++ b/src/target/file.c
@@ -52,7 +52,6 @@ stumpless_close_file_target( struct stumpless_target *target ) {
 struct stumpless_target *
 stumpless_open_file_target( const char *name ) {
   struct stumpless_target *target;
-  int options;
 
   VALIDATE_ARG_NOT_NULL( name );
 
@@ -62,12 +61,9 @@ stumpless_open_file_target( const char *name ) {
     goto fail;
   }
 
-  options = stumpless_get_default_option(  );
-  if ( !((options & STUMPLESS_OPTION_ODELAY) && !(options & STUMPLESS_OPTION_NDELAY)) ) {
-    target->id = new_file_target( name );
-    if( !target->id ) {
-      goto fail_id;
-    }
+  target->id = new_file_target( name );
+  if( !target->id ) {
+    goto fail_id;
   }
 
   stumpless_set_current_target( target );
@@ -96,16 +92,21 @@ file_open_default_target( void ) {
 struct file_target *
 new_file_target( const char *filename ) {
   struct file_target *target;
+  int options;
 
   target = alloc_mem( sizeof( *target ) );
   if( !target ) {
     goto fail;
   }
 
-  target->stream = config_fopen( filename, "a" );
-  if( !target->stream ) {
-    raise_file_open_failure(  );
-    goto fail_stream;
+  options = stumpless_get_default_options(  );
+  target->stream = NULL;
+  if ( !( ( options & STUMPLESS_OPTION_ODELAY ) && !( options & STUMPLESS_OPTION_NDELAY ) ) ) {
+    target->stream = config_fopen( filename, "a" );
+    if( !target->stream ) {
+      raise_file_open_failure(  );
+      goto fail_stream;
+    }
   }
 
   config_init_mutex( &target->stream_mutex );
@@ -119,26 +120,14 @@ fail:
 }
 
 int
-sendto_file_target( struct stumpless_target *target,
+sendto_file_target( struct file_target *target,
                     const char *msg,
                     size_t msg_length ) {
   size_t fwrite_result;
-  struct file_target *ftarget;
 
-  if ( !target->id ) {
-    lock_target( target );
-    target->id = new_file_target( target->name );
-    if ( !target->id ) {
-      unlock_target( target );
-      goto fail;
-    }
-    unlock_target( target );
-  }
-  ftarget = target->id;
-
-  config_lock_mutex( &ftarget->stream_mutex );
-  fwrite_result = fwrite( msg, sizeof( char ), msg_length, ftarget->stream );
-  config_unlock_mutex( &ftarget->stream_mutex );
+  config_lock_mutex( &target->stream_mutex );
+  fwrite_result = fwrite( msg, sizeof( char ), msg_length, target->stream );
+  config_unlock_mutex( &target->stream_mutex );
 
   if( fwrite_result != msg_length ) {
     goto write_failure;
@@ -148,6 +137,5 @@ sendto_file_target( struct stumpless_target *target,
 
 write_failure:
   raise_file_write_failure(  );
-fail:
   return -1;
 }

--- a/src/target/file.c
+++ b/src/target/file.c
@@ -19,6 +19,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stumpless/config.h>
+#include <stumpless/option.h>
 #include <stumpless/target.h>
 #include <stumpless/target/file.h>
 #include "private/config/wrapper/locale.h"
@@ -51,6 +52,7 @@ stumpless_close_file_target( struct stumpless_target *target ) {
 struct stumpless_target *
 stumpless_open_file_target( const char *name ) {
   struct stumpless_target *target;
+  int options;
 
   VALIDATE_ARG_NOT_NULL( name );
 
@@ -60,9 +62,12 @@ stumpless_open_file_target( const char *name ) {
     goto fail;
   }
 
-  target->id = new_file_target( name );
-  if( !target->id ) {
-    goto fail_id;
+  options = stumpless_get_default_option(  );
+  if ( !((options & STUMPLESS_OPTION_ODELAY) && !(options & STUMPLESS_OPTION_NDELAY)) ) {
+    target->id = new_file_target( name );
+    if( !target->id ) {
+      goto fail_id;
+    }
   }
 
   stumpless_set_current_target( target );
@@ -114,14 +119,26 @@ fail:
 }
 
 int
-sendto_file_target( struct file_target *target,
+sendto_file_target( struct stumpless_target *target,
                     const char *msg,
                     size_t msg_length ) {
   size_t fwrite_result;
+  struct file_target *ftarget;
 
-  config_lock_mutex( &target->stream_mutex );
-  fwrite_result = fwrite( msg, sizeof( char ), msg_length, target->stream );
-  config_unlock_mutex( &target->stream_mutex );
+  if ( !target->id ) {
+    lock_target( target );
+    target->id = new_file_target( target->name );
+    if ( !target->id ) {
+      unlock_target( target );
+      goto fail;
+    }
+    unlock_target( target );
+  }
+  ftarget = target->id;
+
+  config_lock_mutex( &ftarget->stream_mutex );
+  fwrite_result = fwrite( msg, sizeof( char ), msg_length, ftarget->stream );
+  config_unlock_mutex( &ftarget->stream_mutex );
 
   if( fwrite_result != msg_length ) {
     goto write_failure;
@@ -131,5 +148,6 @@ sendto_file_target( struct file_target *target,
 
 write_failure:
   raise_file_write_failure(  );
+fail:
   return -1;
 }

--- a/src/target/file.c
+++ b/src/target/file.c
@@ -101,7 +101,7 @@ new_file_target( const char *filename ) {
 
   options = stumpless_get_default_options(  );
   target->stream = NULL;
-  if ( !( ( options & STUMPLESS_OPTION_ODELAY ) && !( options & STUMPLESS_OPTION_NDELAY ) ) ) {
+  if ( !( options & STUMPLESS_OPTION_ODELAY ) ) {
     target->stream = config_fopen( filename, "a" );
     if( !target->stream ) {
       raise_file_open_failure(  );

--- a/src/target/network.c
+++ b/src/target/network.c
@@ -812,7 +812,7 @@ open_new_network_target( const char *destination,
   }
 
   options = stumpless_get_default_options(  );
-  if ( !( ( options & STUMPLESS_OPTION_ODELAY ) && !( options & STUMPLESS_OPTION_NDELAY ) ) ) {
+  if ( !( options & STUMPLESS_OPTION_ODELAY ) ) {
     open_result = open_private_network_target( target );
     if( !open_result ) {
       goto fail_open;

--- a/src/target/network.c
+++ b/src/target/network.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stumpless/target.h>
+#include <stumpless/option.h>
 #include <stumpless/target/network.h>
 #include "private/config/wrapper/locale.h"
 #include "private/config/wrapper/network_supported.h"
@@ -798,6 +799,7 @@ open_new_network_target( const char *destination,
                          enum stumpless_transport_protocol transport ) {
   struct network_target *target;
   const struct network_target *open_result;
+  int options;
 
   target = new_network_target( network, transport );
   if( !target ) {
@@ -809,9 +811,12 @@ open_new_network_target( const char *destination,
     goto fail_open;
   }
 
-  open_result = open_private_network_target( target );
-  if( !open_result ) {
-    goto fail_open;
+  options = stumpless_get_default_option(  );
+  if ( !((options & STUMPLESS_OPTION_ODELAY) && !(options & STUMPLESS_OPTION_NDELAY)) ) {
+    open_result = open_private_network_target( target );
+    if( !open_result ) {
+      goto fail_open;
+    }
   }
 
   return target;
@@ -828,6 +833,14 @@ sendto_network_target( struct network_target *target,
                        size_t msg_length ) {
   // leave off the newline
   msg_length--;
+  struct network_target *open_result;
+
+  if ( target->handle == -1 ) {
+    open_result = open_private_network_target( target );
+    if( !open_result ) {
+      goto fail_open;
+    }
+  } 
 
   if( target->transport == STUMPLESS_UDP_TRANSPORT_PROTOCOL ) {
      return sendto_udp_target( target, msg, msg_length );
@@ -836,6 +849,10 @@ sendto_network_target( struct network_target *target,
      return sendto_tcp_target( target, msg, msg_length );
 
   }
+
+fail_open:
+  destroy_network_target( target );
+  return -1;
 }
 
 void

--- a/src/target/network.c
+++ b/src/target/network.c
@@ -811,8 +811,8 @@ open_new_network_target( const char *destination,
     goto fail_open;
   }
 
-  options = stumpless_get_default_option(  );
-  if ( !((options & STUMPLESS_OPTION_ODELAY) && !(options & STUMPLESS_OPTION_NDELAY)) ) {
+  options = stumpless_get_default_options(  );
+  if ( !( ( options & STUMPLESS_OPTION_ODELAY ) && !( options & STUMPLESS_OPTION_NDELAY ) ) ) {
     open_result = open_private_network_target( target );
     if( !open_result ) {
       goto fail_open;
@@ -833,14 +833,6 @@ sendto_network_target( struct network_target *target,
                        size_t msg_length ) {
   // leave off the newline
   msg_length--;
-  struct network_target *open_result;
-
-  if ( target->handle == -1 ) {
-    open_result = open_private_network_target( target );
-    if( !open_result ) {
-      goto fail_open;
-    }
-  } 
 
   if( target->transport == STUMPLESS_UDP_TRANSPORT_PROTOCOL ) {
      return sendto_udp_target( target, msg, msg_length );
@@ -849,10 +841,6 @@ sendto_network_target( struct network_target *target,
      return sendto_tcp_target( target, msg, msg_length );
 
   }
-
-fail_open:
-  destroy_network_target( target );
-  return -1;
 }
 
 void

--- a/src/target/socket.c
+++ b/src/target/socket.c
@@ -105,6 +105,18 @@ destroy_socket_target( const struct socket_target *trgt ) {
   free_mem( trgt );
 }
 
+struct stumpless_target *
+open_socket_target( struct stumpless_target *target) {
+  const struct socket_target *result;
+
+  result = open_bind_socket( target->id );
+  if ( !result ) {
+    return NULL;
+  }
+
+  return target;
+}
+
 struct socket_target *
 open_bind_socket( struct socket_target *target ) {
   int bind_result;

--- a/src/target/socket.c
+++ b/src/target/socket.c
@@ -151,7 +151,6 @@ open_bind_socket( struct socket_target *target ) {
 
 fail_bind:
   close( target->local_socket );
-  free_mem( target );
   return NULL;
 }
 
@@ -161,6 +160,7 @@ new_socket_target( const char *dest,
                    const char *source,
                    size_t source_len ) {
   struct socket_target *target;
+  struct socket_target *open_result;
   int options;
 
   target = alloc_mem( sizeof( *target ) );
@@ -180,15 +180,17 @@ new_socket_target( const char *dest,
   target->local_socket = -1;
 
   options = stumpless_get_default_options(  );
-  if ( !( ( options & STUMPLESS_OPTION_ODELAY ) && !( options & STUMPLESS_OPTION_NDELAY ) ) ) {
-    target = open_bind_socket( target );
-    if ( !target ) {
-      goto fail;
+  if ( !( options & STUMPLESS_OPTION_ODELAY ) ) {
+    open_result = open_bind_socket( target );
+    if ( !open_result ) {
+      goto fail_open;
     }
   }
 
   return target;
 
+fail_open:
+  free_mem( target );  
 fail:
   return NULL;
 }

--- a/src/target/socket.c
+++ b/src/target/socket.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/socket.h>
+#include <stumpless/option.h>
 #include <stumpless/target.h>
 #include <stumpless/target/socket.h>
 #include "private/config/wrapper/locale.h"
@@ -105,25 +106,10 @@ destroy_socket_target( const struct socket_target *trgt ) {
 }
 
 struct socket_target *
-new_socket_target( const char *dest,
-                   size_t dest_len,
-                   const char *source,
-                   size_t source_len ) {
-  struct socket_target *target;
+open_bind_socket( struct socket_target *target ) {
   int bind_result;
 
-  target = alloc_mem( sizeof( *target ) );
-  if( !target ) {
-    goto fail;
-  }
-
-  target->target_addr.sun_family = AF_UNIX;
-  memcpy( &target->target_addr.sun_path, dest, dest_len );
-  target->target_addr.sun_path[dest_len] = '\0';
-
-  target->local_addr.sun_family = AF_UNIX;
-  memcpy( &target->local_addr.sun_path, source, source_len );
-  target->local_addr.sun_path[source_len] = '\0';
+  clear_error(  );
 
   target->local_socket = socket( target->local_addr.sun_family, SOCK_DGRAM, 0 );
   if( target->local_socket < 0 ) {
@@ -144,27 +130,66 @@ new_socket_target( const char *dest,
     goto fail_bind;
   }
 
-  target->target_addr_len = sizeof( target->target_addr );
-
   return target;
 
 fail_bind:
   close( target->local_socket );
 fail_socket:
   free_mem( target );
+}
+
+struct socket_target *
+new_socket_target( const char *dest,
+                   size_t dest_len,
+                   const char *source,
+                   size_t source_len ) {
+  struct socket_target *target;
+  int options;
+
+  target = alloc_mem( sizeof( *target ) );
+  if( !target ) {
+    goto fail;
+  }
+
+  target->target_addr.sun_family = AF_UNIX;
+  memcpy( &target->target_addr.sun_path, dest, dest_len );
+  target->target_addr.sun_path[dest_len] = '\0';
+
+  target->local_addr.sun_family = AF_UNIX;
+  memcpy( &target->local_addr.sun_path, source, source_len );
+  target->local_addr.sun_path[source_len] = '\0';
+
+  target->target_addr_len = sizeof( target->target_addr );
+  target->local_socket = -1;
+
+  options = stumpless_get_default_option(  );
+  if ( !((options & STUMPLESS_OPTION_ODELAY) && !(options & STUMPLESS_OPTION_NDELAY)) ) {
+    target = open_bind_socket( target );
+  }
+
+  return target;
+
 fail:
   return NULL;
 }
 
 int
-sendto_socket_target( const struct socket_target *target,
+sendto_socket_target( struct socket_target *target,
                       const char *msg, size_t msg_length ) {
   int result;
 
   // leave off the newline
   msg_length--;
 
- result = sendto( target->local_socket,
+  if ( target->local_socket < 0 ) {
+    target = open_bind_socket( target );
+    if ( stumpless_has_error(  ) ) {
+      result = -1;
+      goto fail;
+    }
+  }
+
+  result = sendto( target->local_socket,
                   msg,
                   msg_length,
                   0,
@@ -177,5 +202,6 @@ sendto_socket_target( const struct socket_target *target,
                                L10N_ERRNO_ERROR_CODE_TYPE );
   }
 
+fail:
   return result;
 }

--- a/src/target/socket.c
+++ b/src/target/socket.c
@@ -105,6 +105,23 @@ destroy_socket_target( const struct socket_target *trgt ) {
   free_mem( trgt );
 }
 
+int
+socket_target_is_open( const struct stumpless_target *target ) {
+  return ( ( (struct socket_target *) target->id )->local_socket != -1 );
+}
+
+struct stumpless_target *
+open_socket_target( struct stumpless_target *target) {
+  const struct socket_target *result;
+
+  result = open_bind_socket( target->id );
+  if ( !result ) {
+    return NULL;
+  }
+
+  return target;
+}
+
 struct socket_target *
 open_bind_socket( struct socket_target *target ) {
   int bind_result;

--- a/src/target/socket.c
+++ b/src/target/socket.c
@@ -116,7 +116,7 @@ open_bind_socket( struct socket_target *target ) {
     raise_socket_failure( L10N_UNIX_SOCKET_FAILED_ERROR_MESSAGE,
                           errno,
                           L10N_ERRNO_ERROR_CODE_TYPE );
-    goto fail_socket;
+    return NULL;
   }
 
   bind_result= bind( target->local_socket,
@@ -134,8 +134,7 @@ open_bind_socket( struct socket_target *target ) {
 
 fail_bind:
   close( target->local_socket );
-fail_socket:
-  free_mem( target );
+  return NULL;
 }
 
 struct socket_target *
@@ -162,32 +161,29 @@ new_socket_target( const char *dest,
   target->target_addr_len = sizeof( target->target_addr );
   target->local_socket = -1;
 
-  options = stumpless_get_default_option(  );
-  if ( !((options & STUMPLESS_OPTION_ODELAY) && !(options & STUMPLESS_OPTION_NDELAY)) ) {
+  options = stumpless_get_default_options(  );
+  if ( !( ( options & STUMPLESS_OPTION_ODELAY ) && !( options & STUMPLESS_OPTION_NDELAY ) ) ) {
     target = open_bind_socket( target );
+    if ( !target ) {
+      goto fail_socket;
+    }
   }
 
   return target;
 
+fail_socket:
+  free_mem( target );
 fail:
   return NULL;
 }
 
 int
-sendto_socket_target( struct socket_target *target,
+sendto_socket_target( const struct socket_target *target,
                       const char *msg, size_t msg_length ) {
   int result;
 
   // leave off the newline
   msg_length--;
-
-  if ( target->local_socket < 0 ) {
-    target = open_bind_socket( target );
-    if ( stumpless_has_error(  ) ) {
-      result = -1;
-      goto fail;
-    }
-  }
 
   result = sendto( target->local_socket,
                   msg,
@@ -202,6 +198,5 @@ sendto_socket_target( struct socket_target *target,
                                L10N_ERRNO_ERROR_CODE_TYPE );
   }
 
-fail:
   return result;
 }

--- a/src/target/socket.c
+++ b/src/target/socket.c
@@ -134,6 +134,7 @@ open_bind_socket( struct socket_target *target ) {
 
 fail_bind:
   close( target->local_socket );
+  free_mem( target );
   return NULL;
 }
 
@@ -165,14 +166,12 @@ new_socket_target( const char *dest,
   if ( !( ( options & STUMPLESS_OPTION_ODELAY ) && !( options & STUMPLESS_OPTION_NDELAY ) ) ) {
     target = open_bind_socket( target );
     if ( !target ) {
-      goto fail_socket;
+      goto fail;
     }
   }
 
   return target;
 
-fail_socket:
-  free_mem( target );
 fail:
   return NULL;
 }

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -257,3 +257,5 @@ EXPORTS
   stumpless_get_realloc                         @232
   stumpless_get_priority_string                 @233
   stumpless_param_into_string                   @234
+  stumpless_set_default_option                  @235
+  stumpless_get_default_option                  @236

--- a/src/windows/stumpless.def
+++ b/src/windows/stumpless.def
@@ -257,5 +257,5 @@ EXPORTS
   stumpless_get_realloc                         @232
   stumpless_get_priority_string                 @233
   stumpless_param_into_string                   @234
-  stumpless_set_default_option                  @235
-  stumpless_get_default_option                  @236
+  stumpless_set_default_options                 @235
+  stumpless_get_default_options                 @236

--- a/test/function/target.cpp
+++ b/test/function/target.cpp
@@ -605,6 +605,13 @@ namespace {
     stumpless_free_all(  );
   }
 
+  TEST( GetDefaultOption, DefaultValue ) {
+    int option;
+
+    option = stumpless_get_default_option(  );
+    EXPECT_EQ( option, 0 );
+  }
+
   TEST( OpenTarget, AlreadyOpenTarget ) {
     char buffer[100];
     struct stumpless_target *target;
@@ -1131,6 +1138,53 @@ namespace {
 
     stumpless_close_buffer_target( target );
     stumpless_free_all(  );
+  }
+
+  TEST( SetOption, Odelay ) {
+    struct stumpless_target *target;
+    struct stumpless_target *target_result;
+    char buffer[100];
+    int option;
+
+    target = stumpless_open_buffer_target( "test target",
+                                           buffer,
+                                           sizeof( buffer ) );
+    ASSERT_NOT_NULL( target );
+
+    option = stumpless_get_option( target, STUMPLESS_OPTION_ODELAY );
+    EXPECT_FALSE( option );
+
+    target_result = stumpless_set_option( target, STUMPLESS_OPTION_ODELAY );
+    EXPECT_EQ( target_result, target );
+
+    option = stumpless_get_option( target, STUMPLESS_OPTION_ODELAY );
+    EXPECT_TRUE( option );
+
+    stumpless_close_buffer_target( target );
+    stumpless_free_all(  );
+  }
+
+  TEST( SetDefaultOption, Odelay ) {
+    struct stumpless_target *target;
+    char buffer[100];
+    int option;
+
+    stumpless_set_default_option( STUMPLESS_OPTION_ODELAY );
+
+    option = stumpless_get_default_option(  );
+    ASSERT_EQ( option, STUMPLESS_OPTION_ODELAY );
+
+    target = stumpless_open_buffer_target( "test target",
+                                           buffer,
+                                           sizeof( buffer ) );
+
+    option = stumpless_get_option( target, STUMPLESS_OPTION_ODELAY );
+    EXPECT_TRUE( option );
+
+    stumpless_close_buffer_target( target );
+    stumpless_free_all(  );
+
+    stumpless_set_default_option( STUMPLESS_OPTION_NONE );
   }
 
   TEST( WithCons, ConsDisabled ) {

--- a/test/function/target.cpp
+++ b/test/function/target.cpp
@@ -609,7 +609,7 @@ namespace {
     int option;
 
     option = stumpless_get_default_options(  );
-    EXPECT_EQ( option, 0 );
+    EXPECT_EQ( option, STUMPLESS_OPTION_NDELAY );
   }
 
   TEST( OpenTarget, AlreadyOpenTarget ) {
@@ -623,8 +623,8 @@ namespace {
     ASSERT_NOT_NULL( target );
 
     result = stumpless_open_target( target );
-    EXPECT_NULL( result );
-    EXPECT_ERROR_ID_EQ( STUMPLESS_TARGET_INCOMPATIBLE );
+    EXPECT_NOT_NULL( result );
+    EXPECT_NO_ERROR;
 
     stumpless_close_buffer_target( target );
     stumpless_free_all(  );
@@ -1168,6 +1168,9 @@ namespace {
     struct stumpless_target *target;
     char buffer[100];
     int option;
+    int default_options;
+
+    default_options = stumpless_get_default_options(  );
 
     stumpless_set_default_options( STUMPLESS_OPTION_ODELAY );
 
@@ -1184,7 +1187,7 @@ namespace {
     stumpless_close_buffer_target( target );
     stumpless_free_all(  );
 
-    stumpless_set_default_options( STUMPLESS_OPTION_NONE );
+    stumpless_set_default_options( default_options );
   }
 
   TEST( WithCons, ConsDisabled ) {

--- a/test/function/target.cpp
+++ b/test/function/target.cpp
@@ -608,7 +608,7 @@ namespace {
   TEST( GetDefaultOption, DefaultValue ) {
     int option;
 
-    option = stumpless_get_default_option(  );
+    option = stumpless_get_default_options(  );
     EXPECT_EQ( option, 0 );
   }
 
@@ -1169,9 +1169,9 @@ namespace {
     char buffer[100];
     int option;
 
-    stumpless_set_default_option( STUMPLESS_OPTION_ODELAY );
+    stumpless_set_default_options( STUMPLESS_OPTION_ODELAY );
 
-    option = stumpless_get_default_option(  );
+    option = stumpless_get_default_options(  );
     ASSERT_EQ( option, STUMPLESS_OPTION_ODELAY );
 
     target = stumpless_open_buffer_target( "test target",
@@ -1184,7 +1184,7 @@ namespace {
     stumpless_close_buffer_target( target );
     stumpless_free_all(  );
 
-    stumpless_set_default_option( STUMPLESS_OPTION_NONE );
+    stumpless_set_default_options( STUMPLESS_OPTION_NONE );
   }
 
   TEST( WithCons, ConsDisabled ) {

--- a/test/function/target/file.cpp
+++ b/test/function/target/file.cpp
@@ -189,12 +189,12 @@ namespace {
     size_t line_count = 3;
     size_t i;
 
-    stumpless_set_default_option( STUMPLESS_OPTION_ODELAY );
+    stumpless_set_default_options( STUMPLESS_OPTION_ODELAY );
 
     target = stumpless_open_file_target( filename );
     EXPECT_NO_ERROR;
     EXPECT_NOT_NULL( target );
-    EXPECT_NULL( target->id );
+    EXPECT_NOT_NULL( target->id );
 
     entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
                                  STUMPLESS_SEVERITY_INFO,
@@ -221,6 +221,6 @@ namespace {
     TestRFC5424File( filename, line_count );
     remove( filename );
 
-    stumpless_set_default_option( STUMPLESS_OPTION_NONE );
+    stumpless_set_default_options( STUMPLESS_OPTION_NONE );
   }
 }

--- a/test/function/target/file.cpp
+++ b/test/function/target/file.cpp
@@ -179,4 +179,48 @@ namespace {
     EXPECT_NULL( target );
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
   }
+
+  TEST( FileTargetOpenTest, OptionOdelay ) {
+    const char *filename = "option-odelay.log";
+    struct stumpless_target *target;
+    struct stumpless_entry *entry;
+    struct stumpless_element *element;
+    struct stumpless_param *param;
+    size_t line_count = 3;
+    size_t i;
+
+    stumpless_set_default_option( STUMPLESS_OPTION_ODELAY );
+
+    target = stumpless_open_file_target( filename );
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( target );
+    EXPECT_NULL( target->id );
+
+    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
+                                 STUMPLESS_SEVERITY_INFO,
+                                "stumpless-unit-test",
+                                "basic-entry",
+                                "basic test message" );
+
+    element = stumpless_new_element( "basic-element" );
+    stumpless_add_element( entry, element );
+
+    param = stumpless_new_param( "basic-param-name", "basic-param-value" );
+    stumpless_add_param( element, param );
+
+    for( i = 0; i < line_count; i++ ) {
+      stumpless_add_entry( target, entry );
+    }
+
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( target->id );
+
+    stumpless_destroy_entry_and_contents( entry );
+    stumpless_close_file_target( target );
+
+    TestRFC5424File( filename, line_count );
+    remove( filename );
+
+    stumpless_set_default_option( STUMPLESS_OPTION_NONE );
+  }
 }

--- a/test/function/target/file.cpp
+++ b/test/function/target/file.cpp
@@ -21,6 +21,7 @@
 #include <stumpless.h>
 #include <gtest/gtest.h>
 #include "test/helper/assert.hpp"
+#include "test/helper/fixture.hpp"
 #include "test/helper/memory_allocation.hpp"
 #include "test/helper/rfc5424.hpp"
 
@@ -188,6 +189,9 @@ namespace {
     struct stumpless_param *param;
     size_t line_count = 3;
     size_t i;
+    int default_options;
+
+    default_options = stumpless_get_default_options(  );
 
     stumpless_set_default_options( STUMPLESS_OPTION_ODELAY );
 
@@ -196,17 +200,8 @@ namespace {
     EXPECT_NOT_NULL( target );
     EXPECT_NOT_NULL( target->id );
 
-    entry = stumpless_new_entry( STUMPLESS_FACILITY_USER,
-                                 STUMPLESS_SEVERITY_INFO,
-                                "stumpless-unit-test",
-                                "basic-entry",
-                                "basic test message" );
-
-    element = stumpless_new_element( "basic-element" );
-    stumpless_add_element( entry, element );
-
-    param = stumpless_new_param( "basic-param-name", "basic-param-value" );
-    stumpless_add_param( element, param );
+    entry = create_entry(  );
+    ASSERT_NOT_NULL( entry );
 
     for( i = 0; i < line_count; i++ ) {
       stumpless_add_entry( target, entry );
@@ -221,6 +216,6 @@ namespace {
     TestRFC5424File( filename, line_count );
     remove( filename );
 
-    stumpless_set_default_options( STUMPLESS_OPTION_NONE );
+    stumpless_set_default_options( default_options );
   }
 }

--- a/test/function/target/network.cpp
+++ b/test/function/target/network.cpp
@@ -331,6 +331,37 @@ namespace {
     EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
   }
 
+  TEST( NetworkTargetOpenTest, Odelay ) {
+    struct stumpless_target *target;
+    struct stumpless_entry *entry;
+    const char *hostname = "localhost";
+    int result;
+
+    stumpless_set_default_options( STUMPLESS_OPTION_ODELAY );
+
+    if( !name_resolves( hostname, AF_INET ) ) {
+      printf( "WARNING: %s did not resolve, so this test will be skipped\n", hostname );
+      SUCCEED(  ) <<  "the hostname did not resolve, so this test will be skipped";
+
+    } else {
+      target = stumpless_open_network_target( "local-hostname",
+                                              hostname,
+                                              STUMPLESS_IPV4_NETWORK_PROTOCOL,
+                                              STUMPLESS_UDP_TRANSPORT_PROTOCOL );
+      EXPECT_NO_ERROR;
+      EXPECT_NOT_NULL( target );
+      EXPECT_NULL( stumpless_target_is_open( target ) );
+
+      result = stumpless_add_log_str( target, 14, "sample-message" );
+      EXPECT_NOT_NULL( stumpless_target_is_open( target ) );
+
+      stumpless_close_network_target( target );
+
+    }
+
+    stumpless_set_default_options( STUMPLESS_OPTION_ODELAY );
+  }
+
   TEST( NetworkTargetSetDestination, BadTargetType ) {
     struct stumpless_target *target;
     struct stumpless_target *result;

--- a/test/function/target/network.cpp
+++ b/test/function/target/network.cpp
@@ -336,6 +336,9 @@ namespace {
     struct stumpless_entry *entry;
     const char *hostname = "localhost";
     int result;
+    int default_options;
+
+    default_options = stumpless_get_default_options(  );
 
     stumpless_set_default_options( STUMPLESS_OPTION_ODELAY );
 
@@ -359,7 +362,7 @@ namespace {
 
     }
 
-    stumpless_set_default_options( STUMPLESS_OPTION_ODELAY );
+    stumpless_set_default_options( default_options );
   }
 
   TEST( NetworkTargetSetDestination, BadTargetType ) {

--- a/test/function/target/socket.cpp
+++ b/test/function/target/socket.cpp
@@ -212,6 +212,42 @@ namespace {
     unlink( local_socket_name );
   }
 
+  TEST( SocketTargetOpenTest, LocalSocketAlreadyExistsWithOdelay ) {
+    struct sockaddr_un local_socket_addr;
+    struct stumpless_target *target;
+    struct stumpless_entry *entry;
+    const struct stumpless_error *error;
+    const char *local_socket_name = "taken";
+    int local_socket;
+    int result;
+
+    stumpless_set_default_options( STUMPLESS_OPTION_ODELAY );
+
+    entry = create_entry(  );
+    ASSERT_NOT_NULL( entry );
+
+    local_socket_addr.sun_family = AF_UNIX;
+    memcpy(&local_socket_addr.sun_path, local_socket_name, strlen(local_socket_name)+1);
+    local_socket = socket(local_socket_addr.sun_family, SOCK_DGRAM, 0);
+    bind(local_socket, (struct sockaddr *) &local_socket_addr, sizeof(local_socket_addr));
+
+    target = stumpless_open_socket_target( "socket-taken-test",
+                                           local_socket_name );
+    EXPECT_NOT_NULL( target );
+
+    result = stumpless_add_entry( target, entry );
+    EXPECT_LT( result, 0 );
+    EXPECT_EQ( stumpless_get_current_target(  ),
+               stumpless_get_default_target(  ) );
+
+    stumpless_set_default_options( STUMPLESS_OPTION_NONE );
+
+    close( local_socket );
+    unlink( local_socket_name );
+
+    stumpless_destroy_entry_and_contents( entry );
+  }
+
   TEST( SocketTargetOpenTest, MemoryFailure ) {
     const struct stumpless_error *error;
     struct stumpless_target *target;
@@ -251,6 +287,8 @@ namespace {
     EXPECT_NO_ERROR;
 
     stumpless_set_default_options( STUMPLESS_OPTION_NONE );
+
+    stumpless_destroy_entry_and_contents( entry );
   }
 
   TEST( SocketTargetAddTest, NullId ) {

--- a/test/function/target/socket.cpp
+++ b/test/function/target/socket.cpp
@@ -220,6 +220,9 @@ namespace {
     const char *local_socket_name = "taken";
     int local_socket;
     int result;
+    int default_options;
+
+    default_options = stumpless_get_default_options(  );
 
     stumpless_set_default_options( STUMPLESS_OPTION_ODELAY );
 
@@ -240,10 +243,12 @@ namespace {
     EXPECT_EQ( stumpless_get_current_target(  ),
                stumpless_get_default_target(  ) );
 
-    stumpless_set_default_options( STUMPLESS_OPTION_NONE );
+    stumpless_set_default_options( default_options );
 
     close( local_socket );
     unlink( local_socket_name );
+
+    stumpless_close_target( target );
 
     stumpless_destroy_entry_and_contents( entry );
   }
@@ -269,6 +274,9 @@ namespace {
     struct stumpless_target *target;
     struct stumpless_entry *entry;
     int result;
+    int default_options;
+
+    default_options = stumpless_get_default_options(  );
 
     stumpless_set_default_options( STUMPLESS_OPTION_ODELAY );
 
@@ -286,7 +294,7 @@ namespace {
     stumpless_close_socket_target( target );
     EXPECT_NO_ERROR;
 
-    stumpless_set_default_options( STUMPLESS_OPTION_NONE );
+    stumpless_set_default_options( default_options );
 
     stumpless_destroy_entry_and_contents( entry );
   }

--- a/test/function/target/socket.cpp
+++ b/test/function/target/socket.cpp
@@ -240,8 +240,6 @@ namespace {
 
     result = stumpless_add_entry( target, entry );
     EXPECT_LT( result, 0 );
-    EXPECT_EQ( stumpless_get_current_target(  ),
-               stumpless_get_default_target(  ) );
 
     stumpless_set_default_options( default_options );
 

--- a/test/function/target/socket.cpp
+++ b/test/function/target/socket.cpp
@@ -229,6 +229,30 @@ namespace {
     EXPECT_TRUE( result == malloc );
   }
 
+  TEST( SocketTargetOpenTest, Odelay ) {
+    struct stumpless_target *target;
+    struct stumpless_entry *entry;
+    int result;
+
+    stumpless_set_default_options( STUMPLESS_OPTION_ODELAY );
+
+    target = stumpless_open_socket_target( "odelay-target", NULL );
+    EXPECT_NO_ERROR;
+    EXPECT_NOT_NULL( target );
+    EXPECT_NULL( stumpless_target_is_open( target ) );
+
+    entry = create_entry(  );
+    EXPECT_NOT_NULL( entry );
+
+    result = stumpless_add_entry( target, entry );
+    EXPECT_NOT_NULL( stumpless_target_is_open( target ) );
+
+    stumpless_close_socket_target( target );
+    EXPECT_NO_ERROR;
+
+    stumpless_set_default_options( STUMPLESS_OPTION_NONE );
+  }
+
   TEST( SocketTargetAddTest, NullId ) {
     struct stumpless_target *target;
     struct stumpless_entry *entry;

--- a/tools/check_headers/stumpless.yml
+++ b/tools/check_headers/stumpless.yml
@@ -332,6 +332,8 @@
 "stumpless_open_udp4_target": "stumpless/target/network.h"
 "STUMPLESS_OPTION_NONE": "stumpless/option.h"
 "STUMPLESS_OPTION_PID": "stumpless/option.h"
+"STUMPLESS_OPTION_NDELAY": "stumpless/option.h"
+"STUMPLESS_OPTION_ODELAY": "stumpless/option.h"
 "STUMPLESS_OPTION_NOWAIT" : "stumpless/option.h"
 "STUMPLESS_OPTION_PERROR" :  "stumpless/option.h"
 "STUMPLESS_PATCH_VERSION": "stumpless/config.h"


### PR DESCRIPTION
Issue #80.

### Approach

Used an atomic variable to store default option and exposed two functions (setter and getter) to modify/retrieve the options. This allows initializing the target with certain options as ODELAY requires it be passed before target is created.

Benefits to this approach:

1. Ensures backward compatibility as nothing changes on the current user side behavior.
2. Initiates all subsequent targets with the same default options which helps avoid setting options for each target individually. It can still be overridden ofcourse.

Targets covered:

1. File
2. Network
3. Socket

Targets pending:

1. WEL
2. SQLite3

Targets not applicable:

1. Buffer
2. Stream
3. Journald
4. Chain