### PR TITLE
docs: add @error tag for alloc_mem in memory.h (fixes #371)

### DIFF
--- a/include/private/memory.h
+++ b/include/private/memory.h
@@ -41,8 +41,12 @@
  * @return A pointer to the allocated memory block, or NULL if the allocation
  *         fails. If allocation fails, it triggers a memory allocation failure
  *         error.
+ *
+ * @error STUMPLESS_MEMORY_ALLOCATION_FAILURE_ERROR
+ *         Raised if memory allocation fails.
  */
 void *alloc_mem( size_t size );
+
 
 /**
  * Frees a previously allocated block of memory.


### PR DESCRIPTION
This pull request improves the documentation of the private memory allocation function `alloc_mem` by adding the missing `@error` tag describing the possible allocation failure.

-->  Adds `@error STUMPLESS_MEMORY_ALLOCATION_FAILURE_ERROR` to indicate memory allocation failure.

- -> Follows the Doxygen style used across other private headers.

- -> Addresses issue #371 (document private functions).
