### PR TITLE
reorder tcp6 listener as well

### DIFF
--- a/test/thread_safety/target/network.cpp
+++ b/test/thread_safety/target/network.cpp
@@ -199,8 +199,8 @@ namespace {
                                 false );
 
       // cleanup after the test
-      listener_thread->join();
       stumpless_close_network_target( target );
+      listener_thread->join();
       EXPECT_NO_ERROR;
       stumpless_free_all(  );
 


### PR DESCRIPTION
The same network hangs described in 6a1e8b96c6b7c519841de8dcba734fb7fdac2fef occurred in the Tcp6WriteConsistency test as well. The same reordering of the network target closure and closing of the listener threads is expected to resolve it.