### PR TITLE
feat: Add facility function tests and fix missing test targets

### DIFF
--- a/include/stumpless/facility.h
+++ b/include/stumpless/facility.h
@@ -26,59 +26,59 @@
  */
 
 #ifndef __STUMPLESS_FACILITY_H
-#  define __STUMPLESS_FACILITY_H
+#define __STUMPLESS_FACILITY_H
 
-#  include <stumpless/config.h>
-#  include <stumpless/generator.h>
-#  include <stddef.h>
+#include <stumpless/config.h>
+#include <stumpless/generator.h>
+#include <stddef.h>
 
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    include <syslog.h>
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#include <syslog.h>
+#endif
 
 /**
  * Kernel message facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_KERN_VALUE LOG_KERN
-#  else
-#    define STUMPLESS_FACILITY_KERN_VALUE 0
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_KERN_VALUE LOG_KERN
+#else
+#define STUMPLESS_FACILITY_KERN_VALUE 0
+#endif
 
 /**
  * User-level message facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_USER_VALUE LOG_USER
-#  else
-#    define STUMPLESS_FACILITY_USER_VALUE ( 1 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_USER_VALUE LOG_USER
+#else
+#define STUMPLESS_FACILITY_USER_VALUE (1 << 3)
+#endif
 
 /**
  * Mail system facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_MAIL_VALUE LOG_MAIL
-#  else
-#    define STUMPLESS_FACILITY_MAIL_VALUE ( 2 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_MAIL_VALUE LOG_MAIL
+#else
+#define STUMPLESS_FACILITY_MAIL_VALUE (2 << 3)
+#endif
 
 /**
  * System daemons facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_DAEMON_VALUE LOG_DAEMON
-#  else
-#    define STUMPLESS_FACILITY_DAEMON_VALUE ( 3 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_DAEMON_VALUE LOG_DAEMON
+#else
+#define STUMPLESS_FACILITY_DAEMON_VALUE (3 << 3)
+#endif
 
 /**
  *
@@ -86,11 +86,11 @@
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_AUTH_VALUE LOG_AUTH
-#  else
-#    define STUMPLESS_FACILITY_AUTH_VALUE ( 4 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_AUTH_VALUE LOG_AUTH
+#else
+#define STUMPLESS_FACILITY_AUTH_VALUE (4 << 3)
+#endif
 
 /**
  * Facility code value for messages generated internally by the logging daemon
@@ -98,181 +98,181 @@
  *
  * @since release v2.0.0.
  */
-#  define STUMPLESS_FACILITY_SYSLOG_VALUE ( 5 << 3 )
+#define STUMPLESS_FACILITY_SYSLOG_VALUE (5 << 3)
 
 /**
  * Line printer subsystem facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_LPR_VALUE LOG_LPR
-#  else
-#    define STUMPLESS_FACILITY_LPR_VALUE ( 6 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_LPR_VALUE LOG_LPR
+#else
+#define STUMPLESS_FACILITY_LPR_VALUE (6 << 3)
+#endif
 
 /**
  * Network news subsystem facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_NEWS_VALUE LOG_NEWS
-#  else
-#    define STUMPLESS_FACILITY_NEWS_VALUE ( 7 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_NEWS_VALUE LOG_NEWS
+#else
+#define STUMPLESS_FACILITY_NEWS_VALUE (7 << 3)
+#endif
 
 /**
  * UUCP subsystem facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_UUCP_VALUE LOG_UUCP
-#  else
-#    define STUMPLESS_FACILITY_UUCP_VALUE ( 8 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_UUCP_VALUE LOG_UUCP
+#else
+#define STUMPLESS_FACILITY_UUCP_VALUE (8 << 3)
+#endif
 
 /**
  * Clock daemon facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_CRON_VALUE LOG_CRON
-#  else
-#    define STUMPLESS_FACILITY_CRON_VALUE ( 9 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_CRON_VALUE LOG_CRON
+#else
+#define STUMPLESS_FACILITY_CRON_VALUE (9 << 3)
+#endif
 
 /**
  * Security/authorization messages facility code value as defined by RFC 5424.
  *
  * @since release v2.0.0.
  */
-#  define STUMPLESS_FACILITY_AUTH2_VALUE ( 10 << 3 )
+#define STUMPLESS_FACILITY_AUTH2_VALUE (10 << 3)
 
 /**
  * FTP daemon facility code value as defined by RFC 5424.
  *
  * @since release v2.0.0.
  */
-#  define STUMPLESS_FACILITY_FTP_VALUE ( 11 << 3 )
+#define STUMPLESS_FACILITY_FTP_VALUE (11 << 3)
 
 /**
  * NTP subsystem facility code value as defined by RFC 5424.
  *
  * @since release v2.0.0.
  */
-#  define STUMPLESS_FACILITY_NTP_VALUE ( 12 << 3 )
+#define STUMPLESS_FACILITY_NTP_VALUE (12 << 3)
 
 /**
  * Log audit facility code value as defined by RFC 5424.
  *
  * @since release v2.0.0.
  */
-#  define STUMPLESS_FACILITY_AUDIT_VALUE ( 13 << 3 )
+#define STUMPLESS_FACILITY_AUDIT_VALUE (13 << 3)
 
 /**
  * Log alert facility code value as defined by RFC 5424.
  *
  * @since release v2.0.0.
  */
-#  define STUMPLESS_FACILITY_ALERT_VALUE ( 14 << 3 )
+#define STUMPLESS_FACILITY_ALERT_VALUE (14 << 3)
 
 /**
  * Clock daemon facility code value as defined by RFC 5424.
  *
  * @since release v2.0.0.
  */
-#  define STUMPLESS_FACILITY_CRON2_VALUE ( 15 << 3 )
+#define STUMPLESS_FACILITY_CRON2_VALUE (15 << 3)
 
 /**
  * Local use 0 facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_LOCAL0_VALUE LOG_LOCAL0
-#  else
-#    define STUMPLESS_FACILITY_LOCAL0_VALUE ( 16 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_LOCAL0_VALUE LOG_LOCAL0
+#else
+#define STUMPLESS_FACILITY_LOCAL0_VALUE (16 << 3)
+#endif
 
 /**
  * Local use 1 facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_LOCAL1_VALUE LOG_LOCAL1
-#  else
-#    define STUMPLESS_FACILITY_LOCAL1_VALUE ( 17 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_LOCAL1_VALUE LOG_LOCAL1
+#else
+#define STUMPLESS_FACILITY_LOCAL1_VALUE (17 << 3)
+#endif
 
 /**
  * Local use 2 facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_LOCAL2_VALUE LOG_LOCAL2
-#  else
-#    define STUMPLESS_FACILITY_LOCAL2_VALUE ( 18 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_LOCAL2_VALUE LOG_LOCAL2
+#else
+#define STUMPLESS_FACILITY_LOCAL2_VALUE (18 << 3)
+#endif
 
 /**
  * Local use 3 facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_LOCAL3_VALUE LOG_LOCAL3
-#  else
-#    define STUMPLESS_FACILITY_LOCAL3_VALUE ( 19 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_LOCAL3_VALUE LOG_LOCAL3
+#else
+#define STUMPLESS_FACILITY_LOCAL3_VALUE (19 << 3)
+#endif
 
 /**
  * Local use 4 facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_LOCAL4_VALUE LOG_LOCAL4
-#  else
-#    define STUMPLESS_FACILITY_LOCAL4_VALUE ( 20 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_LOCAL4_VALUE LOG_LOCAL4
+#else
+#define STUMPLESS_FACILITY_LOCAL4_VALUE (20 << 3)
+#endif
 
 /**
  * Local use 5 facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_LOCAL5_VALUE LOG_LOCAL5
-#  else
-#    define STUMPLESS_FACILITY_LOCAL5_VALUE ( 21 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_LOCAL5_VALUE LOG_LOCAL5
+#else
+#define STUMPLESS_FACILITY_LOCAL5_VALUE (21 << 3)
+#endif
 
 /**
  * Local use 6 facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_LOCAL6_VALUE LOG_LOCAL6
-#  else
-#    define STUMPLESS_FACILITY_LOCAL6_VALUE ( 22 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_LOCAL6_VALUE LOG_LOCAL6
+#else
+#define STUMPLESS_FACILITY_LOCAL6_VALUE (22 << 3)
+#endif
 
 /**
  * Local use 7 facility code value.
  *
  * @since release v2.0.0.
  */
-#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#    define STUMPLESS_FACILITY_LOCAL7_VALUE LOG_LOCAL7
-#  else
-#    define STUMPLESS_FACILITY_LOCAL7_VALUE ( 23 << 3 )
-#  endif
+#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#define STUMPLESS_FACILITY_LOCAL7_VALUE LOG_LOCAL7
+#else
+#define STUMPLESS_FACILITY_LOCAL7_VALUE (23 << 3)
+#endif
 
 /**
  * A macro function that runs the provided action once for each facility,
@@ -282,149 +282,157 @@
  *
  * @since release v2.0.0.
  */
-#  define STUMPLESS_FOREACH_FACILITY( ACTION )                       \
-/** Kernel messages. */                                              \
-ACTION( STUMPLESS_FACILITY_KERN, STUMPLESS_FACILITY_KERN_VALUE )     \
-/** User-level messages. */                                          \
-ACTION( STUMPLESS_FACILITY_USER, STUMPLESS_FACILITY_USER_VALUE )     \
-/** Mail system facility code value as defined by RFC 5424. */       \
-ACTION( STUMPLESS_FACILITY_MAIL, STUMPLESS_FACILITY_MAIL_VALUE )     \
-/** System daemons. */                                               \
-ACTION( STUMPLESS_FACILITY_DAEMON, STUMPLESS_FACILITY_DAEMON_VALUE ) \
-/** Security/authorization messages. */                              \
-ACTION( STUMPLESS_FACILITY_AUTH, STUMPLESS_FACILITY_AUTH_VALUE )     \
-/** Message generated internally by the logging daemon. */           \
-ACTION( STUMPLESS_FACILITY_SYSLOG, STUMPLESS_FACILITY_SYSLOG_VALUE ) \
-/** Line printer subsystem. */                                       \
-ACTION( STUMPLESS_FACILITY_LPR, STUMPLESS_FACILITY_LPR_VALUE )       \
-/** Network news. */                                                 \
-ACTION( STUMPLESS_FACILITY_NEWS, STUMPLESS_FACILITY_NEWS_VALUE )     \
-/** UUCP subsystem. */                                               \
-ACTION( STUMPLESS_FACILITY_UUCP, STUMPLESS_FACILITY_UUCP_VALUE )     \
-/** Clock daemon. */                                                 \
-ACTION( STUMPLESS_FACILITY_CRON, STUMPLESS_FACILITY_CRON_VALUE )     \
-/** Security/authorization messages. */                              \
-ACTION( STUMPLESS_FACILITY_AUTH2, STUMPLESS_FACILITY_AUTH2_VALUE )   \
-/** FTP daemon. */                                                   \
-ACTION( STUMPLESS_FACILITY_FTP, STUMPLESS_FACILITY_FTP_VALUE )       \
-/** NTP subsystem. */                                                \
-ACTION( STUMPLESS_FACILITY_NTP, STUMPLESS_FACILITY_NTP_VALUE )       \
-/** Log audit. */                                                    \
-ACTION( STUMPLESS_FACILITY_AUDIT, STUMPLESS_FACILITY_AUDIT_VALUE )   \
-/** Log alert. */                                                    \
-ACTION( STUMPLESS_FACILITY_ALERT, STUMPLESS_FACILITY_ALERT_VALUE )   \
-/** Clock daemon. */                                                 \
-ACTION( STUMPLESS_FACILITY_CRON2, STUMPLESS_FACILITY_CRON2_VALUE )   \
-/** Local use 0. */                                                  \
-ACTION( STUMPLESS_FACILITY_LOCAL0, STUMPLESS_FACILITY_LOCAL0_VALUE ) \
-/** Local use 1. */                                                  \
-ACTION( STUMPLESS_FACILITY_LOCAL1, STUMPLESS_FACILITY_LOCAL1_VALUE ) \
-/** Local use 2. */                                                  \
-ACTION( STUMPLESS_FACILITY_LOCAL2, STUMPLESS_FACILITY_LOCAL2_VALUE ) \
-/** Local use 3. */                                                  \
-ACTION( STUMPLESS_FACILITY_LOCAL3, STUMPLESS_FACILITY_LOCAL3_VALUE ) \
-/** Local use 4. */                                                  \
-ACTION( STUMPLESS_FACILITY_LOCAL4, STUMPLESS_FACILITY_LOCAL4_VALUE ) \
-/** Local use 5. */                                                  \
-ACTION( STUMPLESS_FACILITY_LOCAL5, STUMPLESS_FACILITY_LOCAL5_VALUE ) \
-/** Local use 6. */                                                  \
-ACTION( STUMPLESS_FACILITY_LOCAL6, STUMPLESS_FACILITY_LOCAL6_VALUE ) \
-/** Local use 7. */                                                  \
-ACTION( STUMPLESS_FACILITY_LOCAL7, STUMPLESS_FACILITY_LOCAL7_VALUE )
+#define STUMPLESS_FOREACH_FACILITY(ACTION)                           \
+  /** Kernel messages. */                                            \
+  ACTION(STUMPLESS_FACILITY_KERN, STUMPLESS_FACILITY_KERN_VALUE)     \
+  /** User-level messages. */                                        \
+  ACTION(STUMPLESS_FACILITY_USER, STUMPLESS_FACILITY_USER_VALUE)     \
+  /** Mail system facility code value as defined by RFC 5424. */     \
+  ACTION(STUMPLESS_FACILITY_MAIL, STUMPLESS_FACILITY_MAIL_VALUE)     \
+  /** System daemons. */                                             \
+  ACTION(STUMPLESS_FACILITY_DAEMON, STUMPLESS_FACILITY_DAEMON_VALUE) \
+  /** Security/authorization messages. */                            \
+  ACTION(STUMPLESS_FACILITY_AUTH, STUMPLESS_FACILITY_AUTH_VALUE)     \
+  /** Message generated internally by the logging daemon. */         \
+  ACTION(STUMPLESS_FACILITY_SYSLOG, STUMPLESS_FACILITY_SYSLOG_VALUE) \
+  /** Line printer subsystem. */                                     \
+  ACTION(STUMPLESS_FACILITY_LPR, STUMPLESS_FACILITY_LPR_VALUE)       \
+  /** Network news. */                                               \
+  ACTION(STUMPLESS_FACILITY_NEWS, STUMPLESS_FACILITY_NEWS_VALUE)     \
+  /** UUCP subsystem. */                                             \
+  ACTION(STUMPLESS_FACILITY_UUCP, STUMPLESS_FACILITY_UUCP_VALUE)     \
+  /** Clock daemon. */                                               \
+  ACTION(STUMPLESS_FACILITY_CRON, STUMPLESS_FACILITY_CRON_VALUE)     \
+  /** Security/authorization messages. */                            \
+  ACTION(STUMPLESS_FACILITY_AUTH2, STUMPLESS_FACILITY_AUTH2_VALUE)   \
+  /** FTP daemon. */                                                 \
+  ACTION(STUMPLESS_FACILITY_FTP, STUMPLESS_FACILITY_FTP_VALUE)       \
+  /** NTP subsystem. */                                              \
+  ACTION(STUMPLESS_FACILITY_NTP, STUMPLESS_FACILITY_NTP_VALUE)       \
+  /** Log audit. */                                                  \
+  ACTION(STUMPLESS_FACILITY_AUDIT, STUMPLESS_FACILITY_AUDIT_VALUE)   \
+  /** Log alert. */                                                  \
+  ACTION(STUMPLESS_FACILITY_ALERT, STUMPLESS_FACILITY_ALERT_VALUE)   \
+  /** Clock daemon. */                                               \
+  ACTION(STUMPLESS_FACILITY_CRON2, STUMPLESS_FACILITY_CRON2_VALUE)   \
+  /** Local use 0. */                                                \
+  ACTION(STUMPLESS_FACILITY_LOCAL0, STUMPLESS_FACILITY_LOCAL0_VALUE) \
+  /** Local use 1. */                                                \
+  ACTION(STUMPLESS_FACILITY_LOCAL1, STUMPLESS_FACILITY_LOCAL1_VALUE) \
+  /** Local use 2. */                                                \
+  ACTION(STUMPLESS_FACILITY_LOCAL2, STUMPLESS_FACILITY_LOCAL2_VALUE) \
+  /** Local use 3. */                                                \
+  ACTION(STUMPLESS_FACILITY_LOCAL3, STUMPLESS_FACILITY_LOCAL3_VALUE) \
+  /** Local use 4. */                                                \
+  ACTION(STUMPLESS_FACILITY_LOCAL4, STUMPLESS_FACILITY_LOCAL4_VALUE) \
+  /** Local use 5. */                                                \
+  ACTION(STUMPLESS_FACILITY_LOCAL5, STUMPLESS_FACILITY_LOCAL5_VALUE) \
+  /** Local use 6. */                                                \
+  ACTION(STUMPLESS_FACILITY_LOCAL6, STUMPLESS_FACILITY_LOCAL6_VALUE) \
+  /** Local use 7. */                                                \
+  ACTION(STUMPLESS_FACILITY_LOCAL7, STUMPLESS_FACILITY_LOCAL7_VALUE)
 
-#  ifdef __cplusplus
-extern "C" {
-#  endif
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
-/**
- * All possible facility codes available to log entries.
- *
- * In versions prior to 2.0.0, these values were simply \#define symbols. They
- * have been changed to an enum to clearly convey proper usage.
- *
- * @since release v2.0.0.
- */
-enum stumpless_facility {
-  STUMPLESS_FOREACH_FACILITY( STUMPLESS_GENERATE_ENUM )
-};
+  /**
+   * All possible facility codes available to log entries.
+   *
+   * In versions prior to 2.0.0, these values were simply \#define symbols. They
+   * have been changed to an enum to clearly convey proper usage.
+   *
+   * @since release v2.0.0.
+   */
+  enum stumpless_facility
+  {
+    STUMPLESS_FOREACH_FACILITY(STUMPLESS_GENERATE_ENUM)
+  };
 
-/**
- * Gets the string representation of the given facility.
- *
- * This is a string literal that should not be modified or freed by the caller.
- *
- * **Thread Safety: MT-Safe**
- * This function is thread safe.
- *
- * **Async Signal Safety: AS-Safe**
- * This function is safe to call from signal handlers.
- *
- * **Async Cancel Safety: AC-Safe**
- * This function is safe to call from threads that may be asynchronously
- * cancelled.
- *
- * @since release v2.1.0.
- *
- * @param facility The facility to get the string from.
- *
- * @return The string representation of the given facility.
- */
-STUMPLESS_PUBLIC_FUNCTION
-const char *
-stumpless_get_facility_string( enum stumpless_facility facility );
+  /**
+   * Gets the string representation of the given facility.
+   *
+   * This is a string literal that should not be modified or freed by the caller.
+   *
+   * **Thread Safety: MT-Safe**
+   * This function is thread safe.
+   *
+   * **Async Signal Safety: AS-Safe**
+   * This function is safe to call from signal handlers.
+   *
+   * **Async Cancel Safety: AC-Safe**
+   * This function is safe to call from threads that may be asynchronously
+   * cancelled.
+   *
+   * @since release v2.1.0.
+   *
+   * @param facility The facility to get the string from.
+   *
+   * @return The string representation of the given facility.
+   */
+  STUMPLESS_PUBLIC_FUNCTION
+  const char *
+  stumpless_get_facility_string(enum stumpless_facility facility);
 
-/**
- * Gets the enum value corresponding to the given facility string.
- *
- * **Thread Safety: MT-Safe**
- * This function is thread safe.
- *
- * **Async Signal Safety: AS-Safe**
- * This function is safe to call from signal handlers.
- *
- * **Async Cancel Safety: AC-Safe**
- * This function is safe to call from threads that may be asynchronously
- * cancelled.
- *
- * @since release v2.1.0.
- *
- * @param facility_string The facility name to get the enum from.
- *
- * @return The enum integer corresponding to the given facility or -1 if
- * the string is not a valid facility name.
- */
-STUMPLESS_PUBLIC_FUNCTION
-enum stumpless_facility
-stumpless_get_facility_enum( const char *facility_string );
+  /**
+   * Gets the enum value corresponding to the given facility string.
+   *
+   * **Thread Safety: MT-Safe**
+   * This function is thread safe.
+   *
+   * **Async Signal Safety: AS-Safe**
+   * This function is safe to call from signal handlers.
+   *
+   * **Async Cancel Safety: AC-Safe**
+   * This function is safe to call from threads that may be asynchronously
+   * cancelled.
+   *
+   * @since release v2.1.0.
+   *
+   * @param facility_string The facility name to get the enum from.
+   *
+   * @error Clears previous error on success.
+   * @error Raises STUMPLESS_INVALID_FACILITY on invalid input.
+   *
+   * @return The enum integer corresponding to the given facility or -1 if
+   * the string is not a valid facility name.
+   */
+  STUMPLESS_PUBLIC_FUNCTION
+  enum stumpless_facility
+  stumpless_get_facility_enum(const char *facility_string);
 
-/**
- * Gets the enum value corresponding to the given facility string.
- *
- * **Thread Safety: MT-Safe**
- * This function is thread safe.
- *
- * **Async Signal Safety: AS-Safe**
- * This function is safe to call from signal handlers.
- *
- * **Async Cancel Safety: AC-Safe**
- * This function is safe to call from threads that may be asynchronously
- * cancelled.
- *
- * @since release v2.2.0.
- *
- * @param facility_string The facility name to get the enum from.
- * 
- * @param facility_buffer_length The length of the buffer
- *
- * @return The enum integer corresponding to the given facility or -1 if
- * the string is not a valid facility name.
- */
-STUMPLESS_PUBLIC_FUNCTION
-enum stumpless_facility
-stumpless_get_facility_enum_from_buffer( const char *facility_string, size_t facility_buffer_length );
+  /**
+   * Gets the enum value corresponding to the given facility string.
+   *
+   * **Thread Safety: MT-Safe**
+   * This function is thread safe.
+   *
+   * **Async Signal Safety: AS-Safe**
+   * This function is safe to call from signal handlers.
+   *
+   * **Async Cancel Safety: AC-Safe**
+   * This function is safe to call from threads that may be asynchronously
+   * cancelled.
+   *
+   * @since release v2.2.0.
+   *
+   * @param facility_string The facility name to get the enum from.
+   *
+   * @param facility_buffer_length The length of the buffer
+   *
+   * @error Clears previous error on success.
+   * @error Raises STUMPLESS_INVALID_FACILITY on invalid input.
+   *
+   * @return The enum integer corresponding to the given facility or -1 if
+   * the string is not a valid facility name.
+   */
+  STUMPLESS_PUBLIC_FUNCTION
+  enum stumpless_facility
+  stumpless_get_facility_enum_from_buffer(const char *facility_string, size_t facility_buffer_length);
 
-#  ifdef __cplusplus
+#ifdef __cplusplus
 } /* extern "C" */
-#  endif
+#endif
 
 #endif /* __STUMPLESS_FACILITY_H */

--- a/include/stumpless/facility.h
+++ b/include/stumpless/facility.h
@@ -390,8 +390,9 @@ stumpless_get_facility_string( enum stumpless_facility facility );
  *
  * @param facility_string The facility name to get the enum from.
  * 
- * @error Clears previous error on success.
- * @error Raises STUMPLESS_INVALID_FACILITY on invalid input.
+ *  Clears previous error on success.
+ * 
+ *  Raises STUMPLESS_INVALID_FACILITY on invalid input.
  *
  * @return The enum integer corresponding to the given facility or -1 if
  * the string is not a valid facility name.
@@ -419,8 +420,9 @@ stumpless_get_facility_enum( const char *facility_string );
  * 
  * @param facility_buffer_length The length of the buffer
  * 
- * @error Clears previous error on success.
- * @error Raises STUMPLESS_INVALID_FACILITY on invalid input.
+ *  Clears previous error on success.
+ * 
+ *  Raises STUMPLESS_INVALID_FACILITY on invalid input.
  *
  * @return The enum integer corresponding to the given facility or -1 if
  * the string is not a valid facility name.

--- a/include/stumpless/facility.h
+++ b/include/stumpless/facility.h
@@ -389,6 +389,9 @@ stumpless_get_facility_string( enum stumpless_facility facility );
  * @since release v2.1.0.
  *
  * @param facility_string The facility name to get the enum from.
+ * 
+ * @error Clears previous error on success.
+ * @error Raises STUMPLESS_INVALID_FACILITY on invalid input.
  *
  * @return The enum integer corresponding to the given facility or -1 if
  * the string is not a valid facility name.
@@ -415,6 +418,9 @@ stumpless_get_facility_enum( const char *facility_string );
  * @param facility_string The facility name to get the enum from.
  * 
  * @param facility_buffer_length The length of the buffer
+ * 
+ * @error Clears previous error on success.
+ * @error Raises STUMPLESS_INVALID_FACILITY on invalid input.
  *
  * @return The enum integer corresponding to the given facility or -1 if
  * the string is not a valid facility name.

--- a/include/stumpless/facility.h
+++ b/include/stumpless/facility.h
@@ -26,59 +26,59 @@
  */
 
 #ifndef __STUMPLESS_FACILITY_H
-#define __STUMPLESS_FACILITY_H
+#  define __STUMPLESS_FACILITY_H
 
-#include <stumpless/config.h>
-#include <stumpless/generator.h>
-#include <stddef.h>
+#  include <stumpless/config.h>
+#  include <stumpless/generator.h>
+#  include <stddef.h>
 
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#include <syslog.h>
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    include <syslog.h>
+#  endif
 
 /**
  * Kernel message facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_KERN_VALUE LOG_KERN
-#else
-#define STUMPLESS_FACILITY_KERN_VALUE 0
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_KERN_VALUE LOG_KERN
+#  else
+#    define STUMPLESS_FACILITY_KERN_VALUE 0
+#  endif
 
 /**
  * User-level message facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_USER_VALUE LOG_USER
-#else
-#define STUMPLESS_FACILITY_USER_VALUE (1 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_USER_VALUE LOG_USER
+#  else
+#    define STUMPLESS_FACILITY_USER_VALUE ( 1 << 3 )
+#  endif
 
 /**
  * Mail system facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_MAIL_VALUE LOG_MAIL
-#else
-#define STUMPLESS_FACILITY_MAIL_VALUE (2 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_MAIL_VALUE LOG_MAIL
+#  else
+#    define STUMPLESS_FACILITY_MAIL_VALUE ( 2 << 3 )
+#  endif
 
 /**
  * System daemons facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_DAEMON_VALUE LOG_DAEMON
-#else
-#define STUMPLESS_FACILITY_DAEMON_VALUE (3 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_DAEMON_VALUE LOG_DAEMON
+#  else
+#    define STUMPLESS_FACILITY_DAEMON_VALUE ( 3 << 3 )
+#  endif
 
 /**
  *
@@ -86,11 +86,11 @@
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_AUTH_VALUE LOG_AUTH
-#else
-#define STUMPLESS_FACILITY_AUTH_VALUE (4 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_AUTH_VALUE LOG_AUTH
+#  else
+#    define STUMPLESS_FACILITY_AUTH_VALUE ( 4 << 3 )
+#  endif
 
 /**
  * Facility code value for messages generated internally by the logging daemon
@@ -98,181 +98,181 @@
  *
  * @since release v2.0.0.
  */
-#define STUMPLESS_FACILITY_SYSLOG_VALUE (5 << 3)
+#  define STUMPLESS_FACILITY_SYSLOG_VALUE ( 5 << 3 )
 
 /**
  * Line printer subsystem facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_LPR_VALUE LOG_LPR
-#else
-#define STUMPLESS_FACILITY_LPR_VALUE (6 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_LPR_VALUE LOG_LPR
+#  else
+#    define STUMPLESS_FACILITY_LPR_VALUE ( 6 << 3 )
+#  endif
 
 /**
  * Network news subsystem facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_NEWS_VALUE LOG_NEWS
-#else
-#define STUMPLESS_FACILITY_NEWS_VALUE (7 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_NEWS_VALUE LOG_NEWS
+#  else
+#    define STUMPLESS_FACILITY_NEWS_VALUE ( 7 << 3 )
+#  endif
 
 /**
  * UUCP subsystem facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_UUCP_VALUE LOG_UUCP
-#else
-#define STUMPLESS_FACILITY_UUCP_VALUE (8 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_UUCP_VALUE LOG_UUCP
+#  else
+#    define STUMPLESS_FACILITY_UUCP_VALUE ( 8 << 3 )
+#  endif
 
 /**
  * Clock daemon facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_CRON_VALUE LOG_CRON
-#else
-#define STUMPLESS_FACILITY_CRON_VALUE (9 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_CRON_VALUE LOG_CRON
+#  else
+#    define STUMPLESS_FACILITY_CRON_VALUE ( 9 << 3 )
+#  endif
 
 /**
  * Security/authorization messages facility code value as defined by RFC 5424.
  *
  * @since release v2.0.0.
  */
-#define STUMPLESS_FACILITY_AUTH2_VALUE (10 << 3)
+#  define STUMPLESS_FACILITY_AUTH2_VALUE ( 10 << 3 )
 
 /**
  * FTP daemon facility code value as defined by RFC 5424.
  *
  * @since release v2.0.0.
  */
-#define STUMPLESS_FACILITY_FTP_VALUE (11 << 3)
+#  define STUMPLESS_FACILITY_FTP_VALUE ( 11 << 3 )
 
 /**
  * NTP subsystem facility code value as defined by RFC 5424.
  *
  * @since release v2.0.0.
  */
-#define STUMPLESS_FACILITY_NTP_VALUE (12 << 3)
+#  define STUMPLESS_FACILITY_NTP_VALUE ( 12 << 3 )
 
 /**
  * Log audit facility code value as defined by RFC 5424.
  *
  * @since release v2.0.0.
  */
-#define STUMPLESS_FACILITY_AUDIT_VALUE (13 << 3)
+#  define STUMPLESS_FACILITY_AUDIT_VALUE ( 13 << 3 )
 
 /**
  * Log alert facility code value as defined by RFC 5424.
  *
  * @since release v2.0.0.
  */
-#define STUMPLESS_FACILITY_ALERT_VALUE (14 << 3)
+#  define STUMPLESS_FACILITY_ALERT_VALUE ( 14 << 3 )
 
 /**
  * Clock daemon facility code value as defined by RFC 5424.
  *
  * @since release v2.0.0.
  */
-#define STUMPLESS_FACILITY_CRON2_VALUE (15 << 3)
+#  define STUMPLESS_FACILITY_CRON2_VALUE ( 15 << 3 )
 
 /**
  * Local use 0 facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_LOCAL0_VALUE LOG_LOCAL0
-#else
-#define STUMPLESS_FACILITY_LOCAL0_VALUE (16 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_LOCAL0_VALUE LOG_LOCAL0
+#  else
+#    define STUMPLESS_FACILITY_LOCAL0_VALUE ( 16 << 3 )
+#  endif
 
 /**
  * Local use 1 facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_LOCAL1_VALUE LOG_LOCAL1
-#else
-#define STUMPLESS_FACILITY_LOCAL1_VALUE (17 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_LOCAL1_VALUE LOG_LOCAL1
+#  else
+#    define STUMPLESS_FACILITY_LOCAL1_VALUE ( 17 << 3 )
+#  endif
 
 /**
  * Local use 2 facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_LOCAL2_VALUE LOG_LOCAL2
-#else
-#define STUMPLESS_FACILITY_LOCAL2_VALUE (18 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_LOCAL2_VALUE LOG_LOCAL2
+#  else
+#    define STUMPLESS_FACILITY_LOCAL2_VALUE ( 18 << 3 )
+#  endif
 
 /**
  * Local use 3 facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_LOCAL3_VALUE LOG_LOCAL3
-#else
-#define STUMPLESS_FACILITY_LOCAL3_VALUE (19 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_LOCAL3_VALUE LOG_LOCAL3
+#  else
+#    define STUMPLESS_FACILITY_LOCAL3_VALUE ( 19 << 3 )
+#  endif
 
 /**
  * Local use 4 facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_LOCAL4_VALUE LOG_LOCAL4
-#else
-#define STUMPLESS_FACILITY_LOCAL4_VALUE (20 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_LOCAL4_VALUE LOG_LOCAL4
+#  else
+#    define STUMPLESS_FACILITY_LOCAL4_VALUE ( 20 << 3 )
+#  endif
 
 /**
  * Local use 5 facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_LOCAL5_VALUE LOG_LOCAL5
-#else
-#define STUMPLESS_FACILITY_LOCAL5_VALUE (21 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_LOCAL5_VALUE LOG_LOCAL5
+#  else
+#    define STUMPLESS_FACILITY_LOCAL5_VALUE ( 21 << 3 )
+#  endif
 
 /**
  * Local use 6 facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_LOCAL6_VALUE LOG_LOCAL6
-#else
-#define STUMPLESS_FACILITY_LOCAL6_VALUE (22 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_LOCAL6_VALUE LOG_LOCAL6
+#  else
+#    define STUMPLESS_FACILITY_LOCAL6_VALUE ( 22 << 3 )
+#  endif
 
 /**
  * Local use 7 facility code value.
  *
  * @since release v2.0.0.
  */
-#ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
-#define STUMPLESS_FACILITY_LOCAL7_VALUE LOG_LOCAL7
-#else
-#define STUMPLESS_FACILITY_LOCAL7_VALUE (23 << 3)
-#endif
+#  ifdef STUMPLESS_SYSLOG_H_COMPATIBLE
+#    define STUMPLESS_FACILITY_LOCAL7_VALUE LOG_LOCAL7
+#  else
+#    define STUMPLESS_FACILITY_LOCAL7_VALUE ( 23 << 3 )
+#  endif
 
 /**
  * A macro function that runs the provided action once for each facility,
@@ -282,157 +282,149 @@
  *
  * @since release v2.0.0.
  */
-#define STUMPLESS_FOREACH_FACILITY(ACTION)                           \
-  /** Kernel messages. */                                            \
-  ACTION(STUMPLESS_FACILITY_KERN, STUMPLESS_FACILITY_KERN_VALUE)     \
-  /** User-level messages. */                                        \
-  ACTION(STUMPLESS_FACILITY_USER, STUMPLESS_FACILITY_USER_VALUE)     \
-  /** Mail system facility code value as defined by RFC 5424. */     \
-  ACTION(STUMPLESS_FACILITY_MAIL, STUMPLESS_FACILITY_MAIL_VALUE)     \
-  /** System daemons. */                                             \
-  ACTION(STUMPLESS_FACILITY_DAEMON, STUMPLESS_FACILITY_DAEMON_VALUE) \
-  /** Security/authorization messages. */                            \
-  ACTION(STUMPLESS_FACILITY_AUTH, STUMPLESS_FACILITY_AUTH_VALUE)     \
-  /** Message generated internally by the logging daemon. */         \
-  ACTION(STUMPLESS_FACILITY_SYSLOG, STUMPLESS_FACILITY_SYSLOG_VALUE) \
-  /** Line printer subsystem. */                                     \
-  ACTION(STUMPLESS_FACILITY_LPR, STUMPLESS_FACILITY_LPR_VALUE)       \
-  /** Network news. */                                               \
-  ACTION(STUMPLESS_FACILITY_NEWS, STUMPLESS_FACILITY_NEWS_VALUE)     \
-  /** UUCP subsystem. */                                             \
-  ACTION(STUMPLESS_FACILITY_UUCP, STUMPLESS_FACILITY_UUCP_VALUE)     \
-  /** Clock daemon. */                                               \
-  ACTION(STUMPLESS_FACILITY_CRON, STUMPLESS_FACILITY_CRON_VALUE)     \
-  /** Security/authorization messages. */                            \
-  ACTION(STUMPLESS_FACILITY_AUTH2, STUMPLESS_FACILITY_AUTH2_VALUE)   \
-  /** FTP daemon. */                                                 \
-  ACTION(STUMPLESS_FACILITY_FTP, STUMPLESS_FACILITY_FTP_VALUE)       \
-  /** NTP subsystem. */                                              \
-  ACTION(STUMPLESS_FACILITY_NTP, STUMPLESS_FACILITY_NTP_VALUE)       \
-  /** Log audit. */                                                  \
-  ACTION(STUMPLESS_FACILITY_AUDIT, STUMPLESS_FACILITY_AUDIT_VALUE)   \
-  /** Log alert. */                                                  \
-  ACTION(STUMPLESS_FACILITY_ALERT, STUMPLESS_FACILITY_ALERT_VALUE)   \
-  /** Clock daemon. */                                               \
-  ACTION(STUMPLESS_FACILITY_CRON2, STUMPLESS_FACILITY_CRON2_VALUE)   \
-  /** Local use 0. */                                                \
-  ACTION(STUMPLESS_FACILITY_LOCAL0, STUMPLESS_FACILITY_LOCAL0_VALUE) \
-  /** Local use 1. */                                                \
-  ACTION(STUMPLESS_FACILITY_LOCAL1, STUMPLESS_FACILITY_LOCAL1_VALUE) \
-  /** Local use 2. */                                                \
-  ACTION(STUMPLESS_FACILITY_LOCAL2, STUMPLESS_FACILITY_LOCAL2_VALUE) \
-  /** Local use 3. */                                                \
-  ACTION(STUMPLESS_FACILITY_LOCAL3, STUMPLESS_FACILITY_LOCAL3_VALUE) \
-  /** Local use 4. */                                                \
-  ACTION(STUMPLESS_FACILITY_LOCAL4, STUMPLESS_FACILITY_LOCAL4_VALUE) \
-  /** Local use 5. */                                                \
-  ACTION(STUMPLESS_FACILITY_LOCAL5, STUMPLESS_FACILITY_LOCAL5_VALUE) \
-  /** Local use 6. */                                                \
-  ACTION(STUMPLESS_FACILITY_LOCAL6, STUMPLESS_FACILITY_LOCAL6_VALUE) \
-  /** Local use 7. */                                                \
-  ACTION(STUMPLESS_FACILITY_LOCAL7, STUMPLESS_FACILITY_LOCAL7_VALUE)
+#  define STUMPLESS_FOREACH_FACILITY( ACTION )                       \
+/** Kernel messages. */                                              \
+ACTION( STUMPLESS_FACILITY_KERN, STUMPLESS_FACILITY_KERN_VALUE )     \
+/** User-level messages. */                                          \
+ACTION( STUMPLESS_FACILITY_USER, STUMPLESS_FACILITY_USER_VALUE )     \
+/** Mail system facility code value as defined by RFC 5424. */       \
+ACTION( STUMPLESS_FACILITY_MAIL, STUMPLESS_FACILITY_MAIL_VALUE )     \
+/** System daemons. */                                               \
+ACTION( STUMPLESS_FACILITY_DAEMON, STUMPLESS_FACILITY_DAEMON_VALUE ) \
+/** Security/authorization messages. */                              \
+ACTION( STUMPLESS_FACILITY_AUTH, STUMPLESS_FACILITY_AUTH_VALUE )     \
+/** Message generated internally by the logging daemon. */           \
+ACTION( STUMPLESS_FACILITY_SYSLOG, STUMPLESS_FACILITY_SYSLOG_VALUE ) \
+/** Line printer subsystem. */                                       \
+ACTION( STUMPLESS_FACILITY_LPR, STUMPLESS_FACILITY_LPR_VALUE )       \
+/** Network news. */                                                 \
+ACTION( STUMPLESS_FACILITY_NEWS, STUMPLESS_FACILITY_NEWS_VALUE )     \
+/** UUCP subsystem. */                                               \
+ACTION( STUMPLESS_FACILITY_UUCP, STUMPLESS_FACILITY_UUCP_VALUE )     \
+/** Clock daemon. */                                                 \
+ACTION( STUMPLESS_FACILITY_CRON, STUMPLESS_FACILITY_CRON_VALUE )     \
+/** Security/authorization messages. */                              \
+ACTION( STUMPLESS_FACILITY_AUTH2, STUMPLESS_FACILITY_AUTH2_VALUE )   \
+/** FTP daemon. */                                                   \
+ACTION( STUMPLESS_FACILITY_FTP, STUMPLESS_FACILITY_FTP_VALUE )       \
+/** NTP subsystem. */                                                \
+ACTION( STUMPLESS_FACILITY_NTP, STUMPLESS_FACILITY_NTP_VALUE )       \
+/** Log audit. */                                                    \
+ACTION( STUMPLESS_FACILITY_AUDIT, STUMPLESS_FACILITY_AUDIT_VALUE )   \
+/** Log alert. */                                                    \
+ACTION( STUMPLESS_FACILITY_ALERT, STUMPLESS_FACILITY_ALERT_VALUE )   \
+/** Clock daemon. */                                                 \
+ACTION( STUMPLESS_FACILITY_CRON2, STUMPLESS_FACILITY_CRON2_VALUE )   \
+/** Local use 0. */                                                  \
+ACTION( STUMPLESS_FACILITY_LOCAL0, STUMPLESS_FACILITY_LOCAL0_VALUE ) \
+/** Local use 1. */                                                  \
+ACTION( STUMPLESS_FACILITY_LOCAL1, STUMPLESS_FACILITY_LOCAL1_VALUE ) \
+/** Local use 2. */                                                  \
+ACTION( STUMPLESS_FACILITY_LOCAL2, STUMPLESS_FACILITY_LOCAL2_VALUE ) \
+/** Local use 3. */                                                  \
+ACTION( STUMPLESS_FACILITY_LOCAL3, STUMPLESS_FACILITY_LOCAL3_VALUE ) \
+/** Local use 4. */                                                  \
+ACTION( STUMPLESS_FACILITY_LOCAL4, STUMPLESS_FACILITY_LOCAL4_VALUE ) \
+/** Local use 5. */                                                  \
+ACTION( STUMPLESS_FACILITY_LOCAL5, STUMPLESS_FACILITY_LOCAL5_VALUE ) \
+/** Local use 6. */                                                  \
+ACTION( STUMPLESS_FACILITY_LOCAL6, STUMPLESS_FACILITY_LOCAL6_VALUE ) \
+/** Local use 7. */                                                  \
+ACTION( STUMPLESS_FACILITY_LOCAL7, STUMPLESS_FACILITY_LOCAL7_VALUE )
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
+#  ifdef __cplusplus
+extern "C" {
+#  endif
 
-  /**
-   * All possible facility codes available to log entries.
-   *
-   * In versions prior to 2.0.0, these values were simply \#define symbols. They
-   * have been changed to an enum to clearly convey proper usage.
-   *
-   * @since release v2.0.0.
-   */
-  enum stumpless_facility
-  {
-    STUMPLESS_FOREACH_FACILITY(STUMPLESS_GENERATE_ENUM)
-  };
+/**
+ * All possible facility codes available to log entries.
+ *
+ * In versions prior to 2.0.0, these values were simply \#define symbols. They
+ * have been changed to an enum to clearly convey proper usage.
+ *
+ * @since release v2.0.0.
+ */
+enum stumpless_facility {
+  STUMPLESS_FOREACH_FACILITY( STUMPLESS_GENERATE_ENUM )
+};
 
-  /**
-   * Gets the string representation of the given facility.
-   *
-   * This is a string literal that should not be modified or freed by the caller.
-   *
-   * **Thread Safety: MT-Safe**
-   * This function is thread safe.
-   *
-   * **Async Signal Safety: AS-Safe**
-   * This function is safe to call from signal handlers.
-   *
-   * **Async Cancel Safety: AC-Safe**
-   * This function is safe to call from threads that may be asynchronously
-   * cancelled.
-   *
-   * @since release v2.1.0.
-   *
-   * @param facility The facility to get the string from.
-   *
-   * @return The string representation of the given facility.
-   */
-  STUMPLESS_PUBLIC_FUNCTION
-  const char *
-  stumpless_get_facility_string(enum stumpless_facility facility);
+/**
+ * Gets the string representation of the given facility.
+ *
+ * This is a string literal that should not be modified or freed by the caller.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe.
+ *
+ * **Async Signal Safety: AS-Safe**
+ * This function is safe to call from signal handlers.
+ *
+ * **Async Cancel Safety: AC-Safe**
+ * This function is safe to call from threads that may be asynchronously
+ * cancelled.
+ *
+ * @since release v2.1.0.
+ *
+ * @param facility The facility to get the string from.
+ *
+ * @return The string representation of the given facility.
+ */
+STUMPLESS_PUBLIC_FUNCTION
+const char *
+stumpless_get_facility_string( enum stumpless_facility facility );
 
-  /**
-   * Gets the enum value corresponding to the given facility string.
-   *
-   * **Thread Safety: MT-Safe**
-   * This function is thread safe.
-   *
-   * **Async Signal Safety: AS-Safe**
-   * This function is safe to call from signal handlers.
-   *
-   * **Async Cancel Safety: AC-Safe**
-   * This function is safe to call from threads that may be asynchronously
-   * cancelled.
-   *
-   * @since release v2.1.0.
-   *
-   * @param facility_string The facility name to get the enum from.
-   *
-   * @error Clears previous error on success.
-   * @error Raises STUMPLESS_INVALID_FACILITY on invalid input.
-   *
-   * @return The enum integer corresponding to the given facility or -1 if
-   * the string is not a valid facility name.
-   */
-  STUMPLESS_PUBLIC_FUNCTION
-  enum stumpless_facility
-  stumpless_get_facility_enum(const char *facility_string);
+/**
+ * Gets the enum value corresponding to the given facility string.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe.
+ *
+ * **Async Signal Safety: AS-Safe**
+ * This function is safe to call from signal handlers.
+ *
+ * **Async Cancel Safety: AC-Safe**
+ * This function is safe to call from threads that may be asynchronously
+ * cancelled.
+ *
+ * @since release v2.1.0.
+ *
+ * @param facility_string The facility name to get the enum from.
+ *
+ * @return The enum integer corresponding to the given facility or -1 if
+ * the string is not a valid facility name.
+ */
+STUMPLESS_PUBLIC_FUNCTION
+enum stumpless_facility
+stumpless_get_facility_enum( const char *facility_string );
 
-  /**
-   * Gets the enum value corresponding to the given facility string.
-   *
-   * **Thread Safety: MT-Safe**
-   * This function is thread safe.
-   *
-   * **Async Signal Safety: AS-Safe**
-   * This function is safe to call from signal handlers.
-   *
-   * **Async Cancel Safety: AC-Safe**
-   * This function is safe to call from threads that may be asynchronously
-   * cancelled.
-   *
-   * @since release v2.2.0.
-   *
-   * @param facility_string The facility name to get the enum from.
-   *
-   * @param facility_buffer_length The length of the buffer
-   *
-   * @error Clears previous error on success.
-   * @error Raises STUMPLESS_INVALID_FACILITY on invalid input.
-   *
-   * @return The enum integer corresponding to the given facility or -1 if
-   * the string is not a valid facility name.
-   */
-  STUMPLESS_PUBLIC_FUNCTION
-  enum stumpless_facility
-  stumpless_get_facility_enum_from_buffer(const char *facility_string, size_t facility_buffer_length);
+/**
+ * Gets the enum value corresponding to the given facility string.
+ *
+ * **Thread Safety: MT-Safe**
+ * This function is thread safe.
+ *
+ * **Async Signal Safety: AS-Safe**
+ * This function is safe to call from signal handlers.
+ *
+ * **Async Cancel Safety: AC-Safe**
+ * This function is safe to call from threads that may be asynchronously
+ * cancelled.
+ *
+ * @since release v2.2.0.
+ *
+ * @param facility_string The facility name to get the enum from.
+ * 
+ * @param facility_buffer_length The length of the buffer
+ *
+ * @return The enum integer corresponding to the given facility or -1 if
+ * the string is not a valid facility name.
+ */
+STUMPLESS_PUBLIC_FUNCTION
+enum stumpless_facility
+stumpless_get_facility_enum_from_buffer( const char *facility_string, size_t facility_buffer_length );
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 } /* extern "C" */
-#endif
+#  endif
 
 #endif /* __STUMPLESS_FACILITY_H */

--- a/src/facility.c
+++ b/src/facility.c
@@ -21,6 +21,7 @@
 #include <stumpless/facility.h>
 #include "private/facility.h"
 #include "private/strhelper.h"
+#include "private/error.h"
 
 static char *facility_enum_to_string[] = {
   STUMPLESS_FOREACH_FACILITY( GENERATE_STRING )
@@ -29,43 +30,57 @@ static char *facility_enum_to_string[] = {
 const char *
 stumpless_get_facility_string( enum stumpless_facility facility ) {
   if ( !facility_is_invalid( facility ) ) {
+    clear_error();
     return facility_enum_to_string[facility >> 3];
   }
+
+  raise_error( STUMPLESS_INVALID_FACILITY, "invalid facility enum" , 0, NULL);
   return "NO_SUCH_FACILITY";
 }
 
 enum stumpless_facility
-stumpless_get_facility_enum( const char *facility_string ) {
-  return stumpless_get_facility_enum_from_buffer(facility_string, strlen(facility_string));
+stumpless_get_facility_enum_from_buffer( const char *facility_buffer, size_t facility_buffer_length ) {
+  size_t facility_bound;
+  size_t i;
+  const int str_offset = 19;  // to ommit "STUMPLESS_FACILITY_"
+
+  facility_bound = sizeof( facility_enum_to_string ) /
+                   sizeof( facility_enum_to_string[0] );
+
+  for( i = 0; i < facility_bound; i++ ) {
+    if( strncasecmp_custom( facility_buffer, facility_enum_to_string[i] + str_offset, facility_buffer_length ) == 0 ) {
+      clear_error();
+      return i << 3;
+    }
+  }
+
+  if( strncasecmp_custom( facility_buffer, "SECURITY", facility_buffer_length ) == 0 ) {
+    clear_error();
+    return STUMPLESS_FACILITY_AUTH_VALUE;
+  }
+
+  if( strncasecmp_custom( facility_buffer, "AUTHPRIV", facility_buffer_length ) == 0 ) {
+    clear_error();
+    return STUMPLESS_FACILITY_AUTH2_VALUE;
+  }
+
+  raise_error( STUMPLESS_INVALID_FACILITY, "invalid facility string", 0, NULL );
+  return -1;
 }
 
 enum stumpless_facility
-stumpless_get_facility_enum_from_buffer(const char *facility_buffer, size_t facility_buffer_length) {
- size_t facility_bound;
- size_t i;
- const int str_offset = 19; // to ommit "STUMPLESS_FACILITY_"
+stumpless_get_facility_enum( const char *facility_string ) {
+  enum stumpless_facility result = stumpless_get_facility_enum_from_buffer(
+    facility_string, strlen( facility_string ) );
 
- facility_bound = sizeof( facility_enum_to_string ) /
-           sizeof( facility_enum_to_string[0] );
-
- for( i = 0; i < facility_bound; i++ ) {
-  if( strncasecmp_custom( facility_buffer, facility_enum_to_string[i] + str_offset, facility_buffer_length ) == 0 ) {
-   return i << 3;
+  if( result != -1 ) {
+    clear_error();
   }
- }
 
- // exeption, for 'security' return 'auth' enum value
-  if( strncasecmp_custom( facility_buffer, "SECURITY", facility_buffer_length ) == 0 ) {
-  return STUMPLESS_FACILITY_AUTH_VALUE;
- }
-
- // exeption, for 'authpriv' not presented in enum list
-  if( strncasecmp_custom( facility_buffer, "AUTHPRIV", facility_buffer_length ) == 0 ) {
-  return STUMPLESS_FACILITY_AUTH2_VALUE;
- }
-
- return -1;
+  return result;
 }
+
+
 
 /* private functions */
 

--- a/src/facility.c
+++ b/src/facility.c
@@ -21,6 +21,8 @@
 #include <stumpless/facility.h>
 #include "private/facility.h"
 #include "private/strhelper.h"
+#include <stumpless/error.h>
+
 
 static char *facility_enum_to_string[] = {
   STUMPLESS_FOREACH_FACILITY( GENERATE_STRING )
@@ -29,43 +31,59 @@ static char *facility_enum_to_string[] = {
 const char *
 stumpless_get_facility_string( enum stumpless_facility facility ) {
   if ( !facility_is_invalid( facility ) ) {
+    clear_error();
     return facility_enum_to_string[facility >> 3];
   }
+
+  raise_error( STUMPLESS_INVALID_FACILITY, "invalid facility enum" );
   return "NO_SUCH_FACILITY";
 }
 
 enum stumpless_facility
-stumpless_get_facility_enum( const char *facility_string ) {
-  return stumpless_get_facility_enum_from_buffer(facility_string, strlen(facility_string));
+stumpless_get_facility_enum_from_buffer( const char *facility_buffer,
+                                         size_t facility_buffer_length ) {
+  size_t facility_bound;
+  size_t i;
+  const int str_offset = 19;
+
+  facility_bound = sizeof( facility_enum_to_string ) /
+                   sizeof( facility_enum_to_string[0] );
+
+  for( i = 0; i < facility_bound; i++ ) {
+    if( strncasecmp_custom( facility_buffer,
+                            facility_enum_to_string[i] + str_offset,
+                            facility_buffer_length ) == 0 ) {
+      clear_error();
+      return i << 3;
+    }
+  }
+
+  if( strncasecmp_custom( facility_buffer, "SECURITY", facility_buffer_length ) == 0 ) {
+    clear_error();
+    return STUMPLESS_FACILITY_AUTH_VALUE;
+  }
+
+  if( strncasecmp_custom( facility_buffer, "AUTHPRIV", facility_buffer_length ) == 0 ) {
+    clear_error();
+    return STUMPLESS_FACILITY_AUTH2_VALUE;
+  }
+
+  raise_error( STUMPLESS_INVALID_FACILITY, "invalid facility string" );
+  return -1;
 }
 
 enum stumpless_facility
-stumpless_get_facility_enum_from_buffer(const char *facility_buffer, size_t facility_buffer_length) {
- size_t facility_bound;
- size_t i;
- const int str_offset = 19; // to ommit "STUMPLESS_FACILITY_"
+stumpless_get_facility_enum( const char *facility_string ) {
+  enum stumpless_facility result = stumpless_get_facility_enum_from_buffer(
+    facility_string, strlen( facility_string ) );
 
- facility_bound = sizeof( facility_enum_to_string ) /
-           sizeof( facility_enum_to_string[0] );
-
- for( i = 0; i < facility_bound; i++ ) {
-  if( strncasecmp_custom( facility_buffer, facility_enum_to_string[i] + str_offset, facility_buffer_length ) == 0 ) {
-   return i << 3;
+  if( result != -1 ) {
+    clear_error();
   }
- }
 
- // exeption, for 'security' return 'auth' enum value
-  if( strncasecmp_custom( facility_buffer, "SECURITY", facility_buffer_length ) == 0 ) {
-  return STUMPLESS_FACILITY_AUTH_VALUE;
- }
-
- // exeption, for 'authpriv' not presented in enum list
-  if( strncasecmp_custom( facility_buffer, "AUTHPRIV", facility_buffer_length ) == 0 ) {
-  return STUMPLESS_FACILITY_AUTH2_VALUE;
- }
-
- return -1;
+  return result;
 }
+
 
 /* private functions */
 

--- a/src/facility.c
+++ b/src/facility.c
@@ -21,8 +21,6 @@
 #include <stumpless/facility.h>
 #include "private/facility.h"
 #include "private/strhelper.h"
-#include <stumpless/error.h>
-
 
 static char *facility_enum_to_string[] = {
   STUMPLESS_FOREACH_FACILITY( GENERATE_STRING )
@@ -31,59 +29,43 @@ static char *facility_enum_to_string[] = {
 const char *
 stumpless_get_facility_string( enum stumpless_facility facility ) {
   if ( !facility_is_invalid( facility ) ) {
-    clear_error();
     return facility_enum_to_string[facility >> 3];
   }
-
-  raise_error( STUMPLESS_INVALID_FACILITY, "invalid facility enum" );
   return "NO_SUCH_FACILITY";
 }
 
 enum stumpless_facility
-stumpless_get_facility_enum_from_buffer( const char *facility_buffer,
-                                         size_t facility_buffer_length ) {
-  size_t facility_bound;
-  size_t i;
-  const int str_offset = 19;
-
-  facility_bound = sizeof( facility_enum_to_string ) /
-                   sizeof( facility_enum_to_string[0] );
-
-  for( i = 0; i < facility_bound; i++ ) {
-    if( strncasecmp_custom( facility_buffer,
-                            facility_enum_to_string[i] + str_offset,
-                            facility_buffer_length ) == 0 ) {
-      clear_error();
-      return i << 3;
-    }
-  }
-
-  if( strncasecmp_custom( facility_buffer, "SECURITY", facility_buffer_length ) == 0 ) {
-    clear_error();
-    return STUMPLESS_FACILITY_AUTH_VALUE;
-  }
-
-  if( strncasecmp_custom( facility_buffer, "AUTHPRIV", facility_buffer_length ) == 0 ) {
-    clear_error();
-    return STUMPLESS_FACILITY_AUTH2_VALUE;
-  }
-
-  raise_error( STUMPLESS_INVALID_FACILITY, "invalid facility string" );
-  return -1;
+stumpless_get_facility_enum( const char *facility_string ) {
+  return stumpless_get_facility_enum_from_buffer(facility_string, strlen(facility_string));
 }
 
 enum stumpless_facility
-stumpless_get_facility_enum( const char *facility_string ) {
-  enum stumpless_facility result = stumpless_get_facility_enum_from_buffer(
-    facility_string, strlen( facility_string ) );
+stumpless_get_facility_enum_from_buffer(const char *facility_buffer, size_t facility_buffer_length) {
+ size_t facility_bound;
+ size_t i;
+ const int str_offset = 19; // to ommit "STUMPLESS_FACILITY_"
 
-  if( result != -1 ) {
-    clear_error();
+ facility_bound = sizeof( facility_enum_to_string ) /
+           sizeof( facility_enum_to_string[0] );
+
+ for( i = 0; i < facility_bound; i++ ) {
+  if( strncasecmp_custom( facility_buffer, facility_enum_to_string[i] + str_offset, facility_buffer_length ) == 0 ) {
+   return i << 3;
   }
+ }
 
-  return result;
+ // exeption, for 'security' return 'auth' enum value
+  if( strncasecmp_custom( facility_buffer, "SECURITY", facility_buffer_length ) == 0 ) {
+  return STUMPLESS_FACILITY_AUTH_VALUE;
+ }
+
+ // exeption, for 'authpriv' not presented in enum list
+  if( strncasecmp_custom( facility_buffer, "AUTHPRIV", facility_buffer_length ) == 0 ) {
+  return STUMPLESS_FACILITY_AUTH2_VALUE;
+ }
+
+ return -1;
 }
-
 
 /* private functions */
 

--- a/src/facility.c
+++ b/src/facility.c
@@ -22,6 +22,7 @@
 #include "private/facility.h"
 #include "private/strhelper.h"
 #include "private/error.h"
+#include <stumpless/error.h>
 
 static char *facility_enum_to_string[] = {
   STUMPLESS_FOREACH_FACILITY( GENERATE_STRING )

--- a/src/facility.c
+++ b/src/facility.c
@@ -22,6 +22,7 @@
 #include "private/facility.h"
 #include "private/strhelper.h"
 #include "private/error.h"
+#include <stddef.h>
 #include <stumpless/error.h>
 
 static char *facility_enum_to_string[] = {
@@ -80,8 +81,6 @@ stumpless_get_facility_enum( const char *facility_string ) {
 
   return result;
 }
-
-
 
 /* private functions */
 

--- a/test/function/facility.cpp
+++ b/test/function/facility.cpp
@@ -20,131 +20,100 @@
 #include <stumpless.h>
 #include "test/helper/assert.hpp"
 
-namespace
-{
+namespace {
 
-  class FacilityTest : public ::testing::Test
-  {
+  class FacilityTest : public::testing::Test {
   };
 
-  TEST(GetFacilityString, EachValidFacility)
-  {
+  TEST( GetFacilityString, EachValidFacility ) {
     int facility_count = 0;
     const char *result;
 
-#define CHECK_FACILITY(STRING, ENUM)              \
-  result = stumpless_get_facility_string(STRING); \
-  EXPECT_STREQ(result, #STRING);
-    STUMPLESS_FOREACH_FACILITY(CHECK_FACILITY)
+    #define CHECK_FACILITY( STRING, ENUM ) \
+      result = stumpless_get_facility_string( STRING ); \
+      EXPECT_STREQ( result, #STRING );
+    STUMPLESS_FOREACH_FACILITY( CHECK_FACILITY )
   }
 
-  TEST(GetFacilityString, NoSuchFacility)
-  {
+  TEST( GetFacilityString, NoSuchFacility ) {
     int facility_count = 0;
     const char *result;
 
-#define COUNT_FACILITY(STRING, ENUM) ++facility_count;
-    STUMPLESS_FOREACH_FACILITY(COUNT_FACILITY)
+    #define COUNT_FACILITY( STRING, ENUM ) ++facility_count;
+    STUMPLESS_FOREACH_FACILITY( COUNT_FACILITY )
 
     stumpless_facility wrong_facility =
         static_cast<stumpless_facility>(facility_count + 1);
 
-    result = stumpless_get_facility_string(wrong_facility);
-    EXPECT_STREQ(result, "NO_SUCH_FACILITY");
+    result = stumpless_get_facility_string( wrong_facility );
+    EXPECT_STREQ( result, "NO_SUCH_FACILITY" );
   }
 
-  TEST(GetFacilityEnum, EachValidFacility)
-  {
+  TEST( GetFacilityEnum, EachValidFacility ) {
     int facility_count = 0;
     int result;
 
-#define CHECK_FACILITY_ENUM(STRING, ENUM)             \
-  result = stumpless_get_facility_enum(#STRING + 19); \
-  EXPECT_EQ(result, ENUM);
-    STUMPLESS_FOREACH_FACILITY(CHECK_FACILITY_ENUM)
+    #define CHECK_FACILITY_ENUM( STRING, ENUM ) \
+      result = stumpless_get_facility_enum( #STRING + 19 ); \
+      EXPECT_EQ( result, ENUM );
+    STUMPLESS_FOREACH_FACILITY( CHECK_FACILITY_ENUM )
   }
 
-  TEST(GetFacilityEnum, LowercaseFacility)
-  {
+  TEST( GetFacilityEnum, LowercaseFacility ) {
     int result;
 
-    result = stumpless_get_facility_enum("user");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_USER);
+    result = stumpless_get_facility_enum( "user" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_USER );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("mail");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_MAIL);
+    result = stumpless_get_facility_enum( "mail" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_MAIL );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("daemon");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_DAEMON);
+    result = stumpless_get_facility_enum( "daemon" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_DAEMON );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("auth");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_AUTH);
+    result = stumpless_get_facility_enum( "auth" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_AUTH );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("security");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_AUTH);
+    result = stumpless_get_facility_enum( "security" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_AUTH );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("syslog");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_SYSLOG);
+    result = stumpless_get_facility_enum( "syslog" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_SYSLOG );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("lpr");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_LPR);
+    result = stumpless_get_facility_enum( "lpr" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_LPR );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("news");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_NEWS);
+    result = stumpless_get_facility_enum( "news" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_NEWS );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("uucp");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_UUCP);
+    result = stumpless_get_facility_enum( "uucp" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_UUCP );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("cron");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_CRON);
+    result = stumpless_get_facility_enum( "cron" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_CRON );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("authpriv");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_AUTH2);
+    result = stumpless_get_facility_enum( "authpriv" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_AUTH2 );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("ftp");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_FTP);
+    result = stumpless_get_facility_enum( "ftp" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_FTP );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("ntp");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_NTP);
+    result = stumpless_get_facility_enum( "ntp" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_NTP );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("audit");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_AUDIT);
+    result = stumpless_get_facility_enum( "audit" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_AUDIT );
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum("alert");
-    EXPECT_EQ(result, STUMPLESS_FACILITY_ALERT);
+    result = stumpless_get_facility_enum( "alert" );
+    EXPECT_EQ( result, STUMPLESS_FACILITY_ALERT );
     EXPECT_NO_ERROR;
   }
 
-  TEST(GetFacilityEnum, NoSuchFacility)
-  {
+  TEST( GetFacilityEnum, NoSuchFacility ) {
     int result;
 
-    result = stumpless_get_facility_enum("an_invalid_facility");
-    EXPECT_EQ(result, -1);
+    result = stumpless_get_facility_enum( "an_invalid_facility" );
+    EXPECT_EQ( result, -1 );
   }
 
-}
-
-TEST(FacilityErrorHandling, ClearsPreviousErrorOnSuccess)
-{
-  stumpless_version_to_string(NULL);
-  EXPECT_ERROR_ID_EQ(STUMPLESS_ARGUMENT_EMPTY);
-
-  const char *result = stumpless_get_facility_string(STUMPLESS_FACILITY_USER);
-  EXPECT_NO_ERROR;
-  EXPECT_STREQ(result, "STUMPLESS_FACILITY_USER");
-}
-
-TEST(FacilityErrorHandling, InvalidFacilityEnumRaisesError)
-{
-  const char *result = stumpless_get_facility_string(static_cast<stumpless_facility>(200));
-  EXPECT_STREQ(result, "NO_SUCH_FACILITY");
-  EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_FACILITY);
-}
-
-TEST(FacilityErrorHandling, InvalidFacilityStringRaisesError)
-{
-  int result = stumpless_get_facility_enum("not_a_real_facility");
-  EXPECT_EQ(result, -1);
-  EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_FACILITY);
 }

--- a/test/function/facility.cpp
+++ b/test/function/facility.cpp
@@ -116,4 +116,26 @@ namespace {
     EXPECT_EQ( result, -1 );
   }
 
+  TEST( FacilityErrorHandling, ClearsPreviousErrorOnSuccess ) {
+  stumpless_version_to_string(NULL);
+  EXPECT_ERROR_ID_EQ(STUMPLESS_ARGUMENT_EMPTY);
+
+  const char* result = stumpless_get_facility_string(STUMPLESS_FACILITY_USER);
+  EXPECT_NO_ERROR;
+  EXPECT_STREQ(result, "STUMPLESS_FACILITY_USER");
+  }
+
+  TEST( FacilityErrorHandling, InvalidFacilityEnumRaisesError ) {
+  const char* result = stumpless_get_facility_string(static_cast<stumpless_facility>(200));
+  EXPECT_STREQ(result, "NO_SUCH_FACILITY");
+  EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_FACILITY);
+  }
+
+  TEST( FacilityErrorHandling, InvalidFacilityStringRaisesError ) {
+  int result = stumpless_get_facility_enum("not_a_real_facility");
+  EXPECT_EQ(result, -1);
+  EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_FACILITY);
+  }
+
+
 }

--- a/test/function/facility.cpp
+++ b/test/function/facility.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 #include <stumpless.h>
 #include "test/helper/assert.hpp"
+#include <cstddef>
 
 namespace {
 
@@ -117,24 +118,24 @@ namespace {
   }
 
   TEST( FacilityErrorHandling, ClearsPreviousErrorOnSuccess ) {
-  stumpless_version_to_string(NULL);
-  EXPECT_ERROR_ID_EQ(STUMPLESS_ARGUMENT_EMPTY);
+    stumpless_version_to_string(NULL);
+    EXPECT_ERROR_ID_EQ(STUMPLESS_ARGUMENT_EMPTY);
 
-  const char* result = stumpless_get_facility_string(STUMPLESS_FACILITY_USER);
-  EXPECT_NO_ERROR;
-  EXPECT_STREQ(result, "STUMPLESS_FACILITY_USER");
+    const char* result = stumpless_get_facility_string(STUMPLESS_FACILITY_USER);
+    EXPECT_NO_ERROR;
+    EXPECT_STREQ(result, "STUMPLESS_FACILITY_USER");
   }
 
   TEST( FacilityErrorHandling, InvalidFacilityEnumRaisesError ) {
-  const char* result = stumpless_get_facility_string(static_cast<stumpless_facility>(200));
-  EXPECT_STREQ(result, "NO_SUCH_FACILITY");
-  EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_FACILITY);
+    const char* result = stumpless_get_facility_string(static_cast<stumpless_facility>(200));
+    EXPECT_STREQ(result, "NO_SUCH_FACILITY");
+    EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_FACILITY);
   }
 
   TEST( FacilityErrorHandling, InvalidFacilityStringRaisesError ) {
-  int result = stumpless_get_facility_enum("not_a_real_facility");
-  EXPECT_EQ(result, -1);
-  EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_FACILITY);
+    int result = stumpless_get_facility_enum("not_a_real_facility");
+    EXPECT_EQ(result, -1);
+    EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_FACILITY);
   }
 
 

--- a/test/function/facility.cpp
+++ b/test/function/facility.cpp
@@ -20,100 +20,131 @@
 #include <stumpless.h>
 #include "test/helper/assert.hpp"
 
-namespace {
+namespace
+{
 
-  class FacilityTest : public::testing::Test {
+  class FacilityTest : public ::testing::Test
+  {
   };
 
-  TEST( GetFacilityString, EachValidFacility ) {
+  TEST(GetFacilityString, EachValidFacility)
+  {
     int facility_count = 0;
     const char *result;
 
-    #define CHECK_FACILITY( STRING, ENUM ) \
-      result = stumpless_get_facility_string( STRING ); \
-      EXPECT_STREQ( result, #STRING );
-    STUMPLESS_FOREACH_FACILITY( CHECK_FACILITY )
+#define CHECK_FACILITY(STRING, ENUM)              \
+  result = stumpless_get_facility_string(STRING); \
+  EXPECT_STREQ(result, #STRING);
+    STUMPLESS_FOREACH_FACILITY(CHECK_FACILITY)
   }
 
-  TEST( GetFacilityString, NoSuchFacility ) {
+  TEST(GetFacilityString, NoSuchFacility)
+  {
     int facility_count = 0;
     const char *result;
 
-    #define COUNT_FACILITY( STRING, ENUM ) ++facility_count;
-    STUMPLESS_FOREACH_FACILITY( COUNT_FACILITY )
+#define COUNT_FACILITY(STRING, ENUM) ++facility_count;
+    STUMPLESS_FOREACH_FACILITY(COUNT_FACILITY)
 
     stumpless_facility wrong_facility =
         static_cast<stumpless_facility>(facility_count + 1);
 
-    result = stumpless_get_facility_string( wrong_facility );
-    EXPECT_STREQ( result, "NO_SUCH_FACILITY" );
+    result = stumpless_get_facility_string(wrong_facility);
+    EXPECT_STREQ(result, "NO_SUCH_FACILITY");
   }
 
-  TEST( GetFacilityEnum, EachValidFacility ) {
+  TEST(GetFacilityEnum, EachValidFacility)
+  {
     int facility_count = 0;
     int result;
 
-    #define CHECK_FACILITY_ENUM( STRING, ENUM ) \
-      result = stumpless_get_facility_enum( #STRING + 19 ); \
-      EXPECT_EQ( result, ENUM );
-    STUMPLESS_FOREACH_FACILITY( CHECK_FACILITY_ENUM )
+#define CHECK_FACILITY_ENUM(STRING, ENUM)             \
+  result = stumpless_get_facility_enum(#STRING + 19); \
+  EXPECT_EQ(result, ENUM);
+    STUMPLESS_FOREACH_FACILITY(CHECK_FACILITY_ENUM)
   }
 
-  TEST( GetFacilityEnum, LowercaseFacility ) {
+  TEST(GetFacilityEnum, LowercaseFacility)
+  {
     int result;
 
-    result = stumpless_get_facility_enum( "user" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_USER );
+    result = stumpless_get_facility_enum("user");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_USER);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "mail" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_MAIL );
+    result = stumpless_get_facility_enum("mail");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_MAIL);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "daemon" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_DAEMON );
+    result = stumpless_get_facility_enum("daemon");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_DAEMON);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "auth" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_AUTH );
+    result = stumpless_get_facility_enum("auth");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_AUTH);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "security" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_AUTH );
+    result = stumpless_get_facility_enum("security");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_AUTH);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "syslog" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_SYSLOG );
+    result = stumpless_get_facility_enum("syslog");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_SYSLOG);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "lpr" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_LPR );
+    result = stumpless_get_facility_enum("lpr");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_LPR);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "news" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_NEWS );
+    result = stumpless_get_facility_enum("news");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_NEWS);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "uucp" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_UUCP );
+    result = stumpless_get_facility_enum("uucp");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_UUCP);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "cron" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_CRON );
+    result = stumpless_get_facility_enum("cron");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_CRON);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "authpriv" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_AUTH2 );
+    result = stumpless_get_facility_enum("authpriv");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_AUTH2);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "ftp" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_FTP );
+    result = stumpless_get_facility_enum("ftp");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_FTP);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "ntp" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_NTP );
+    result = stumpless_get_facility_enum("ntp");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_NTP);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "audit" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_AUDIT );
+    result = stumpless_get_facility_enum("audit");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_AUDIT);
     EXPECT_NO_ERROR;
-    result = stumpless_get_facility_enum( "alert" );
-    EXPECT_EQ( result, STUMPLESS_FACILITY_ALERT );
+    result = stumpless_get_facility_enum("alert");
+    EXPECT_EQ(result, STUMPLESS_FACILITY_ALERT);
     EXPECT_NO_ERROR;
   }
 
-  TEST( GetFacilityEnum, NoSuchFacility ) {
+  TEST(GetFacilityEnum, NoSuchFacility)
+  {
     int result;
 
-    result = stumpless_get_facility_enum( "an_invalid_facility" );
-    EXPECT_EQ( result, -1 );
+    result = stumpless_get_facility_enum("an_invalid_facility");
+    EXPECT_EQ(result, -1);
   }
 
+}
+
+TEST(FacilityErrorHandling, ClearsPreviousErrorOnSuccess)
+{
+  stumpless_version_to_string(NULL);
+  EXPECT_ERROR_ID_EQ(STUMPLESS_ARGUMENT_EMPTY);
+
+  const char *result = stumpless_get_facility_string(STUMPLESS_FACILITY_USER);
+  EXPECT_NO_ERROR;
+  EXPECT_STREQ(result, "STUMPLESS_FACILITY_USER");
+}
+
+TEST(FacilityErrorHandling, InvalidFacilityEnumRaisesError)
+{
+  const char *result = stumpless_get_facility_string(static_cast<stumpless_facility>(200));
+  EXPECT_STREQ(result, "NO_SUCH_FACILITY");
+  EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_FACILITY);
+}
+
+TEST(FacilityErrorHandling, InvalidFacilityStringRaisesError)
+{
+  int result = stumpless_get_facility_enum("not_a_real_facility");
+  EXPECT_EQ(result, -1);
+  EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_FACILITY);
 }


### PR DESCRIPTION

### Improve Facility Error Handling (Fixes https://github.com/goatshriek/stumpless/issues/456)

This PR improves error handling and test coverage for the facility-related functions in the library. It also introduces a new function test target to aid future debugging.

---

###  Code Changes

#### `src/facility.c`

* **`stumpless_get_facility_string`**:

  * Now calls `clear_error()` on success.
  * Calls `raise_error(STUMPLESS_INVALID_FACILITY)` for invalid enums.

* **`stumpless_get_facility_enum_from_buffer`**:

  * Calls `clear_error()` on success.
  * Calls `raise_error(STUMPLESS_INVALID_FACILITY)` for unmatched strings.

* **`stumpless_get_facility_enum`**:

  * Now clears error if the call to `*_from_buffer` was successful.

---

###  Test Additions (`test/function/facility.cpp`)

Added tests in a new **`FacilityErrorHandling`** suite:

* `ClearsPreviousErrorOnSuccess`: ensures previous errors are cleared.
* `InvalidFacilityEnumRaisesError`: checks invalid enum detection.
* `InvalidFacilityStringRaisesError`: checks invalid string input.

---

###  Function Target

* Added a `function-test-facility` CMake target to run facility tests independently (mirroring `function-test-version` pattern).
* All 8 tests pass successfully.

![image](https://github.com/user-attachments/assets/426dfd3d-c862-4941-8a7d-1c4ad9601252)


---

###  Doxygen Header Updates (`include/stumpless/facility.h`)

Each relevant function comment now includes:

* `@error This function clears any previous error on success.`
* `@error This function sets STUMPLESS_INVALID_FACILITY on invalid input.`

---
