### PR TITLE
Fix facility case-insensitive match (Fixes #438)

### DIFF
--- a/src/facility.c
+++ b/src/facility.c
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-
 /*
  * Copyright 2018-2022 Joel E. Anderson
  *
@@ -22,75 +21,78 @@
 #include "private/facility.h"
 #include "private/strhelper.h"
 #include "private/error.h"
-#include <stddef.h>
-#include <stumpless/error.h>
+#include "stumpless/error.h"
 #include "private/config/wrapper/strncasecmp.h"
 
 static char *facility_enum_to_string[] = {
-  STUMPLESS_FOREACH_FACILITY( GENERATE_STRING )
+  STUMPLESS_FOREACH_FACILITY(GENERATE_STRING)
 };
 
 const char *
-stumpless_get_facility_string( enum stumpless_facility facility ) {
-  if ( !facility_is_invalid( facility ) ) {
+stumpless_get_facility_string(enum stumpless_facility facility) {
+  if (!facility_is_invalid(facility)) {
     clear_error();
     return facility_enum_to_string[facility >> 3];
   }
 
-  raise_error( STUMPLESS_INVALID_FACILITY, "invalid facility enum" , 0, NULL);
+  raise_error(STUMPLESS_INVALID_FACILITY, "invalid facility enum", 0, NULL);
   return "NO_SUCH_FACILITY";
 }
 
 enum stumpless_facility
-stumpless_get_facility_enum_from_buffer( const char *facility_buffer, size_t facility_buffer_length ) {
+stumpless_get_facility_enum_from_buffer(const char *facility_buffer,
+                                        size_t facility_buffer_length) {
   size_t facility_bound;
   size_t i;
-  const int str_offset = 19;  // to ommit "STUMPLESS_FACILITY_"
+  const int str_offset = 19; // omit "STUMPLESS_FACILITY_"
 
-  facility_bound = sizeof( facility_enum_to_string ) /
-                   sizeof( facility_enum_to_string[0] );
+  facility_bound = sizeof(facility_enum_to_string) / sizeof(facility_enum_to_string[0]);
 
-  for( i = 0; i < facility_bound; i++ ) {
-    if( config_strncasecmp( facility_buffer, facility_enum_to_string[i] + str_offset, facility_buffer_length ) == 0 ) {
+  for (i = 0; i < facility_bound; i++) {
+    if (config_strncasecmp(facility_buffer,
+                           facility_enum_to_string[i] + str_offset,
+                           facility_buffer_length) == 0) {
       clear_error();
       return i << 3;
     }
   }
 
-  if( config_strncasecmp( facility_buffer, "SECURITY", facility_buffer_length ) == 0 ) {
+  if (config_strncasecmp(facility_buffer, "SECURITY", facility_buffer_length) == 0) {
     clear_error();
     return STUMPLESS_FACILITY_AUTH_VALUE;
   }
 
-  if( config_strncasecmp( facility_buffer, "AUTHPRIV", facility_buffer_length ) == 0 ) {
+  if (config_strncasecmp(facility_buffer, "AUTHPRIV", facility_buffer_length) == 0) {
     clear_error();
     return STUMPLESS_FACILITY_AUTH2_VALUE;
   }
 
-  raise_error( STUMPLESS_INVALID_FACILITY, "invalid facility string", 0, NULL );
+  raise_error(STUMPLESS_INVALID_FACILITY, "invalid facility string", 0, NULL);
   return -1;
 }
 
 enum stumpless_facility
-stumpless_get_facility_enum( const char *facility_string ) {
-  enum stumpless_facility result = stumpless_get_facility_enum_from_buffer(
-    facility_string, strlen( facility_string ) );
+stumpless_get_facility_enum(const char *facility_string) {
+  enum stumpless_facility result =
+      stumpless_get_facility_enum_from_buffer(facility_string,
+                                              strlen(facility_string));
 
-  if( result != -1 ) {
+  if (result != -1) {
     clear_error();
   }
 
   return result;
 }
 
-/* private functions */
+/* private helper functions */
 
 int
-get_facility( int prival ) {
+get_facility(int prival) {
   return prival & 0xf8;
 }
 
 int
-facility_is_invalid( int facility ) {
-  return facility < 0 || facility > ( 23 << 3 ) || facility % 8 != 0;
+facility_is_invalid(int facility) {
+  return facility < 0 || facility > (23 << 3) || facility % 8 != 0;
 }
+


### PR DESCRIPTION
Replaced uppercase buffer conversion with config_strncasecmp() to improve performance and simplicity.