### PR TITLE
docs: add VS Code IDE setup doc and (#473)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/html/*
 *.swp
 .vs/*
 .vscode/*
+!.vscode/extensions.json
 CMakeSettings.json
 **/.DS_Store
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "ms-vscode.cpptools",
+    "ms-vscode.cmake-tools",
+    "ms-python.python"
+  ]
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -65,6 +65,10 @@ cmake --build . --parallel 4 --config x64-Debug --target check
 # name, which for functionality tests is function-test-<name>
 cmake --build . --target --parallel 4 function-test-target && ./function-test-target
 ```
+## IDE Setup
+
+If you use Visual Studio Code, see **[IDE Setup (VS Code)](./ide-setup.md)** for the minimal extension list and how to open the repo. This keeps IDE guidance lightweight and defers to official documentation.
+
 
 More details about building the library are available in the
 [INSTALL.md](../INSTALL.md) file. However, if you plan to be developing

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -1,0 +1,18 @@
+# IDE Setup (VS Code)
+
+This page helps new contributors open the project in **Visual Studio Code** and install a few helpful extensions. It does **not** change build settings; please see the main development docs for build/run details.
+
+## 1) Install VS Code
+- Download and install VS Code: <https://code.visualstudio.com/>
+
+## 2) Open the project folder
+- `File → Open Folder…` and select the repository root.
+
+## 3) Accept the recommended extensions
+- VS Code will prompt: “This workspace has extension recommendations.”
+- Click **Install** to add the minimal set from `.vscode/extensions.json`.
+
+> If you prefer manual install, see: <https://code.visualstudio.com/docs/editor/extension-marketplace>
+
+## 4) Next steps (follow project docs)
+- Build, test, and other workflows are documented in **`docs/development.md`**.  


### PR DESCRIPTION
Summary
Adds a short VS Code IDE setup guide and minimal extension recommendations.

Changes

docs/ide-setup.md with setup notes

.vscode/extensions.json with recommended extensions

Linked in docs/development.md

Updated .gitignore

Notes
Documentation only, no build changes.

#473