### PR TITLE
Make process ID included by default

### DIFF
--- a/src/target.c
+++ b/src/target.c
@@ -70,7 +70,7 @@
 static const char *target_type_enum_to_string[] = {
   STUMPLESS_FOREACH_TARGET_TYPE( GENERATE_STRING )
 };
-static config_atomic_int_t default_option = STUMPLESS_OPTION_NDELAY;
+static config_atomic_int_t default_option = STUMPLESS_OPTION_NDELAY | STUMPLESS_OPTION_PID;
 static config_atomic_ptr_t current_target = config_atomic_ptr_initializer;
 static config_atomic_ptr_t default_target = config_atomic_ptr_initializer;
 static config_atomic_ptr_t cons_stream = config_atomic_ptr_initializer;

--- a/test/function/target.cpp
+++ b/test/function/target.cpp
@@ -1399,7 +1399,7 @@ namespace {
     if( !std::regex_match( message_buffer, matches, pid_regex ) ) {
       FAIL(  ) << "produced invalid procid";
     } else {
-      EXPECT_EQ( matches[RFC_5424_PROCID_MATCH_INDEX], '-' );
+      EXPECT_NE(matches[RFC_5424_PROCID_MATCH_INDEX], '-');
     }
 
     target_result = stumpless_set_option( target, STUMPLESS_OPTION_PID );


### PR DESCRIPTION
Summary
Make the process ID automatically included in the RFC 5424 PROCID field by default.

Changes
Include STUMPLESS_OPTION_PID in the default target options.
Update the existing PID test to verify that the process ID is included by default.
Existing behavior for explicitly unsetting STUMPLESS_OPTION_PID remains unchanged.

Testing
All 63 tests pass successfully.
Closes #556