### PR TITLE
Remove unused strhelper.h include

### DIFF
--- a/src/strhelper.c
+++ b/src/strhelper.c
@@ -20,7 +20,7 @@
 #include <stddef.h>
 #include <string.h>
 #include "private/memory.h"
-#include "private/strhelper.h"
+
 
 char *
 copy_cstring( const char *str ) {


### PR DESCRIPTION
The `strhelper.h` header was included in the file but none of its functions are being used.  
Removing this include cleans up the code, avoids unnecessary dependencies, and improves readability.  
Functions like `copy_cstring`, `copy_cstring_with_length`, and `strncasecmp_custom` remain unaffected.

Fixes: #536
