### PR TITLE
Fix strncasecmp_custom

### DIFF
--- a/src/config/no_strncasecmp.c
+++ b/src/config/no_strncasecmp.c
@@ -25,14 +25,9 @@
  */
 int
 strncasecmp_custom( const char *s1, const char *s2, size_t n ) {
-  if (n != 0) {
-    do {
-      if (tolower(*s1) != tolower(*s2++))
-        return tolower(*--s2) - tolower(*s1);
-      if (*s1++ == '\0')
-        break;
-    } while (--n != 0);
-    if(*s2 != '\0') return tolower(*s2) - tolower(*s1);
+  for (size_t i = 0; i < n; i++, s1++, s2++) {
+    if (*s1 == '\0' || *s2 == '\0' || tolower(*s1) != tolower(*s2))
+      return tolower(*s1) - tolower(*s2);
   }
   return 0;
 }

--- a/src/severity.c
+++ b/src/severity.c
@@ -60,20 +60,24 @@ enum stumpless_severity stumpless_get_severity_enum_from_buffer(const char *seve
                      sizeof( severity_enum_to_string[0] );
 
   for( i = 0; i < severity_bound; i++ ) {
-    if( config_strncasecmp( severity_buffer, severity_enum_to_string[i] + str_offset, severity_buffer_length ) == 0 ) {
+    const char *target = severity_enum_to_string[i] + str_offset;
+    if( (config_strncasecmp( severity_buffer, target, severity_buffer_length ) == 0) && (strlen(target) == severity_buffer_length) ) {
       return i;
     }
   }
 
-  if( config_strncasecmp( severity_buffer, "PANIC", severity_buffer_length ) == 0 ) {
+  if( (config_strncasecmp( severity_buffer, "PANIC", severity_buffer_length ) == 0) &&
+      (severity_buffer_length == 5) ) {
     return STUMPLESS_SEVERITY_EMERG_VALUE;
   }
 
-  if( config_strncasecmp( severity_buffer, "ERROR", severity_buffer_length ) == 0 ) {
+  if( (config_strncasecmp( severity_buffer, "ERROR", severity_buffer_length ) == 0) &&
+      (severity_buffer_length == 5) ) {
     return STUMPLESS_SEVERITY_ERR_VALUE;
   }
 
-  if( config_strncasecmp( severity_buffer, "WARN", severity_buffer_length ) == 0 ) {
+  if( (config_strncasecmp( severity_buffer, "WARN", severity_buffer_length ) == 0) &&
+      (severity_buffer_length == 4) ) {
     return STUMPLESS_SEVERITY_WARNING_VALUE;
   }
 

--- a/test/function/severity.cpp
+++ b/test/function/severity.cpp
@@ -148,16 +148,15 @@ namespace {
     EXPECT_EQ( result, -1 );
   }
 
-  // NOTE: this test fails
-  // TEST( GetSeverityEnumFromBuffer, IncompleteSeverity ) {
-  //   enum stumpless_severity result = stumpless_get_severity_enum( "war" );
-  //   EXPECT_EQ( result, -1 );
-  //   EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
+  TEST( GetSeverityEnumFromBuffer, IncompleteSeverity ) {
+    enum stumpless_severity result = stumpless_get_severity_enum( "war" );
+    EXPECT_EQ( result, -1 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
     
-  //   result = stumpless_get_severity_enum( "not" );
-  //   EXPECT_EQ( result, -1 );
-  //   EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
-  // }	
+    result = stumpless_get_severity_enum( "not" );
+    EXPECT_EQ( result, -1 );
+    EXPECT_ERROR_ID_EQ( STUMPLESS_INVALID_SEVERITY );
+  }
 
 
   TEST( GetSeverityEnumFromBuffer, OverextendedSeverity ) {


### PR DESCRIPTION
- Fixes `strncasecmp_custom` so that its behavior matches that of the `libc` implementation.
- Add explicit checks to `stumpless_get_severity_enum_from_buffer` to disallow partial matches even when using `strncasecmp`. I've reenabled the failing test.

The explicit checks in `src/severity.c` are a bit ugly since we're essentially just forcing `strncasecmp` to behave like `strcasecmp`, but if the user doesn't have one they probably will not have the other ;).