### PR TITLE
l10n: translate remaining Japanese (ja-jp) strings

### DIFF
--- a/include/private/config/locale/ja-jp.h
+++ b/include/private/config/locale/ja-jp.h
@@ -26,16 +26,14 @@
 #  define L10N_BIND_UNIX_SOCKET_FAILED_ERROR_MESSAGE \
 "ローカルの UNIX ソケットにバインドできませんでした"
 
-// todo translate
 #  define L10N_BUFFER_SIZE_ERROR_CODE_TYPE \
-"buffer used to store the message"
+"メッセージを格納するために使用されたバッファ"
 
 #  define L10N_BUFFER_TOO_SMALL_ERROR_MESSAGE \
 "指定されたメッセージに対してバッファが小さすぎます"
 
-// todo translate
 #  define L10N_CHAIN_TARGETS_UNSUPPORTED \
-"chain targets are not supported by this build"
+"チェインターゲットはこのビルドではサポートされていません"
 
 #  define L10N_CLOSE_UNSUPPORTED_TARGET_ERROR_MESSAGE \
 "サポートされていないターゲット タイプを閉じようとしました"
@@ -218,9 +216,8 @@ ARG_NAME "NULL でした"
 #  define L10N_SEND_WIN_SOCKET_FAILED_ERROR_MESSAGE \
 "winsock2 ソケットで送信に失敗しました"
 
-// todo translate
 #  define L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE \
-"severity colors are only supported for stream targets"
+"重大度カラーはストリームターゲットでのみサポートされています"
 
 #  define L10N_SOCKET_FAILED_ERROR_MESSAGE \
 "ソケットを開けませんでした"


### PR DESCRIPTION
## Summary
- Translate the 3 remaining untranslated strings marked with `// todo translate` in the `ja-jp` locale header
- All strings in `include/private/config/locale/ja-jp.h` are now fully translated

### Translated strings
| Symbol | English | Japanese |
|--------|---------|----------|
| `L10N_BUFFER_SIZE_ERROR_CODE_TYPE` | buffer used to store the message | メッセージを格納するために使用されたバッファ |
| `L10N_CHAIN_TARGETS_UNSUPPORTED` | chain targets are not supported by this build | チェインターゲットはこのビルドではサポートされていません |
| `L10N_SEVERITY_COLORS_UNSUPPORTED_TARGET_ERROR_MESSAGE` | severity colors are only supported for stream targets | 重大度カラーはストリームターゲットでのみサポートされています |

Resolves #117 (partial - completes ja-jp locale)