### PR TITLE
Refactoring stumpless_param_to_string and stumpless_element_to_string

### DIFF
--- a/include/private/param.h
+++ b/include/private/param.h
@@ -64,6 +64,55 @@ unchecked_load_param( struct stumpless_param *param,
                       size_t name_length,
                       const char *value );
 
+/**
+ * Retrieves the size required to store the parameter as a string.
+ *
+ * **Thread Safety: MT-Unsafe**
+ * This function is not thread safe as it doesn't use any synchronization
+ * or locking mechanisms while accessing shared resources.
+ *
+ * **Async Signal Safety: AS-Safe**
+ * This function is safe to call from signal handlers.
+ *
+ * **Async Cancel Safety: AC-Safe**
+ * This function is safe to call from threads that may be asynchronously
+ *
+ * @param param The param to retrieve the size required to store the 
+ * parameter as a string.
+ *
+ * @return The size required to store the parameter as a string.
+ */
+size_t
+locked_get_param_string_size( const struct stumpless_param *param );
+
+/**
+ * Writes the parameter as a string into the buffer provided.
+ *
+ * **Thread Safety: MT-Unsafe**
+ * This function is not thread safe as it doesn't use any synchronization
+ * or locking mechanisms while accessing shared resources.
+ *
+ * **Async Signal Safety: AS-Unsafe**
+ * This function is not safe to call from signal handlers due to the use of
+ * memory functions.
+ *
+ * **Async Cancel Safety: AC-Unsafe**
+ * This function is not safe to call from threads that may be asynchronously
+ * cancelled, due to the use of memory functions that could leave the
+ * memory in undefined state.
+ *
+ * @param entry The param to write as a string.
+ *
+ * @param buffer The buffer to write in.
+ *
+ * @param buffer_size The size of the buffer.
+ *
+ * @return The number of bytes written in the buffer.
+ */
+size_t
+locked_param_into_buffer( const struct stumpless_param *param,
+                        char *buffer, size_t buffer_size );
+
 void
 unlock_param( const struct stumpless_param *param );
 

--- a/src/element.c
+++ b/src/element.c
@@ -203,10 +203,10 @@ stumpless_element_to_string( const struct stumpless_element *element ) {
 
     if( param_count != 0 ) {
       // extra param list chars and commas
-      format_len += 4 + param_count ;
+      format_len += 4 + param_count - 1 ;
     } else {
       // no params, just name
-      format_len += 3;
+      format_len += 1;
     }
 
     format = alloc_mem( format_len );
@@ -246,6 +246,7 @@ stumpless_element_to_string( const struct stumpless_element *element ) {
 
     clear_error( );
     return format;
+
 fail:
     unlock_element( element );
     return NULL;

--- a/src/element.c
+++ b/src/element.c
@@ -176,11 +176,10 @@ stumpless_element_to_string( const struct stumpless_element *element ) {
     const char *name;
     size_t name_len;
     size_t format_len;
-    const char **params_format;
     size_t i;
     size_t param_count;
+    size_t written = 0U;
     struct stumpless_param **params;
-    size_t pos_offset;
 
     VALIDATE_ARG_NOT_NULL( element );
 
@@ -194,18 +193,17 @@ stumpless_element_to_string( const struct stumpless_element *element ) {
     // acc total format size
     format_len = name_len;
 
-    params_format = alloc_array( param_count, sizeof(char*) );
     for( i = 0; i < param_count; i++ ) {
-      params_format[i] = stumpless_param_to_string(params[i]);
-      // does not count '\0' on purpose
-      format_len += strlen(params_format[i]);
+      lock_param( params[i] );
+      // do not count '\0'
+      format_len += locked_get_param_string_size( params[i] ) - 1;
     }
 
     if( param_count != 0 ) {
-      // extra param list chars and commas
+      // extra param list chars (=[...]) and commas
       format_len += 4 + param_count - 1 ;
     } else {
-      // no params, just name
+      // no params, just name with '\0'
       format_len += 1;
     }
 
@@ -215,34 +213,27 @@ stumpless_element_to_string( const struct stumpless_element *element ) {
     }
 
     memcpy( format, name, name_len );
+    written += name_len;
 
-    // build params list "param_1_to_string,param_2_to_string, ..."
-    pos_offset = name_len + 2;
-    for( i = 0; i < param_count; i++) {
-      // replace '\0' with ',' at the end of each string
-      memcpy( format + pos_offset, params_format[i], strlen(params_format[i]));
-      pos_offset += strlen(params_format[i]);
-      if( i < param_count - 1 ) {
-        format[pos_offset++] = ',';
+    if (param_count != 0U ) {
+      format[written++] = '=';
+      format[written++] = '[';
+
+      for( i = 0; i < param_count; i++ ) {
+        // remove 1 to discard '\0' automatically by locked_param_into_buffer
+        written += locked_param_into_buffer( params[i], &format[written], format_len - written ) - 1;
+        unlock_param( params[i] );
+        if( i < param_count - 1 ) {
+          format[written++] = ',';
+        }
       }
-      free_mem(params_format[i]);
+
+      format[written++] = ']';
     }
-    free_mem(params_format);
+    
+    format[written] = '\0';
 
     unlock_element( element );
-
-    if (param_count != 0 ) {
-      // name=[param_1_to_string,param_2_to_string,etc.] (with params)
-      format[name_len ] = '=';
-      format[name_len + 1] = '[';
-      format[pos_offset] = ']';
-    } else {
-      // name (no params)
-      // pos_offset is name_len + 2 here
-      pos_offset -= 3;
-    }
-
-    format[pos_offset + 1] = '\0';
 
     clear_error( );
     return format;

--- a/src/param.c
+++ b/src/param.c
@@ -278,37 +278,22 @@ fail:
 const char *
 stumpless_param_to_string( const struct stumpless_param *param ) {
     char *format;
-    const char *name;
-    const char *value;
-    size_t value_len;
-    size_t name_len;
+    size_t len;
 
     VALIDATE_ARG_NOT_NULL( param );
 
     lock_param( param );
 
-    name  = param->name;
-    value = param->value;
-    name_len = param->name_length;
-    value_len = param->value_length;
+    len = locked_get_param_string_size( param );
 
-    /* name="value"*/
-    format = alloc_mem( value_len + name_len + 4 );
+    format = alloc_mem( len );
     if( !format ) {
       goto fail;
     }
-
-  
-    memcpy(format, name, name_len);
-    memcpy(format + name_len + 2, value, value_len);
+    
+    (void)locked_param_into_buffer( param, format, len );
 
     unlock_param( param );
-
-    format[name_len ] = '=';
-    format[name_len + 1] = '\"';
-    format[name_len + value_len + 2] = '\"';
-    format[name_len + value_len + 3] = '\0';
-
 
     clear_error( );
     return format;
@@ -410,6 +395,7 @@ fail_value:
 
 size_t
 locked_get_param_string_size( const struct stumpless_param *param ) {
+  /* name="value" */
   return param->name_length + param->value_length + 4;
 }
 

--- a/src/param.c
+++ b/src/param.c
@@ -413,16 +413,14 @@ locked_param_into_buffer( const struct stumpless_param *param,
   name_len = param->name_length;
   value_len = param->value_length;
 
-  memcpy( buffer, name, name_len );
+  memcpy( &buffer[written], name, name_len );
   written += name_len;
-  memcpy( buffer + name_len + 2, value, value_len );
+  buffer[written++] = '=';
+  buffer[written++] = '\"';
+  memcpy( &buffer[written], value, value_len );
   written += value_len;
-
-  buffer[name_len ] = '=';
-  buffer[name_len + 1] = '\"';
-  buffer[name_len + value_len + 2] = '\"';
-  buffer[name_len + value_len + 3] = '\0';
-  written += 4U;
+  buffer[written++] = '\"';
+  buffer[written++] = '\0';
 
   return written;
 }

--- a/src/param.c
+++ b/src/param.c
@@ -408,6 +408,39 @@ fail_value:
   return NULL;
 }
 
+size_t
+locked_get_param_string_size( const struct stumpless_param *param ) {
+  return param->name_length + param->value_length + 4;
+}
+
+size_t
+locked_param_into_buffer( const struct stumpless_param *param,
+                        char *buffer, size_t buffer_size ) {
+  size_t written = 0U;
+  const char *name;
+  const char *value;
+  size_t value_len;
+  size_t name_len;
+
+  name  = param->name;
+  value = param->value;
+  name_len = param->name_length;
+  value_len = param->value_length;
+
+  memcpy( buffer, name, name_len );
+  written += name_len;
+  memcpy( buffer + name_len + 2, value, value_len );
+  written += value_len;
+
+  buffer[name_len ] = '=';
+  buffer[name_len + 1] = '\"';
+  buffer[name_len + value_len + 2] = '\"';
+  buffer[name_len + value_len + 3] = '\0';
+  written += 4U;
+
+  return written;
+}
+
 void
 unlock_param( const struct stumpless_param *param ) {
   config_unlock_mutex( param->mutex );

--- a/tools/check_headers/stumpless_private.yml
+++ b/tools/check_headers/stumpless_private.yml
@@ -109,6 +109,8 @@
 "locked_get_element_by_index": "private/entry.h"
 "locked_get_element_by_name": "private/entry.h"
 "locked_get_param_by_index": "private/element.h"
+"locked_get_param_string_size": "private/param.h"
+"locked_param_into_buffer": "private/param.h"
 "locked_swap_wel_insertion_string": "private/config/wel_supported.h"
 "new_entry": "private/entry.h"
 "new_chain_target": "private/target/chain.h"


### PR DESCRIPTION
This PR refactors stumpless_param_to_string and stumpless_element_to_string as stated in #183 .