### PR TITLE
docs(vscode): add IDE setup + examples; preset-based tasks; opt-in example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "cmake.useCMakePresets": "always",
+  "cmake.defaultConfigurePreset": "Default",
+  "cmake.defaultBuildPreset": "Default",
+  "cmake.defaultTestPreset": "Default"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Configure (Preset Auto)",
+      "type": "process",
+      "command": "cmake",
+      "args": ["--preset", "${config:cmake.defaultConfigurePreset}"],
+      "group": { "kind": "build", "isDefault": false },
+      "problemMatcher": []
+    },
+    {
+      "label": "Build (Preset Auto)",
+      "type": "process",
+      "command": "cmake",
+      "args": ["--build", "--preset", "${config:cmake.defaultBuildPreset}"],
+      "dependsOn": ["Configure (Preset Auto)"],
+      "group": { "kind": "build", "isDefault": false },
+      "problemMatcher": []
+    },
+    {
+      "label": "Clean (Preset Auto)",
+      "type": "shell",
+      "linux":   { "command": "rm",        "args": ["-rf", "${workspaceFolder}/build"] },
+      "osx":     { "command": "rm",        "args": ["-rf", "${workspaceFolder}/build"] },
+      "windows": { "command": "powershell","args": ["-NoProfile","-ExecutionPolicy","Bypass","-Command","Remove-Item -Recurse -Force build"] },
+      "group": { "kind": "build", "isDefault": false },
+      "problemMatcher": []
+    },
+    {
+      "label": "Clean & Rebuild",
+      "type": "shell",
+      "dependsOn": ["Clean (Preset Auto)", "Build (Preset Auto)"],
+      "group": { "kind": "build", "isDefault": false },
+      "command": "echo",
+      "args": ["Rebuilding..."],
+      "problemMatcher": []
+    }
+  ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,3 +711,23 @@ endif()
 if(DOXYGEN_FOUND)
   include(tools/cmake/doxygen.cmake)
 endif()
+
+# Option to build examples
+option(STUMPLESS_BUILD_EXAMPLES "Build example programs" OFF)
+
+if(STUMPLESS_BUILD_EXAMPLES)
+  # for compiling examples
+  add_executable(basic_example docs/examples/basic/basic_example.c)
+
+  target_include_directories(basic_example PRIVATE
+    ${PROJECT_SOURCE_DIR}/include        # <-- headers in repo (stumpless.h)
+    ${CMAKE_BINARY_DIR}/include          # <-- generated headers (stumpless/config.h)
+  )
+
+  target_link_libraries(basic_example PRIVATE stumpless)
+
+  # keep your rpath if you want
+  set_target_properties(basic_example PROPERTIES
+    BUILD_RPATH "${CMAKE_BINARY_DIR};${CMAKE_BINARY_DIR}/Debug"
+  )
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,18 @@
+{
+  "version": 5,
+  "cmakeMinimumRequired": { "major": 3, "minor": 23 },
+  "configurePresets": [
+    {
+      "name": "Default",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+    }
+  ],
+  "buildPresets": [
+    { "name": "Default", "configurePreset": "Default" }
+  ],
+  "testPresets": [
+    { "name": "Default", "configurePreset": "Default" }
+  ]
+}

--- a/docs/IDE-setup.md
+++ b/docs/IDE-setup.md
@@ -1,0 +1,122 @@
+# IDE Setup - Visual Studio Code
+
+This guide will help you set up **Visual Studio Code (VS Code)** for developing and debugging this project.
+
+## 1. Install Visual Studio Code
+
+Download and install VS Code from:  
+[https://code.visualstudio.com/Download](https://code.visualstudio.com/Download)
+
+---
+
+## 2. Install Required Extensions
+
+Open the Extensions panel (`Ctrl+Shift+X`) and install:
+
+- **C/C++** (by Microsoft) – IntelliSense, debugging, and code browsing.
+- **CMake Tools** – For configuring, building, and debugging CMake-based projects.
+- **Dev Containers** *(optional)* – For working in a pre-configured containerized environment.
+- **CodeLLDB** or **Microsoft C/C++ Debugger** – For debugging support.
+
+---
+
+## 3. Clone the Repository
+
+Open a terminal and run:
+
+```bash
+git clone https://github.com/goatshriek/stumpless.git
+cd stumpless
+```
+
+---
+
+## 4. Open the Project in VS Code
+
+From VS Code:
+1. Click **File → Open Folder…**
+2. Select the cloned repository folder.
+
+---
+## 5. Build, Clean, and Rebuild (VS Code)
+
+This project includes predefined VS Code tasks for building, cleaning, and rebuilding.
+
+#### Build the project
+1. Press **Ctrl+Shift+B**.
+2. Select **Build (Preset Auto)** from the list.
+
+#### Clean the project
+1. Press **Ctrl+Shift+B**.
+2. Select **Clean (Preset Auto)**.
+   - This will delete the entire `build` directory.
+
+#### Clean & Rebuild the project
+1. Press **Ctrl+Shift+B**.
+2. Select **Clean & Rebuild**.
+   - This will first delete the `build` directory and then run the build again automatically.
+
+---
+
+## 6. Building and Running Examples
+
+This project includes example programs such as `basic_example`.  
+To enable them, configure CMake with the `STUMPLESS_BUILD_EXAMPLES` option:
+
+### Enable Examples
+
+By default, example programs are **not** built.  
+To enable them, you have two options:
+
+1. **Enable via CMake command:**
+```bash
+cmake -S . -B build/Debug -DCMAKE_BUILD_TYPE=Debug -DSTUMPLESS_BUILD_EXAMPLES=ON
+```
+
+2. **Enable via CMakeLists.txt:**  
+Open the main `CMakeLists.txt` file and change:
+```cmake
+option(STUMPLESS_BUILD_EXAMPLES "Build example programs" OFF)
+```
+to:
+```cmake
+option(STUMPLESS_BUILD_EXAMPLES "Build example programs" ON)
+```
+
+### Build example
+```bash
+cmake --build build/Debug --target basic_example
+```
+
+### Run example
+```bash
+./build/Debug/basic_example
+```
+> This will create an `example.log` file in the current directory containing the log output.
+
+### Disable examples
+```bash
+cmake -S . -B build/Debug -DCMAKE_BUILD_TYPE=Debug -DSTUMPLESS_BUILD_EXAMPLES=OFF
+```
+
+---
+
+## 7. Tips
+
+- Use `.vscode/settings.json` to store workspace-specific settings.
+- Use `.vscode/c_cpp_properties.json` to configure IntelliSense include paths.
+- Use `.vscode/launch.json` to store debugging configurations.
+- Use `.vscode/tasks.json` for custom build commands.
+
+---
+
+## 8. Troubleshooting
+
+- **CMake not found**: Ensure CMake is installed and added to your system PATH.
+- **Compiler not found**: Install GCC/Clang or Visual Studio Build Tools.
+- **Debugger errors**: Check that `gdb` or `lldb` is installed.
+- **Example not building**: Make sure `STUMPLESS_BUILD_EXAMPLES=ON` when running CMake.
+
+---
+
+**Now you’re ready to code, build, and debug the project in VS Code!**

--- a/include/private/memory.h
+++ b/include/private/memory.h
@@ -115,10 +115,56 @@ size_t get_paged_size( size_t size );
  */
 void *realloc_mem( const void *mem, size_t size );
 
-// A wrapper for alloc_mem that checks for overflow before proper allocation
+/**
+ * Allocates an array of `item_count` elements, each of size `item_size`.
+ *
+ * This is a thin wrapper around `alloc_mem` that checks for integer
+ * overflow in the multiplication `item_count * item_size` before calling
+ * through to the underlying allocator.
+ *
+ * **Thread Safety: MT-Safe**  
+ * Relies on `alloc_mem` (and the C heap), which is assumed thread-safe.
+ *
+ * **Async Signal Safety: AS-Unsafe**  
+ * Allocation may invoke non-reentrant calls (e.g. `malloc`), so this
+ * cannot be used in signal handlers.
+ *
+ * **Async Cancel Safety: AC-Unsafe**  
+ * If cancellation occurs during allocation, the heap state may become
+ * inconsistent.
+ *
+ * @param item_count  Number of elements to allocate.
+ * @param item_size   Size in bytes of each element.
+ * @return A pointer to the newly allocated zero-initialized array,
+ *         or NULL if overflow is detected or allocation fails.
+ */
 void *alloc_array( size_t item_count, size_t item_size );
 
-// A wrapper for realloc_mem that checks for overflow before proper allocation
+/**
+ * Reallocates an array previously allocated with `alloc_array` (or
+ * another `realloc_array`) to hold `item_count` elements of size
+ * `item_size`, with overflow checking.
+ *
+ * If `mem` is NULL, behaves like `alloc_array`. If `item_count * item_size`
+ * would overflow, no reallocation is attempted and NULL is returned.
+ *
+ * **Thread Safety: MT-Safe**  
+ * Depends on `realloc_mem`, which is assumed to be thread-safe.
+ *
+ * **Async Signal Safety: AS-Unsafe**  
+ * May call non-reentrant routines; unsafe in signal contexts.
+ *
+ * **Async Cancel Safety: AC-Unsafe**  
+ * Cancellation during the call may leave the heap in an undefined state.
+ *
+ * @param mem         Pointer to an existing block (from `alloc_array`),
+ *                    or NULL.
+ * @param item_count  New number of elements.
+ * @param item_size   Size in bytes of each element.
+ * @return A pointer to the resized block, or NULL if overflow is
+ *         detected or reallocation fails. In case of failure with
+ *         non-NULL `mem`, the original block remains valid.
+ */
 void *realloc_array( const void *mem, size_t item_count, size_t item_size );
 
 #endif /* __STUMPLESS_PRIVATE_MEMORY_H */


### PR DESCRIPTION
Add docs/IDE-setup.md (VS Code guide with build/clean & examples)

Add .vscode/ configs: tasks.json (Build/Clean/Clean&Rebuild), settings.json, extensions.json

Add CMakePresets.json (single build/ dir via preset)

Make examples optional via STUMPLESS_BUILD_EXAMPLES in CMakeLists.txt; document enable/disable

Keeps builds consistent across OS; no manual CMake config needed

(refs https://github.com/goatshriek/stumpless/issues/473)