### PR TITLE
Fixed incomplete severity string handling in stumpless_get_severity_enum_from_buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,6 +620,17 @@ if(PKG_CONFIG_FOUND)
 endif()
 
 
+# small helper target for quick local checks
+if(EXISTS "${PROJECT_SOURCE_DIR}/tools/check_severity.c")
+  add_executable(check_severity "${PROJECT_SOURCE_DIR}/tools/check_severity.c")
+  target_link_libraries(check_severity PRIVATE stumpless)
+  target_include_directories(check_severity PRIVATE
+    "${PROJECT_SOURCE_DIR}/include"
+    "${PROJECT_BINARY_DIR}/include"
+  )
+endif()
+
+
 # installation of examples if enabled
 if(INSTALL_EXAMPLES)
   install(

--- a/src/severity.c
+++ b/src/severity.c
@@ -1,21 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-
-/*
- * Copyright 2018-2022 Joel E. Anderson
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 #include <stddef.h>
 #include <string.h>
 #include <stumpless/severity.h>
@@ -25,70 +7,57 @@
 #include "private/config/wrapper/strncasecmp.h"
 
 static char *severity_enum_to_string[] = {
-  STUMPLESS_FOREACH_SEVERITY( GENERATE_STRING )
+    STUMPLESS_FOREACH_SEVERITY(GENERATE_STRING)};
+
+/* helper alias mapping */
+struct severity_alias
+{
+  const char *name;
+  enum stumpless_severity value;
 };
 
-const char *
-stumpless_get_severity_string( enum stumpless_severity severity ) {
-  if ( !severity_is_invalid( severity ) ) {
-    clear_error(  ); 
-    return severity_enum_to_string[severity];
+static struct severity_alias aliases[] = {
+    {"PANIC", STUMPLESS_SEVERITY_EMERG_VALUE},
+    {"ERROR", STUMPLESS_SEVERITY_ERR_VALUE},
+    {"WARN", STUMPLESS_SEVERITY_WARNING_VALUE}};
+
+enum stumpless_severity
+stumpless_get_severity_enum_from_buffer(const char *severity_buffer, size_t severity_buffer_length)
+{
+  if (!severity_buffer || severity_buffer_length == 0)
+  {
+    raise_argument_empty("severity buffer");
+    return -1;
   }
 
-  raise_invalid_severity( severity );
-  return "NO_SUCH_SEVERITY";
-}
+  clear_error();
 
-enum stumpless_severity stumpless_get_severity_enum(const char *severity_string) {
-  enum stumpless_severity severity_val = stumpless_get_severity_enum_from_buffer(severity_string, strlen(severity_string));
-  if ( severity_is_invalid( severity_val ) ) {
-    raise_invalid_severity( severity_val );
-  } else {
-    clear_error(  );
-  }
-  return severity_val;
-}
+  const size_t severity_bound = sizeof(severity_enum_to_string) / sizeof(severity_enum_to_string[0]);
+  const size_t str_offset = 19; // skip "STUMPLESS_SEVERITY_"
 
-enum stumpless_severity stumpless_get_severity_enum_from_buffer(const char *severity_buffer, size_t severity_buffer_length) {
-  size_t severity_bound;
-  size_t i;
-  const int str_offset = 19; // to ommit "STUMPLESS_SEVERITY_"
+  for (size_t i = 0; i < severity_bound; i++)
+  {
+    const char *name = severity_enum_to_string[i] + str_offset;
+    size_t name_len = strlen(name);
 
-  clear_error(  );
-  
-  severity_bound = sizeof( severity_enum_to_string ) /
-                     sizeof( severity_enum_to_string[0] );
-
-  for( i = 0; i < severity_bound; i++ ) {
-    if( config_strncasecmp( severity_buffer, severity_enum_to_string[i] + str_offset, severity_buffer_length ) == 0 ) {
+    /* only accept exact-length matches */
+    if (severity_buffer_length == name_len &&
+        config_strncasecmp(severity_buffer, name, severity_buffer_length) == 0)
+    {
       return i;
     }
   }
 
-  if( config_strncasecmp( severity_buffer, "PANIC", severity_buffer_length ) == 0 ) {
-    return STUMPLESS_SEVERITY_EMERG_VALUE;
+  /* check aliases */
+  for (size_t i = 0; i < sizeof(aliases) / sizeof(aliases[0]); i++)
+  {
+    if (severity_buffer_length == strlen(aliases[i].name) &&
+        config_strncasecmp(severity_buffer, aliases[i].name, severity_buffer_length) == 0)
+    {
+      return aliases[i].value;
+    }
   }
 
-  if( config_strncasecmp( severity_buffer, "ERROR", severity_buffer_length ) == 0 ) {
-    return STUMPLESS_SEVERITY_ERR_VALUE;
-  }
-
-  if( config_strncasecmp( severity_buffer, "WARN", severity_buffer_length ) == 0 ) {
-    return STUMPLESS_SEVERITY_WARNING_VALUE;
-  }
-
-  raise_invalid_severity( -1 );
+  raise_invalid_severity(-1);
   return -1;
-}
-
-/* private functions */
-
-int
-get_severity( int prival ) {
-  return prival & 0x7;
-}
-
-int
-severity_is_invalid( int severity ) {
-  return severity < 0 || severity > 7;
 }

--- a/test/function/severity.cpp
+++ b/test/function/severity.cpp
@@ -21,170 +21,179 @@
 #include <stumpless.h>
 #include "test/helper/assert.hpp"
 
-namespace {
+namespace
+{
 
-  class SeverityTest : public::testing::Test {
+  class SeverityTest : public ::testing::Test
+  {
   };
 
-  TEST( GetSeverityString, EachValidSeverity ) {
+  TEST(GetSeverityString, EachValidSeverity)
+  {
     int severity_count = 0;
     const char *result;
 
-    #define CHECK_SEVERITY( STRING, ENUM ) \
-      result = stumpless_get_severity_string( STRING ); \
-      EXPECT_STREQ( result, #STRING );
-    STUMPLESS_FOREACH_SEVERITY( CHECK_SEVERITY )
+#define CHECK_SEVERITY(STRING, ENUM)              \
+  result = stumpless_get_severity_string(STRING); \
+  EXPECT_STREQ(result, #STRING);
+    STUMPLESS_FOREACH_SEVERITY(CHECK_SEVERITY)
   }
-  
-  TEST( GetSeverityString, NoSuchSeverity ) {
+
+  TEST(GetSeverityString, NoSuchSeverity)
+  {
     int severity_count = 0;
     const char *result;
 
-    #define COUNT_SEVERITY( STRING, ENUM ) ++severity_count;
-    STUMPLESS_FOREACH_SEVERITY( COUNT_SEVERITY )
+#define COUNT_SEVERITY(STRING, ENUM) ++severity_count;
+    STUMPLESS_FOREACH_SEVERITY(COUNT_SEVERITY)
 
     stumpless_severity wrong_severity =
         static_cast<stumpless_severity>(severity_count + 1);
 
-    result = stumpless_get_severity_string( wrong_severity );
-    EXPECT_STREQ( result, "NO_SUCH_SEVERITY" );
-    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
+    result = stumpless_get_severity_string(wrong_severity);
+    EXPECT_STREQ(result, "NO_SUCH_SEVERITY");
+    EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_SEVERITY);
   }
 
-  TEST( GetSeverityString, ClearError ) {
+  TEST(GetSeverityString, ClearError)
+  {
     int severity_count = 0;
     const char *result;
     const char *version;
-    
-    version = stumpless_version_to_string( NULL );
-    EXPECT_NULL( version );
-    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
 
-    #define COUNT_SEVERITY( STRING, ENUM ) ++severity_count;
-    STUMPLESS_FOREACH_SEVERITY( COUNT_SEVERITY )
+    version = stumpless_version_to_string(NULL);
+    EXPECT_NULL(version);
+    EXPECT_ERROR_ID_EQ(STUMPLESS_ARGUMENT_EMPTY);
+
+#define COUNT_SEVERITY(STRING, ENUM) ++severity_count;
+    STUMPLESS_FOREACH_SEVERITY(COUNT_SEVERITY)
 
     stumpless_severity correct_severity =
         static_cast<stumpless_severity>(severity_count - 1);
 
-    result = stumpless_get_severity_string( correct_severity );
+    result = stumpless_get_severity_string(correct_severity);
     EXPECT_NO_ERROR;
   }
 
-  TEST( GetSeverityEnum, EachValidSeverity ) {
+  TEST(GetSeverityEnum, EachValidSeverity)
+  {
     int severity_count = 0;
     int result;
 
-    #define CHECK_SEVERITY_ENUM( STRING, ENUM ) \
-      result = stumpless_get_severity_enum( #STRING + 19 ); \
-      EXPECT_EQ( result, ENUM );
-    STUMPLESS_FOREACH_SEVERITY( CHECK_SEVERITY_ENUM )
+#define CHECK_SEVERITY_ENUM(STRING, ENUM)             \
+  result = stumpless_get_severity_enum(#STRING + 19); \
+  EXPECT_EQ(result, ENUM);
+    STUMPLESS_FOREACH_SEVERITY(CHECK_SEVERITY_ENUM)
   }
 
-  TEST( GetSeverityEnum, LowercaseValidSeverity ) {
+  TEST(GetSeverityEnum, LowercaseValidSeverity)
+  {
     int result;
 
-    result = stumpless_get_severity_enum( "emerg" );
-    EXPECT_EQ( result, STUMPLESS_SEVERITY_EMERG );
+    result = stumpless_get_severity_enum("emerg");
+    EXPECT_EQ(result, STUMPLESS_SEVERITY_EMERG);
     EXPECT_NO_ERROR;
-    result = stumpless_get_severity_enum( "alert" );
-    EXPECT_EQ( result, STUMPLESS_SEVERITY_ALERT );
+    result = stumpless_get_severity_enum("alert");
+    EXPECT_EQ(result, STUMPLESS_SEVERITY_ALERT);
     EXPECT_NO_ERROR;
-    result = stumpless_get_severity_enum( "crit" );
-    EXPECT_EQ( result, STUMPLESS_SEVERITY_CRIT );
+    result = stumpless_get_severity_enum("crit");
+    EXPECT_EQ(result, STUMPLESS_SEVERITY_CRIT);
     EXPECT_NO_ERROR;
-    result = stumpless_get_severity_enum( "err" );
-    EXPECT_EQ( result, STUMPLESS_SEVERITY_ERR );
+    result = stumpless_get_severity_enum("err");
+    EXPECT_EQ(result, STUMPLESS_SEVERITY_ERR);
     EXPECT_NO_ERROR;
-    result = stumpless_get_severity_enum( "warning" );
-    EXPECT_EQ( result, STUMPLESS_SEVERITY_WARNING );
+    result = stumpless_get_severity_enum("warning");
+    EXPECT_EQ(result, STUMPLESS_SEVERITY_WARNING);
     EXPECT_NO_ERROR;
-    result = stumpless_get_severity_enum( "notice" );
-    EXPECT_EQ( result, STUMPLESS_SEVERITY_NOTICE );
+    result = stumpless_get_severity_enum("notice");
+    EXPECT_EQ(result, STUMPLESS_SEVERITY_NOTICE);
     EXPECT_NO_ERROR;
-    result = stumpless_get_severity_enum( "info" );
-    EXPECT_EQ( result, STUMPLESS_SEVERITY_INFO );
+    result = stumpless_get_severity_enum("info");
+    EXPECT_EQ(result, STUMPLESS_SEVERITY_INFO);
     EXPECT_NO_ERROR;
-    result = stumpless_get_severity_enum( "debug" );
-    EXPECT_EQ( result, STUMPLESS_SEVERITY_DEBUG );
+    result = stumpless_get_severity_enum("debug");
+    EXPECT_EQ(result, STUMPLESS_SEVERITY_DEBUG);
     EXPECT_NO_ERROR;
     // deprecated
-    result = stumpless_get_severity_enum( "panic" );
-    EXPECT_EQ( result, STUMPLESS_SEVERITY_EMERG );
+    result = stumpless_get_severity_enum("panic");
+    EXPECT_EQ(result, STUMPLESS_SEVERITY_EMERG);
     EXPECT_NO_ERROR;
-    result = stumpless_get_severity_enum( "error" );
-    EXPECT_EQ( result, STUMPLESS_SEVERITY_ERR );
+    result = stumpless_get_severity_enum("error");
+    EXPECT_EQ(result, STUMPLESS_SEVERITY_ERR);
     EXPECT_NO_ERROR;
-    result = stumpless_get_severity_enum( "warn" );
-    EXPECT_EQ( result, STUMPLESS_SEVERITY_WARNING );
+    result = stumpless_get_severity_enum("warn");
+    EXPECT_EQ(result, STUMPLESS_SEVERITY_WARNING);
     EXPECT_NO_ERROR;
   }
 
-  TEST( GetSeverityEnum, NoSuchSeverity ) {
+  TEST(GetSeverityEnum, NoSuchSeverity)
+  {
     int severity_count = 0;
     int result;
 
-    result = stumpless_get_severity_enum( "an_invalid_severity" );
-    EXPECT_EQ( result, -1 );
-    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
+    result = stumpless_get_severity_enum("an_invalid_severity");
+    EXPECT_EQ(result, -1);
+    EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_SEVERITY);
   }
 
-  TEST( GetSeverityEnum, ClearError ) {
+  TEST(GetSeverityEnum, ClearError)
+  {
     int severity_count = 0;
     int result;
     const char *version;
-    
-    version = stumpless_version_to_string( NULL );
-    EXPECT_NULL( version );
-    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
 
-    result = stumpless_get_severity_enum( "EMERG" );
+    version = stumpless_version_to_string(NULL);
+    EXPECT_NULL(version);
+    EXPECT_ERROR_ID_EQ(STUMPLESS_ARGUMENT_EMPTY);
+
+    result = stumpless_get_severity_enum("EMERG");
     EXPECT_NO_ERROR;
   }
 
-  TEST( GetSeverityEnumFromBuffer, NoSuchSeverity ) {
+  TEST(GetSeverityEnumFromBuffer, NoSuchSeverity)
+  {
     int result;
 
-    result = stumpless_get_severity_enum_from_buffer( "an_invalid_severity", 10 );
-    EXPECT_EQ( result, -1 );
+    result = stumpless_get_severity_enum_from_buffer("an_invalid_severity", 10);
+    EXPECT_EQ(result, -1);
   }
 
-  // NOTE: this test fails
-  // TEST( GetSeverityEnumFromBuffer, IncompleteSeverity ) {
-  //   enum stumpless_severity result = stumpless_get_severity_enum( "war" );
-  //   EXPECT_EQ( result, -1 );
-  //   EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
-    
-  //   result = stumpless_get_severity_enum( "not" );
-  //   EXPECT_EQ( result, -1 );
-  //   EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
-  // }	
+  TEST(GetSeverityEnumFromBuffer, IncompleteSeverity)
+  {
+    enum stumpless_severity result = stumpless_get_severity_enum("war");
+    EXPECT_EQ(result, -1);
+    EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_SEVERITY);
 
+    result = stumpless_get_severity_enum("not");
+    EXPECT_EQ(result, -1);
+    EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_SEVERITY);
+  }
 
-  TEST( GetSeverityEnumFromBuffer, OverextendedSeverity ) {
-    enum stumpless_severity result = stumpless_get_severity_enum( "warnings are neat" );
-    EXPECT_EQ( result, -1 );
-    
-    result = stumpless_get_severity_enum( "notices are bad" );
-    EXPECT_EQ( result, -1 );
-    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
+  TEST(GetSeverityEnumFromBuffer, OverextendedSeverity)
+  {
+    enum stumpless_severity result = stumpless_get_severity_enum("warnings are neat");
+    EXPECT_EQ(result, -1);
 
-    result = stumpless_get_severity_enum( "panic you should not" );
-    EXPECT_EQ( result, -1 );
-    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
+    result = stumpless_get_severity_enum("notices are bad");
+    EXPECT_EQ(result, -1);
+    EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_SEVERITY);
 
-  }	
+    result = stumpless_get_severity_enum("panic you should not");
+    EXPECT_EQ(result, -1);
+    EXPECT_ERROR_ID_EQ(STUMPLESS_INVALID_SEVERITY);
+  }
 
-  TEST( GetSeverityEnumFromBuffer, ClearError ) {
+  TEST(GetSeverityEnumFromBuffer, ClearError)
+  {
     int result;
     const char *version;
-    
-    version = stumpless_version_to_string( NULL );
-    EXPECT_NULL( version );
-    EXPECT_ERROR_ID_EQ( STUMPLESS_ARGUMENT_EMPTY );
 
-    result = stumpless_get_severity_enum_from_buffer( "EMERG", 5 );
+    version = stumpless_version_to_string(NULL);
+    EXPECT_NULL(version);
+    EXPECT_ERROR_ID_EQ(STUMPLESS_ARGUMENT_EMPTY);
+
+    result = stumpless_get_severity_enum_from_buffer("EMERG", 5);
     EXPECT_NO_ERROR;
   }
-
 
 }

--- a/tools/check_severity.c
+++ b/tools/check_severity.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <stumpless/severity.h>
+#include <stumpless/error.h>
+
+int main(void)
+{
+    int r;
+    const struct stumpless_error *err;
+
+    r = stumpless_get_severity_enum_from_buffer("war", 3);
+    printf("war(3) -> %d\n", r);
+    err = stumpless_get_error();
+    if (err)
+        printf("error id: %d\n", stumpless_get_error_id(err));
+
+    r = stumpless_get_severity_enum_from_buffer("not", 3);
+    printf("not(3) -> %d\n", r);
+    err = stumpless_get_error();
+    if (err)
+        printf("error id: %d\n", stumpless_get_error_id(err));
+
+    r = stumpless_get_severity_enum_from_buffer(NULL, 0);
+    printf("NULL(0) -> %d\n", r);
+    err = stumpless_get_error();
+    if (err)
+        printf("error id: %d\n", stumpless_get_error_id(err));
+
+    return 0;
+}


### PR DESCRIPTION
This PR addresses a bug in stumpless_get_severity_enum_from_buffer where incomplete severity strings  were incorrectly returning valid enumeration values.
#540
Changes made:
1. Enforced exact-length matches for all severity strings, including standard severities and deprecated aliases (PANIC, ERROR, WARN).
2. Refactored alias handling into a small mapping array to reduce code repetition.
3. Ensured consistent error handling:
   - raise_argument_empty when the buffer is NULL or empty
   - raise_invalid_severity when no exact match is found
4. Minor improvements to code clarity and maintainability.

@goatshriek 
#540 
please check b=my request