### PR TITLE
feat: added test for non cache owned memory fallback, refactored cache_free

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -169,8 +169,7 @@ cache_free( const struct cache *c, const void *entry ) {
       entry_index = ( ( const char * ) entry - current_page ) / c->entry_size;
       locks[entry_index] = 0;
 
-      config_unlock_mutex( &c->mutex );
-      return;
+      break;
     }
   }
 

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -2995,4 +2995,17 @@ namespace {
     stumpless_destroy_entry_and_contents(large_entry);
   }
 
+  TEST( EntryDestructTest, FreeUncachedEntry ) {
+    struct stumpless_entry *original = create_empty_entry();
+    ASSERT_NE(original, nullptr);
+
+    struct stumpless_entry *manual = (struct stumpless_entry *) malloc(sizeof(*manual));
+    ASSERT_NE(manual, nullptr);
+    memcpy(manual, original, sizeof(*manual));
+
+    stumpless_destroy_entry_only(original);
+    stumpless_destroy_entry_only(manual);
+    free(manual);
+  }
+
 }

--- a/test/function/entry.cpp
+++ b/test/function/entry.cpp
@@ -2995,17 +2995,16 @@ namespace {
     stumpless_destroy_entry_and_contents(large_entry);
   }
 
-  TEST( EntryDestructTest, FreeUncachedEntry ) {
-    struct stumpless_entry *original = create_empty_entry();
-    ASSERT_NE(original, nullptr);
+TEST( EntryDestructTest, FreeUncachedEntry ) {
 
-    struct stumpless_entry *manual = (struct stumpless_entry *) malloc(sizeof(*manual));
-    ASSERT_NE(manual, nullptr);
-    memcpy(manual, original, sizeof(*manual));
+  struct stumpless_entry *original = create_empty_entry();
+  ASSERT_NE(original, nullptr);
+  
+  struct stumpless_entry manual;
 
-    stumpless_destroy_entry_only(original);
-    stumpless_destroy_entry_only(manual);
-    free(manual);
-  }
+  memcpy(&manual, original, sizeof(manual));
+
+  stumpless_destroy_entry_only(&manual);
+}
 
 }


### PR DESCRIPTION
Fixes #441 

This PR adds a test to cover the fallback behavior in `cache_free()` when the object being freed is **not found in any cache page**. This triggers the final `config_unlock_mutex()` call outside the loop — a line previously uncovered.

To support this, a small refactor was also made to simplify the control flow in `cache_free` by replacing `return` with `break` and allowing a single exit path at the end of the function:

```c
      break;
    }
  }

  config_unlock_mutex( &c->mutex );
}
```

---

### What the Test Does

```cpp
TEST( EntryDestructTest, FreeUncachedEntry ) {
  struct stumpless_entry *original = create_empty_entry();
  ASSERT_NE(original, nullptr);

  struct stumpless_entry *manual = (struct stumpless_entry *) malloc(sizeof(*manual));
  ASSERT_NE(manual, nullptr);
  memcpy(manual, original, sizeof(*manual));

  stumpless_destroy_entry_only(original);
  stumpless_destroy_entry_only(manual);
  free(manual);
}
```

This creates a valid `stumpless_entry`, then copies it into a manually allocated one (`manual`). Since the second one isn’t managed by the slab cache, it forces `cache_free` to run through the loop and hit the unlock path.

---

### Valgrind Warning: Double Free

This version causes a double free warning under Valgrind because `manual` and `original` point to the same internal fields (`message`, `app_name`, `msgid`, etc.). Both get freed in `stumpless_destroy_entry_only()`.

The test still executes correctly and reliably triggers the intended fallback behavior, despite this shared-memory issue, so any guidance to fix that would be appreciated.

---

### Alternate Approaches Explored

* **Direct `cache_free()` call**: Tried calling it via extern + entry_cache, but this isn’t part of the public API. Compiling this from C++ caused issues with _Atomic due to stdatomic.h
* **Zeroed-out struct**: Allocated a malloc'd block and zeroed it out with memset, but calling stumpless_destroy_entry_only() on it triggered pthread_mutex_destroy() on uninitialized memory → segfault.
* **Deep copy of internals**: Too complex and fragile for a unit test — would require safe string duplication and mutex init logic, a lot of which isn't exposed to the public API (for example: the mutex functions not exposed, leading to the necessity of using direct thread interfacing using libraries like pthread.h in the test file)


The current test is a practical compromise to verify the fallback path in `cache_free()` is exercised without rewriting internals or bypassing the public API.