### PR TITLE
Doxygen comments by Satyam

### DIFF
--- a/include/private/strhelper.h
+++ b/include/private/strhelper.h
@@ -22,18 +22,56 @@
 #  include <stddef.h>
 
 /**
- * Stringifies the first argument and adds a comma afterwards, and ignores the
- * second argument. Useful in FOREACH macros used to define enumerations,
- * particularly for conversion to string functionality.
+ * @brief Stringifies the first argument and appends a comma.
+ *
+ * This macro ignores the second argument. It is primarily used in
+ * FOREACH macros when defining enumerations, especially for
+ * converting enum values to strings.
+ *
+ * @param STRING The value to stringify.
+ * @param INDEX  Ignored parameter, typically used in FOREACH macros.
  */
 #  define GENERATE_STRING( STRING, INDEX ) #STRING,
 
+/**
+ * @brief Creates a copy of a null-terminated C string.
+ *
+ * Allocates memory for a new string and copies the contents of the
+ * provided string into it.
+ *
+ * @param str The original null-terminated string to copy.
+ * @return A pointer to the newly allocated copy of the string,
+ *         or NULL if memory allocation fails.
+ */
 char *
 copy_cstring( const char *str );
 
+/**
+ * @brief Creates a copy of a C string and optionally returns its length.
+ *
+ * Allocates memory for a new string, copies the contents of the
+ * provided string, and if the `length` pointer is provided, stores
+ * the length of the copied string.
+ *
+ * @param str    The original null-terminated string to copy.
+ * @param length Optional pointer to store the length of the copied string.
+ * @return A pointer to the newly allocated copy of the string,
+ *         or NULL if memory allocation fails.
+ */
 char *
 copy_cstring_with_length( const char *str, size_t *length );
 
+/**
+ * @brief Compares two strings ignoring case, up to a given number of characters.
+ *
+ * Works similarly to the standard `strncasecmp`, but is a custom implementation.
+ *
+ * @param s1 The first string to compare.
+ * @param s2 The second string to compare.
+ * @param n  Maximum number of characters to compare.
+ * @return An integer less than, equal to, or greater than zero if s1 is found,
+ *         respectively, to be less than, to match, or be greater than s2.
+ */
 int
 strncasecmp_custom( const char *s1, const char *s2, size_t n );
 

--- a/include/private/target.h
+++ b/include/private/target.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file private_target.h
+ * @file
  * @brief Internal target management functions for the Stumpless logging library.
  *
  * This file defines private helper functions used for creating, locking,
@@ -35,7 +35,13 @@
 /**
  * @brief Destroys the specified target.
  *
- * Frees all internal resources associated with the target.
+ * Frees all internal resources associated with the target. This should only
+ * be called internally — use public APIs like `stumpless_close_target()` in
+ * user code.
+ *
+ * **Thread Safety:** MT-Unsafe  
+ * **Async Signal Safety:** AS-Unsafe  
+ * **Async Cancel Safety:** AC-Unsafe
  *
  * @param target The target to destroy.
  */
@@ -45,7 +51,12 @@ destroy_target( const struct stumpless_target *target );
 /**
  * @brief Locks the specified target for thread-safe access.
  *
- * Prevents concurrent modifications by other threads.
+ * Prevents concurrent modifications by other threads. A matching call to
+ * `unlock_target()` must be made when access is complete.
+ *
+ * **Thread Safety:** MT-Safe  
+ * **Async Signal Safety:** AS-Unsafe  
+ * **Async Cancel Safety:** AC-Safe
  *
  * @param target The target to lock.
  */
@@ -55,7 +66,12 @@ lock_target( const struct stumpless_target *target );
 /**
  * @brief Creates a new target object of the specified type and name.
  *
- * Allocates and initializes a new target.
+ * Allocates and initializes a new target, preparing internal fields for use.
+ * This function may return `NULL` if memory allocation fails.
+ *
+ * **Thread Safety:** MT-Safe  
+ * **Async Signal Safety:** AS-Unsafe  
+ * **Async Cancel Safety:** AC-Unsafe
  *
  * @param type The type of target to create.
  * @param name The name of the target.
@@ -69,6 +85,11 @@ new_target( enum stumpless_target_type type, const char *name );
  * @brief Opens an unsupported target type.
  *
  * Used internally when a target type is not implemented on the platform.
+ * Simply returns the same pointer and sets an internal error.
+ *
+ * **Thread Safety:** MT-Safe  
+ * **Async Signal Safety:** AS-Unsafe  
+ * **Async Cancel Safety:** AC-Unsafe
  *
  * @param target The target to open.
  *
@@ -104,7 +125,11 @@ send_entry_and_msg_to_unsupported_target( const struct stumpless_target *target,
 /**
  * @brief Handles attempts to send an entry to an unsupported target.
  *
- * Always raises a "target unsupported" error.
+ * Always raises a "target unsupported" error and returns -1.
+ *
+ * **Thread Safety:** MT-Safe  
+ * **Async Signal Safety:** AS-Unsafe  
+ * **Async Cancel Safety:** AC-Unsafe
  *
  * @param target The target the entry was to be sent to.
  * @param entry The entry that was to be sent.
@@ -119,7 +144,11 @@ send_entry_to_unsupported_target( const struct stumpless_target *target,
 /**
  * @brief Handles attempts to send raw message data to an unsupported target.
  *
- * Always raises a "target unsupported" error.
+ * Always raises a "target unsupported" error and returns -1.
+ *
+ * **Thread Safety:** MT-Safe  
+ * **Async Signal Safety:** AS-Unsafe  
+ * **Async Cancel Safety:** AC-Unsafe
  *
  * @param target The target the message was to be sent to.
  * @param msg The message string.
@@ -138,6 +167,10 @@ sendto_unsupported_target( const struct stumpless_target *target,
  *
  * Should be called during library shutdown to release all target-related
  * global resources.
+ *
+ * **Thread Safety:** MT-Unsafe  
+ * **Async Signal Safety:** AS-Unsafe  
+ * **Async Cancel Safety:** AC-Safe
  */
 void
 target_free_global( void );
@@ -146,6 +179,10 @@ target_free_global( void );
  * @brief Frees thread-local memory used by targets.
  *
  * Should be called when a thread that used target functions exits.
+ *
+ * **Thread Safety:** MT-Conditional (thread-specific)  
+ * **Async Signal Safety:** AS-Unsafe  
+ * **Async Cancel Safety:** AC-Safe
  */
 void
 target_free_thread( void );
@@ -154,6 +191,10 @@ target_free_thread( void );
  * @brief Gets the value of a target option without validation.
  *
  * Internal use only — assumes the target pointer is valid.
+ *
+ * **Thread Safety:** MT-Unsafe  
+ * **Async Signal Safety:** AS-Unsafe  
+ * **Async Cancel Safety:** AC-Safe
  *
  * @param target The target to query.
  * @param option The option identifier.
@@ -166,7 +207,11 @@ unchecked_get_option( const struct stumpless_target *target, int option );
 /**
  * @brief Unlocks the specified target.
  *
- * Releases the lock previously acquired by @ref lock_target.
+ * Releases the lock previously acquired by `lock_target()`.
+ *
+ * **Thread Safety:** MT-Safe  
+ * **Async Signal Safety:** AS-Unsafe  
+ * **Async Cancel Safety:** AC-Safe
  *
  * @param target The target to unlock.
  */
@@ -177,6 +222,10 @@ unlock_target( const struct stumpless_target *target );
  * @brief Checks whether an unsupported target is open.
  *
  * Always returns 0 (false).
+ *
+ * **Thread Safety:** MT-Safe  
+ * **Async Signal Safety:** AS-Safe  
+ * **Async Cancel Safety:** AC-Safe
  *
  * @param target The target to check.
  *

--- a/include/private/target.h
+++ b/include/private/target.h
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+/**
+ * @file private_target.h
+ * @brief Internal target management functions for the Stumpless logging library.
+ *
+ * This file defines private helper functions used for creating, locking,
+ * unlocking, and managing logging targets internally within Stumpless.
+ */
+
 #ifndef __STUMPLESS_PRIVATE_TARGET_H
 #  define __STUMPLESS_PRIVATE_TARGET_H
 
@@ -24,40 +32,64 @@
 #  include <stumpless/target.h>
 #  include "private/config.h"
 
+/**
+ * @brief Destroys the specified target.
+ *
+ * Frees all internal resources associated with the target.
+ *
+ * @param target The target to destroy.
+ */
 void
 destroy_target( const struct stumpless_target *target );
 
+/**
+ * @brief Locks the specified target for thread-safe access.
+ *
+ * Prevents concurrent modifications by other threads.
+ *
+ * @param target The target to lock.
+ */
 void
 lock_target( const struct stumpless_target *target );
 
+/**
+ * @brief Creates a new target object of the specified type and name.
+ *
+ * Allocates and initializes a new target.
+ *
+ * @param type The type of target to create.
+ * @param name The name of the target.
+ *
+ * @return A pointer to the new target, or NULL on failure.
+ */
 struct stumpless_target *
 new_target( enum stumpless_target_type type, const char *name );
 
+/**
+ * @brief Opens an unsupported target type.
+ *
+ * Used internally when a target type is not implemented on the platform.
+ *
+ * @param target The target to open.
+ *
+ * @return The same target pointer, unmodified.
+ */
 COLD_FUNCTION
 struct stumpless_target *
 open_unsupported_target( struct stumpless_target *target );
 
 /**
- * Ignores all parameters and raises a target unsupported error.
+ * @brief Handles attempts to send an entry and formatted message to an unsupported target.
  *
- * **Thread Safety: MT-Safe**
- * This function is thread safe.
+ * Ignores all parameters and raises a "target unsupported" error.
  *
- * **Async Signal Safety: AS-Unsafe**
- * This function is not safe to call from signal handlers due to the use of
- * a thread-global structure to store errors.
+ * **Thread Safety:** MT-Safe  
+ * **Async Signal Safety:** AS-Unsafe  
+ * **Async Cancel Safety:** AC-Unsafe
  *
- * **Async Cancel Safety: AC-Unsafe**
- * This function is not safe to call from threads that may be asynchronously
- * cancelled, due to the use of a thread-global structure to store errors.
- *
- * @param target The target that the entry was to be sent to.
- *
+ * @param target The target the entry was to be sent to.
  * @param entry The entry that was to be sent.
- *
- * @param msg The formatted message string that was to be sent, as a UTF-8
- * string.
- *
+ * @param msg The formatted UTF-8 message string.
  * @param msg_size The size of the formatted message in bytes.
  *
  * @return Always returns -1.
@@ -69,29 +101,87 @@ send_entry_and_msg_to_unsupported_target( const struct stumpless_target *target,
                                           const char *msg,
                                           size_t msg_size );
 
+/**
+ * @brief Handles attempts to send an entry to an unsupported target.
+ *
+ * Always raises a "target unsupported" error.
+ *
+ * @param target The target the entry was to be sent to.
+ * @param entry The entry that was to be sent.
+ *
+ * @return Always returns -1.
+ */
 COLD_FUNCTION
 int
 send_entry_to_unsupported_target( const struct stumpless_target *target,
                                   const struct stumpless_entry *entry );
 
+/**
+ * @brief Handles attempts to send raw message data to an unsupported target.
+ *
+ * Always raises a "target unsupported" error.
+ *
+ * @param target The target the message was to be sent to.
+ * @param msg The message string.
+ * @param msg_length The length of the message string.
+ *
+ * @return Always returns -1.
+ */
 COLD_FUNCTION
 int
 sendto_unsupported_target( const struct stumpless_target *target,
                            const char *msg,
                            size_t msg_length );
 
+/**
+ * @brief Frees global memory used by targets.
+ *
+ * Should be called during library shutdown to release all target-related
+ * global resources.
+ */
 void
 target_free_global( void );
 
+/**
+ * @brief Frees thread-local memory used by targets.
+ *
+ * Should be called when a thread that used target functions exits.
+ */
 void
 target_free_thread( void );
 
+/**
+ * @brief Gets the value of a target option without validation.
+ *
+ * Internal use only — assumes the target pointer is valid.
+ *
+ * @param target The target to query.
+ * @param option The option identifier.
+ *
+ * @return The value of the specified option.
+ */
 int
 unchecked_get_option( const struct stumpless_target *target, int option );
 
+/**
+ * @brief Unlocks the specified target.
+ *
+ * Releases the lock previously acquired by @ref lock_target.
+ *
+ * @param target The target to unlock.
+ */
 void
 unlock_target( const struct stumpless_target *target );
 
+/**
+ * @brief Checks whether an unsupported target is open.
+ *
+ * Always returns 0 (false).
+ *
+ * @param target The target to check.
+ *
+ * @return Always returns 0.
+ */
 COLD_FUNCTION
 int
 unsupported_target_is_open( const struct stumpless_target *target );

--- a/include/private/windows_wrapper.h
+++ b/include/private/windows_wrapper.h
@@ -32,7 +32,7 @@
  * @note This header should **only be included by internal Stumpless files**
  * that need Windows APIs.
  *
- * @since Stumpless 2.0
+ * @since release v2.0.0
  */
 
 #ifndef __STUMPLESS_PRIVATE_WINDOWS_WRAPPER_H

--- a/include/private/windows_wrapper.h
+++ b/include/private/windows_wrapper.h
@@ -16,10 +16,23 @@
  * limitations under the License.
  */
 
-/** @file
- * Serves as a single inclusion point for windows.h, winsock2.h, and
- * ws2tcpip.h. Windows headers have ordering dependencies that can cause
- * compilation errors, and as such need to be done carefully.
+/**
+ * @file private_windows_wrapper.h
+ * @brief Safe inclusion wrapper for Windows-specific headers.
+ *
+ * This header acts as a **single inclusion point** for `windows.h`,
+ * `winsock2.h`, and `ws2tcpip.h`, ensuring that they are included in the
+ * correct order to prevent compilation conflicts.
+ *
+ * Windows headers have known ordering dependencies — for example, including
+ * `windows.h` before `winsock2.h` can lead to symbol redefinitions and other
+ * errors.  
+ * This wrapper handles these dependencies automatically for internal use.
+ *
+ * @note This header should **only be included by internal Stumpless files**
+ * that need Windows APIs.
+ *
+ * @since Stumpless 2.0
  */
 
 #ifndef __STUMPLESS_PRIVATE_WINDOWS_WRAPPER_H
@@ -27,13 +40,37 @@
 
 #  include "private/config.h"
 
+/**
+ * @defgroup windows_wrapper Internal Windows Header Management
+ * @ingroup internal_headers
+ * @brief Safely manages inclusion of Windows API headers.
+ *
+ * This group ensures that all Windows-specific includes are handled in a
+ * consistent and safe manner throughout the library.
+ * @{
+ */
+
 #  ifdef HAVE_WINSOCK2_H
+  /**
+   * @brief Includes Windows socket API headers if available.
+   *
+   * These headers provide definitions for networking operations,
+   * sockets, and related structures used internally by Stumpless.
+   */
 #    include <winsock2.h>
 #    include <ws2tcpip.h>
 #  endif
 
 #  ifdef HAVE_WINDOWS_H
+  /**
+   * @brief Includes the main Windows API header if available.
+   *
+   * Provides access to system-level APIs such as file handling,
+   * synchronization, and process management.
+   */
 #    include <windows.h>
 #  endif
+
+/** @} */ /* end of windows_wrapper group */
 
 #endif /* __STUMPLESS_PRIVATE_WINDOWS_WRAPPER_H */


### PR DESCRIPTION
This pull request adds Doxygen-compatible documentation comments to several internal header files in the codebase.
The goal is to improve code readability, maintainability, and automatic documentation generation without altering any existing logic or behavior.

**Details**

Added Doxygen-style @file, @brief, and structured function/macro documentation to:

- private_target.h
- private_strhelper.h
- private_windows_wrapper.h

Preserved all existing code, includes, macros, and function declarations — no logic changes made.

Documentation follows standard Doxygen conventions used throughout the project.

**Rationale**

This change:

- Makes internal APIs more self-documented.

- Ensures consistency with Doxygen parsing.
 
- Lays groundwork for future developer documentation generation (HTML/PDF).

**Verification**

- Verified that no compilation errors or behavior changes occur.

- Confirmed via git diff that only comments were added.

- Tested build on local environment to ensure header integrity.
