### PR TITLE
resolve network test deadlock

### DIFF
--- a/test/thread_safety/target/network.cpp
+++ b/test/thread_safety/target/network.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2020 Joel E. Anderson
+ * Copyright 2020-2025 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,8 +163,8 @@ namespace {
                                 false );
 
       // cleanup after the test
-      listener_thread->join();
       stumpless_close_network_target( target );
+      listener_thread->join();
       EXPECT_NO_ERROR;
       stumpless_free_all(  );
 


### PR DESCRIPTION
The network target thread safety test `Tcp4WriteConsistency.SimultaneousWrites` would occasionally hang in MacOS Github Actions runs, eventually being cancelled. Testing with a FreeBSD revealed that the joining of the listening threads needed to be done _after_ closing the network targets in order for the connection to properly terminate.

This is intended to resolve #477.